### PR TITLE
changes to FortLewis answerHelp macro file

### DIFF
--- a/OpenProblemLibrary/macros/FortLewis/AnswerFormatHelp.pl
+++ b/OpenProblemLibrary/macros/FortLewis/AnswerFormatHelp.pl
@@ -80,7 +80,8 @@ our ($syntaxHelpExists,   $angleHelpExists, $decimalHelpExists,
     $equationHelpExists, $exponentHelpExists, $formulaHelpExists, $fractionHelpExists, $inequalitiesHelpExists, 
     $intervalHelpExists, $limitsHelpExists, $logarithmsHelpExists, $numberHelpExists, $pointsHelpExists,
     $unitsHelpExists, $vectorsHelpExists,
-    );
+    ) = (0,0,0,0,0, 0,0,0,0,0, 0,0,0,0,0, 0,0,0,0,0, );
+    
 sub _AnswerFormatHelp_init {}; # don't reload this file
 
 sub AnswerFormatHelp {


### PR DESCRIPTION
Placed the "our"  definition of the xxxHelpExists variables at the top of the page to avoid "not numeric in != compare " warnings in the log.
