### PR TITLE
update instructions for location of OPL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -8,16 +8,16 @@ Installing the problem library can be done in 5 steps.
 ----------------------------
 
 The files can be obtained from 
-
+   cd /opt/webwork/libraries
    http://github.com/openwebwork/webwork-open-problem-library
 
 You can download the library as a zipfile, or using git software.
 
-Once you have downloaded the library, you will have a directory
+Once you have downloaded the library, you will have a directory webwork-open-problem-library
 containing the following files and directories:
 
-  Instructions
-  OPL_LICENSE.txt
+  INSTALL
+  OPL_LICENSE
   OpenProblemLibrary/
   README.md
 
@@ -32,7 +32,7 @@ In the file $WEBWORK_ROOT/conf/localOverrides.conf, set the following
 values.  The first one is where you put the problem library files
 in step 1.
 
-$problemLibrary{root}        = "/opt/webwork/libraries/OpenProblemLibrary";
+$problemLibrary{root}        = "/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary";
 $problemLibrary{version} = "2.5";
 
 
@@ -55,7 +55,7 @@ finishes, you are ready to go.
 If you have courses which had been accessing version 1 of the problem
 library, your courses will have a symbolic link in their templates
 directories called Library.  Delete this link (rm Library).  WeBWorK
-will make the correct new link for you the next time you need it.
+will make the correct new link for you the next time you use the library browser.
 
 
 5. Using the Rochester problem library from OPL
@@ -75,7 +75,7 @@ The trickiest part of the instructions for doing this is that
 different systems may have put files in different places.  Here we
 assume:
 
-  OPL is located at /opt/libarProblemLibrary
+  OPL is located at /opt/libary/webwork-open-problem-library/ProblemLibrary
 
   Rochester problems were a symbolic link in each course templates
   directory called "rochester_problib" (you may have to substitute
@@ -102,7 +102,7 @@ Upgrading
 First update the problems in the problem library.  "cd" to the
 location of the problem library, which might be
 
-  cd /opt/library/OpenProblemLibrary
+  cd /opt/library/webwork-open-problem-library/OpenProblemLibrary
 
 depending on where you installed it initially.  From that location,
 give the command


### PR DESCRIPTION
The default location for the OPL when downloaded from github is 

/opt/webwork/libraries/webwork-open-problem-library/OpenProblemLibrary

This just updates the instructions in INSTALL to assume this default value.
