### PR TITLE
Remove sentence about ln or log being used in answer.

### DIFF
--- a/OpenProblemLibrary/LoyolaChicago/Precalc/Chap4Tools/Connally3-4-Tools-28b.pg
+++ b/OpenProblemLibrary/LoyolaChicago/Precalc/Chap4Tools/Connally3-4-Tools-28b.pg
@@ -63,9 +63,6 @@ Using laws of logarithms, write the expression
 below using sums and/or differences 
 of logarithmic expressions which do not contain 
 the logarithms of products, quotients, or powers.
-Enter the natural logarithm of x as 
-${BITALIC}ln(x)${EITALIC} or
-${BITALIC}log(x)${EITALIC}.
 $BR
 $BR
 \( $expression = \)


### PR DESCRIPTION
Reason: problem specifies "ln" and offering "log" will confuse some.

Note: this suggested change is independent of my disagreement about "log"
defaulting to be base-e logarithm in WeBWorK.
