### PR TITLE
Replace  black  with  'black'  to avoid a warning message:

### DIFF
--- a/OpenProblemLibrary/LoyolaChicago/Precalc/Chap3Sec3/Q23-new.pg
+++ b/OpenProblemLibrary/LoyolaChicago/Precalc/Chap3Sec3/Q23-new.pg
@@ -59,7 +59,7 @@ $graph->lb(new Label($x0,-0.1,"t0",'black','right','center'));
 $graph->lb(new Label(2.8,-.2,"t",'black','right','top'));
 $graph->lb(new Label(1,2,$funct[0],$color[0],'right','top'));
 $graph->lb(new Label(1,5,$funct[1],$color[1],'right','top'));
-$point = closed_circle( $x0,$y0, black );
+$point = closed_circle( $x0,$y0, 'black' );
 $graph -> stamps($point);
 plot_functions( $graph, @f);
 


### PR DESCRIPTION
```
Unquoted string "black" may clash with future reserved word
at line 61 of (eval 6877)
```

curious: warning if redirected from Q23.pg but not if loaded directly
