### PR TITLE
Add a hint for the first two answer blanks

### DIFF
--- a/OpenProblemLibrary/OSU/high_school_apcalc/dchmwk3/prob9.pg
+++ b/OpenProblemLibrary/OSU/high_school_apcalc/dchmwk3/prob9.pg
@@ -14,11 +14,7 @@
 DOCUMENT();        # This should be the first executable line in the problem.
 
 loadMacros(
-  "PG.pl",
-  "PGbasicmacros.pl",
-  "PGchoicemacros.pl",
-  "PGanswermacros.pl",
-  "PGauxiliaryFunctions.pl",
+  "PGstandard.pl",
   "MathObjects.pl"
 );
 
@@ -65,7 +61,8 @@ $argChecker = sub {
   my ($correct, $student, $ansHash) = @_;
 
   Value::Error("<b>You must enter a function of x, not a constant here</b><br>"
-      . "(Remember, you are not asked for the value of the limit here.)")
+      . "(Remember, you are asked for what limit to compute, "
+      . "not the value of the limit.)")
     unless $student->isFormula;
 
   return ($student == $correct) ? 1 : 0;


### PR DESCRIPTION
This change implements a custom answer checker for the first two answers.  The answer checker gives a message if the student gives the value of the limit (or any constant) instead of the function that one would take a limit of.  It also converts to MathObjects and removes some loadMacros files.
