### PR TITLE
Fixed bug 2941 (or worked around it).  Also cleaned up the output somewhat.

### DIFF
--- a/OpenProblemLibrary/Rochester/setDiffEQ10Linear2ndOrderNonhom/ur_de_10_16.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ10Linear2ndOrderNonhom/ur_de_10_16.pg
@@ -38,11 +38,11 @@ TEXT(beginproblem()) ;
 $showPartialCorrectAnswers = 1 ;
 #Problem written by Dr. Lesh
 BEGIN_TEXT
- $BR
 $PAR
 
 Find a particular solution to 
-\[ y'' + $a y' + $b y =  \frac{$c e^{$r t}}{t^2+1} \].
+\[ \{ nicestring([1, $a, $b], ["y''", "y'", 'y']) \}
+  =  \frac{$c e^{ \{ nicestring([$r], ['t']) \} }}{t^2+1} \;. \]
 $PAR 
 
 $BR
@@ -51,7 +51,8 @@ $BR
 END_TEXT
 $ans = "($c*exp($r*t))(-ln(1+t^2)/2+t atan(t))";
 $homogeneous = "a*e^($r*t) + b*t*e**($r*t)";
-ANS(fun_cmp("$ans + $homogeneous", var => 't',  params => ['a', 'b']) );
+ANS( fun_cmp("$ans + $homogeneous", var => 't', params => ['a', 'b'],
+  limits => [.1, 1]) );
 
 ENDDOCUMENT() ; 
 


### PR DESCRIPTION
Fixed (or worked around) bug 2941 by adding "limits => [.1, 1]"
  (The bug was:  with random seed 3544, it rejected the correct answer -20_e^(-t)_(-ln(1+t^2)/2+t*arctan(t))
Cleaned up the output somewhat, by using nicestring().
