### PR TITLE
Fix OPL tags in linear algebra pg files from Rochester and TCNJ

### DIFF
--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/cubing_2x2.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/cubing_2x2.pg
@@ -6,7 +6,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/defined_ops.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/defined_ops.pg
@@ -8,7 +8,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/det_inv_3x3.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/det_inv_3x3.pg
@@ -7,7 +7,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Institution('Rochester')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_2x2a.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_2x2a.pg
@@ -7,7 +7,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_3x3.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_3x3.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_3x3a.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_3x3a.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_3x3b.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/determinant_3x3b.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/id_entry.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/id_entry.pg
@@ -6,7 +6,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse2x2.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse2x2.pg
@@ -5,8 +5,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')
 ## TitleText1('Linear Algebra with Applications')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse2x2a.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse2x2a.pg
@@ -7,8 +7,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse3x3.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse3x3.pg
@@ -5,8 +5,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse3x3a.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse3x3a.pg
@@ -7,8 +7,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse3x3b.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/inverse3x3b.pg
@@ -7,8 +7,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/product_size.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/product_size.pg
@@ -6,7 +6,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/size.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/size.pg
@@ -6,7 +6,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_1.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_1.pg
@@ -4,7 +4,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_10.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_10.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_11.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_11.pg
@@ -4,7 +4,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_3.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_3.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_5.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_4_5.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_6_15.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_6_15.pg
@@ -5,8 +5,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_6_17.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_6_17.pg
@@ -5,7 +5,7 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Institution('Rochester')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_6_3.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra34Matrices/sw7_6_3.pg
@@ -5,8 +5,8 @@
 ##Tagged by ynw2d
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Institution('Rochester and Hope College')
 ## Author('Paul Pearson')
 ## KEYWORDS('algebra', 'matrix operation', 'matrix')

--- a/OpenProblemLibrary/Rochester/setDiffEQ5ModelingWith1stOrder/ns7_4_31b.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ5ModelingWith1stOrder/ns7_4_31b.pg
@@ -5,8 +5,8 @@
 ## Tagged by tda2d
 
 ## DBsubject(Differential equations)
-## DBchapter(First order)
-## DBsection(Separable equations)
+## DBchapter(First order differential equations)
+## DBsection(Applications - mixing problems)
 ## Date(6/3/2002)
 ## TitleText1('Calculus: Early Transcendentals')
 ## AuthorText1('Stewart')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra10Bases/ur_la_10_11a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra10Bases/ur_la_10_11a.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter(Linear transformations)
-## DBsection(Kernel and image)
+## DBchapter(Euclidean spaces)
+## DBsection(Row, column, and null spaces)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_12.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_12.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_13.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_13.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_17a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_17a.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter(Eigenvalues and eigenvectors)
-## DBsection(Computing eigenvalues and eigenvectors)
+## DBchapter(Matrix factorizations)
+## DBsection(Diagonalization)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_20a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_20a.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection(Computing eigenvalues and eigenvectors)
+## DBsection(Complex eigenvalues and eigenvectors)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_26.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_26.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_27.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_27.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra11Eigenvalues/ur_la_11_9.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_10.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_10.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_11.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_11.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_12.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_12.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Institution('Rochester')
 
 DOCUMENT();        # This should be the first executable line in the problem.

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_8a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_8a.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_9a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra13ComplexEigenvalues/ur_la_13_9a.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_1.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_11.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_11.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Inverses')
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_25.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_25.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Inverses')
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_26.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_26.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Inverses')
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_27.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_27.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Inverses')
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_30.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_30.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_31.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_31.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Inverses')
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra14TransfOfRn/ur_la_14_9.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_1.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_16.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_16.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_17.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_17.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_18.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_18.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_19.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_19.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Inverses')
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_2.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra15TransfOfLinSpaces/ur_la_15_3.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Linear transformations)
-## DBsection('Properties')
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra17DotProductRn/ur_la_17_13.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra17DotProductRn/ur_la_17_13.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra17DotProductRn/ur_la_17_18.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra17DotProductRn/ur_la_17_18.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra17DotProductRn/ur_la_17_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra17DotProductRn/ur_la_17_3.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra1Systems/ur_la_1_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra1Systems/ur_la_1_1.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra1Systems/ur_la_1_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra1Systems/ur_la_1_2.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_1.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_10.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_10.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_2.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_3.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_4.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_5.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_6.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_7.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_8.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra20LeastSquares/ur_la_20_9.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra21InnerProductSpaces/ur_la_21_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra21InnerProductSpaces/ur_la_21_8.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra22SymmetricMatrices/ur_la_22_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra22SymmetricMatrices/ur_la_22_6.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Inner products)
-## DBsection(Orthogonal and orthonormal sets)
+## DBsection(Gram-Schmidt process)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_1.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_2.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_3.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_4.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_5.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_6.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra2SystemsApplications/ur_la_2_7.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Systems of linear equations)
-## DBsection('Applications')
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_1.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_2.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Rank')
+## DBchapter(Matrices)
+## DBsection(Rank)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_3.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Rank')
+## DBchapter(Matrices)
+## DBsection(Rank)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_Ch1_3_5.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1.pg
@@ -6,7 +6,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection('Matrix Operations')
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_10.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_10.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## KEYWORDS('linear algebra','matrix','characteristic polynomial')
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_11.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_11.pg
@@ -7,7 +7,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Eigenvalues and eigenvectors)
-## DBsection('Properties')
+## DBsection(Properties)
 ## KEYWORDS('linear algebra','matrix','characteristic polynomial')
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_12.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_12.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_13.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_13.pg
@@ -1,7 +1,7 @@
 ##DESCRIPTION
 ##   hcao tagged and PAID on 2-20-2004
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('6/3/2002')
 ## TitleText1('Elementary Linear Algebra')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_14.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_14.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Rank')
+## DBchapter(Matrices)
+## DBsection(Rank)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_16.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_16.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_17.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_17.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_18.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_18.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_18a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_18a.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
-## DBsection('Matrix Operations')
+## DBchapter(Matrices)
+## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_19.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_19.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1a.pg
@@ -6,7 +6,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection('Matrix Operations')
 ## Date('')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1b.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1b.pg
@@ -5,9 +5,9 @@
 ## KEYWORDS('linear algebra','matrix','transpose')
 ## Tagged by cmd6a 5/3/06
 
-## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
-## DBsection('Matrix Operations')
+## DBsubject(Linear algebra)
+## DBchapter(Matrices)
+## DBsection(Matrix algebra)
 ## Date('')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1c.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_1c.pg
@@ -5,9 +5,9 @@
 ## KEYWORDS('linear algebra','matrix','transpose')
 ## Tagged by cmd6a 5/3/06
 
-## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
-## DBsection('Matrix Operations')
+## DBsubject(Linear algebra)
+## DBchapter(Matrices)
+## DBsection(Transpose and trace)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_2.pg
@@ -6,7 +6,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection('Matrix Operations')
 ## Date('')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_21.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_21.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_22.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_22.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_25.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_25.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_26.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_26.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Rank')
+## DBchapter(Matrices)
+## DBsection(Rank)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_27.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_27.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_28.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_28.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_29.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_29.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Elementary matrices)
 ## Institution('Rochester')
 ## KEYWORDS('linear algebra','matrix')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_3.pg
@@ -6,7 +6,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Complex entries)
 ## Date('')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_30.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_30.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Echelon form)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_31.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_31.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Echelon form)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_32.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_32.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Echelon form)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_33.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_33.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_34.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_34.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_35.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_35.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_4.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_5.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Row operations)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_5a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_5a.pg
@@ -5,9 +5,9 @@
 ## KEYWORDS('linear algebra','matrix','transpose')
 ## Tagged by cmd6a 5/3/06
 
-## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
-## DBsection('Matrix Operations')
+## DBsubject(Linear algebra)
+## DBchapter(Matrices)
+## DBsection(Row operations)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_7.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_8.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
+## DBchapter(Matrices)
 ## DBsection(Matrix algebra)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_9.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 5/3/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Rank')
+## DBchapter(Matrices)
+## DBsection(Rank)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_9a.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra3Matrices/ur_la_3_9a.pg
@@ -5,9 +5,9 @@
 ## KEYWORDS('linear algebra','matrix','transpose')
 ## Tagged by cmd6a 5/3/06
 
-## DBsubject('Linear Algebra')
-## DBchapter('Matrices')
-## DBsection('Matrix Operations')
+## DBsubject(Linear algebra)
+## DBchapter(Matrices)
+## DBsection(Rank)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_Ch2_1_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_Ch2_1_4.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_1.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_10.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_10.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Complex entries)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_11.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_11.pg
@@ -2,8 +2,8 @@
 ## lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('6/3/2002')
 ## TitleText1('Elementary Linear Algebra')
 ## AuthorText1('Larson, Edwards, Falvo')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_2.pg
@@ -2,8 +2,8 @@
 ## lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_3.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_4.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_5.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_6.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_7.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_8.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Inverses)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra4InverseMatrix/ur_la_4_9.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/30/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Matrices')
-## DBsection('Inverses')
+## DBchapter(Matrices)
+## DBsection(Complex entries)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_1.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_11.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_11.pg
@@ -1,6 +1,6 @@
 ##DESCRIPTION
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_12.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_12.pg
@@ -2,7 +2,7 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_13.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_13.pg
@@ -2,7 +2,7 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_14.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_14.pg
@@ -2,7 +2,7 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_15.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_15.pg
@@ -2,7 +2,7 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_16.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_16.pg
@@ -2,8 +2,8 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_17.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_17.pg
@@ -2,8 +2,8 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_18.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_18.pg
@@ -2,8 +2,8 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_19.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_19.pg
@@ -2,8 +2,8 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_20.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_20.pg
@@ -2,8 +2,8 @@
 ##lcao tagged and PAID on 3-22-2004
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_21.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_21.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_22.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_22.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_23.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_23.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_24.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_24.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Applications')
+## DBchapter(Determinants)
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_25.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_25.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Applications')
+## DBchapter(Determinants)
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_26.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_26.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Applications')
+## DBchapter(Determinants)
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_27.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_27.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Applications')
+## DBchapter(Determinants)
+## DBsection(Applications)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_3.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Determinants)
-## DBsection(Applications)
+## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_4.pg
@@ -7,7 +7,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Determinants)
-## DBsection(Applications)
+## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_5.pg
@@ -7,7 +7,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Determinants)
-## DBsection(Applications)
+## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_6.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_7.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_8.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
+## DBchapter(Determinants)
 ## DBsection(Computing determinants)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra6Determinants/ur_la_6_9.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter('Determinants')
-## DBsection('Properties')
+## DBchapter(Determinants)
+## DBsection(Properties)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_1.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_11.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_11.pg
@@ -5,8 +5,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Calculus - multivariable)
-## DBchapter(Multiple Integrals)
-## DBsection(Applications of Multiple Integrals)
+## DBchapter(Integration of multivariable functions)
+## DBsection(Applications of triple integrals)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_2.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_3.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Euclidean plane)
+## DBsection(Misc.)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_4.pg
@@ -6,8 +6,8 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Calculus - single variable)
-## DBchapter('Applications of Integration')
-## DBsection('Areas Between Curves')
+## DBchapter(Applications of integration)
+## DBsection(Areas between curves)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_5.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_5.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_6.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_7.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_8.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_9.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra7AreaVolume/ur_la_7_9.pg
@@ -4,9 +4,9 @@
 
 ## Tagged by cmd6a 4/29/06
 
-## DBsubject(Calculus - multivariable)
-## DBchapter(Vectors and the Geometry of Space)
-## DBsection(The Cross Product)
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Cross product)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_1.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_1.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Abstract vector spaces)
-## DBsection('Subspaces')
+## DBsection(Subspaces)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_2.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_2.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Abstract vector spaces)
-## DBsection('Subspaces')
+## DBsection(Subspaces)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_3.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Abstract vector spaces)
-## DBsection('Subspaces')
+## DBsection(Subspaces)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_4.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_4.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Abstract vector spaces)
-## DBsection('Subspaces')
+## DBsection(Subspaces)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_6.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra8VectorSpaces/ur_la_8_6.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Euclidean spaces)
-## DBsection('Subspaces')
+## DBsection(Subspaces)
 ## Institution('Rochester')
 ## TitleText1('Linear Algebra with Applications')
 ## AuthorText1('Jeffrey Holt')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra9Dependence/ur_la_9_3.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra9Dependence/ur_la_9_3.pg
@@ -5,7 +5,7 @@
 ## Tagged by cmd6a 4/29/06
 
 ## DBsubject(Linear algebra)
-## DBchapter(Abstract vector spaces)
+## DBchapter(Euclidean spaces)
 ## DBsection(Linear independence)
 ## Date('July 2013')
 ## Author('Paul Pearson')

--- a/OpenProblemLibrary/Rochester/setLinearAlgebra9Dependence/ur_la_9_8.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra9Dependence/ur_la_9_8.pg
@@ -6,7 +6,7 @@
 
 ## DBsubject(Linear algebra)
 ## DBchapter(Euclidean spaces)
-## DBsection('Span')
+## DBsection(Span)
 ## Date('July 2013')
 ## Author('Paul Pearson')
 ## Institution('Rochester and Hope College')


### PR DESCRIPTION
I looked at the differences in the tags using log file:

git log -p --since=2014-08-05 --author=paultpearson > gitlog.txt

I read the gitlog.txt file and tried to resolve the tagging issues manually for each file listed.  This pull request is the result of that work.  Apparently, you did some editing today (so there may be some merging required, which I do not know how to do well).  Anyway, this pull request should help fix the OPL-update problem.
