### PR TITLE
Fix answer.

### DIFF
--- a/OpenProblemLibrary/Rochester/setComplexNumbers/ur_cn_1_18.pg
+++ b/OpenProblemLibrary/Rochester/setComplexNumbers/ur_cn_1_18.pg
@@ -1,5 +1,5 @@
 ## DESCRIPTION
-## Calculus
+## Triangle inequality for the complex modulus
 ## ENDDESCRIPTION
 
 ## Tagged by cmd6a 4/20/06
@@ -17,46 +17,36 @@
 ## Problem1('7')
 ## KEYWORDS('Complex', 'Norm', 'Inequality','algebra', 'complex number')
 
-DOCUMENT();        # This should be the first executable line in the problem.
+DOCUMENT();
 
 loadMacros(
-"PG.pl",
-"PGbasicmacros.pl",
-"PGchoicemacros.pl",
-"PGanswermacros.pl",
-"PGauxiliaryFunctions.pl",
-"PGcomplexmacros.pl"
+	'PGstandard.pl',
+	'PGchoicemacros.pl'
 );
 
 TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
-@choices = ("\(\vert z_2 \vert - \vert z_1 \vert\)" , 
-	    "\(\bigl\vert \vert z_2 \vert - \vert z_1 \vert \bigr\vert\)" , 
-	    "\(\vert z_1\ + z_2 \vert \)" ,
-	    "\( \vert z_1 \vert + \vert z_2 \vert \)");
-@answers = ("a", "b", "c", "d");
-
-@slice = NchooseK( scalar(@choices), 4 );
-
-@scrambled_choices = @choices[@slice];
-@scrambled_answers = @answers[@slice];
+@slice = NchooseK(4, 4);
+@choices = (
+	'\( |z_2| - |z_1| \)', 
+	'\( \bigl| |z_2| - |z_1| \bigr| \)', 
+	'\( |z_1 + z_2| \)',
+	'\( |z_1| + |z_2| \)'
+)[@slice];
+@answers = @ALPHABET[invert(@slice)];
 
 BEGIN_TEXT
-Place the following in order: $PAR
-(a) $scrambled_choices[0] , $PAR 
-(b) $scrambled_choices[1] , $PAR 
-(c) $scrambled_choices[2] , $PAR
-(d) $scrambled_choices[3] .
-$PAR
-\{ans_rule(5)\} \(\le\) \{ans_rule(5)\} \(\le\) \{ans_rule(5)\} \(\le\) \{ans_rule(5)\}.
-
+Place the following in order: $BR $BR
+(a) $SPACE $choices[0] $BR $BR
+(b) $SPACE $choices[1] $BR $BR
+(c) $SPACE $choices[2] $BR $BR
+(d) $SPACE $choices[3] $BR $BR $BR
+${BBOLD}Answer:${EBOLD} $SPACE
+\{ans_rule(1)\} \(\le\) \{ans_rule(1)\} \(\le\)
+\{ans_rule(1)\} \(\le\) \{ans_rule(1)\}
 END_TEXT
 
-ANS(str_cmp( $scrambled_answers[0] ) );
-ANS(str_cmp( $scrambled_answers[1] ) );
-ANS(str_cmp( $scrambled_answers[2] ) );
-ANS(str_cmp( $scrambled_answers[3] ) );
+ANS(str_cmp([@answers]));
 
-ENDDOCUMENT();        # This should be the last executable line in the problem.
-
+ENDDOCUMENT();


### PR DESCRIPTION
Invert @slice to order the answers correctly.
The commit

849c4b77966a0d9ca3367b2ef0b073c38c8757bb

did not fix Bug 3162.

Also, improve the question/answer formatting
and clean up the code a little.

Bug 3168 should be closed.