### PR TITLE
	planned fix: hack to avoid & in M&M disrupting hardcopy

### DIFF
--- a/OpenProblemLibrary/MC/PreAlgebra/setPreAlgebraC06S04/BasicProbability03.pg
+++ b/OpenProblemLibrary/MC/PreAlgebra/setPreAlgebraC06S04/BasicProbability03.pg
@@ -22,7 +22,7 @@
 
 ########################################################################
 
-DOCUMENT();      
+DOCUMENT();
 
 loadMacros(
    "PGstandard.pl",     # Standard macros for PG language
@@ -61,10 +61,10 @@ $n = $blues+$yellows+$browns+$reds+$greens;
 Context()->texStrings;
 
 BEGIN_TEXT
-A fun size bag of M&Ms has about $n candies.  You open one of the bags and discover:
+A fun size bag of M\(\&\)Ms has about $n candies.  You open one of the bags and discover:
 $PAR
-$BCENTER 
-$blues Blues, $yellows Yellows, $browns Browns, $reds Reds and $greens Greens. 
+$BCENTER
+$blues Blues, $yellows Yellows, $browns Browns, $reds Reds and $greens Greens.
 $ECENTER
 $PAR
 $BCENTER
@@ -88,9 +88,6 @@ Odds against an event = number of unfavorable outcomes / number of favorable out
 END_HINT
 
 
-BEGIN_SOLUTION
-END_SOLUTION
-
 ##############################################################
 #
 #  Answers
@@ -102,4 +99,11 @@ ANS( Compute("$yellows/($n-$yellows)")->cmp() );
 ANS( Compute("($blues+$reds)/$n")->cmp() );
 ANS( Compute("($n-$greens)/$greens")->cmp() );
 
-ENDDOCUMENT();        
+ENDDOCUMENT();
+
+
+####	moved empty solution:
+##		reminder of author's intent,
+##		but do not confuse instructors about actual state-of-affairs
+BEGIN_SOLUTION
+END_SOLUTION

--- a/OpenProblemLibrary/NewHampshire/NECAP/grade6/gr6-2005/n6-2005-15s.pg
+++ b/OpenProblemLibrary/NewHampshire/NECAP/grade6/gr6-2005/n6-2005-15s.pg
@@ -6,7 +6,7 @@ loadMacros(
 "PGgraphmacros.pl",
 "contextString.pl",
 "PGauxiliaryFunctions.pl", #for lcm, gcd,etc
-);	
+);
 
 # make sure we're in the context we want
 Context("Numeric");
@@ -55,7 +55,7 @@ $graph->lineTo(5.135 ,-1  ,'black');
          $graph -> stamps($circle_object2);
          $circle_object3 = closed_circle(5.125 ,$q ,'black' );
          $graph -> stamps($circle_object3);
- 
+
 $scale=100;
 
 $poly1 = new GD::Polygon;
@@ -257,7 +257,7 @@ $graphb->moveTo(0,1);
 $graphb->lineTo($g ,1 ,'black');
 $graphb->moveTo(0,1.5);
 $graphb->lineTo($g ,1.5 ,'black');
-$graphb->moveTo(0,2);     
+$graphb->moveTo(0,2);
 $graphb->lineTo($g ,2 ,'black');
 
 $graphb->moveTo($k,0);
@@ -334,7 +334,7 @@ Lori used the remaining spinner. $PAR
 \{ image( insertGraph($graphc), tex_size=>$TEXSIZE1,
     height=>$HEIGHT1, width=>$WIDTH1
     ) \}
-$PAR 
+$PAR
 In Lori's table, x= \{ans_rule(1 )\}, y=  \{ans_rule(1 )\}, z=  \{ans_rule(1 )\}.
 END_TEXT
 Context("String")->strings->add(A=>{}, B=>{}, C=>{}) ;
@@ -353,13 +353,12 @@ $PAR
 Greg's result is \(\frac{30}{40}=\frac{3}{4}\) is exactly the fraction
 $BR of spinner B that is yellow, and since the remainder is equally split, $BR
 spinner B exactly matches Greg's result.$PAR
-That leaves spinner A for Lori.  Spinner A is \(\fraction{1}{2}\) yellow and
+That leaves spinner A for Lori.  Spinner A is \(\frac{1}{2}\) yellow and
 \(\frac{1}{4}\) blue and \(\frac{1}{4}\) red.$BR  In 40 spins, the single most
 likely result is 20 yellow and 10 each for blue and red.
 
 END_SOLUTION
 
-COMMENT('MathObject version');
 ENDDOCUMENT();
 
 

--- a/OpenProblemLibrary/NewHampshire/unh_schoolib/Wordy/worsns102.pg
+++ b/OpenProblemLibrary/NewHampshire/unh_schoolib/Wordy/worsns102.pg
@@ -43,10 +43,9 @@ BEGIN_SOLUTION
 $PAR Solution $PAR
 There is one relevant fact in the description.  A pair of dice is rolled.$BR
 In order for the sum to be 2, each die must show a 1 on top.  Since there are$BR
-6 faces on a die, the probability that a die shows a 1 is \(\fraction{1}{6}\) and $BR so the probability that both dice show 1's is \(\frac{1}{6}\times\frac{1}{6}=\frac{1}{36}\).
+6 faces on a die, the probability that a die shows a 1 is \(\frac{1}{6}\) and $BR so the probability that both dice show 1's is \(\frac{1}{6}\times\frac{1}{6}=\frac{1}{36}\).
 END_SOLUTION
 
-COMMENT('MathObject version');
 ENDDOCUMENT();
 ## DBsubject(Probability)
 ## DBchapter(Sample Space)


### PR DESCRIPTION
	incidental: move empty SOLUTION outside of executable code, trim trailing spaces

	planned fix: replace  \fraction  with  \frac
	incidental: remove MO comment (but retain the new MO tag), trim trailing spaces

#### supplemental comments
a) my local repo got munged (reports of local changes which I had not made as a deliberate act) --- rather than diagnose & fix that, I moved it and created a new local repo to use for these fixes

b) my commit had 2 comments about the first fix (MC/...) and 2 comments about the others (NewHampshire/...)
  This supplemental note seems attached to the first --- should I have used two separate commits?

c) if "trim trailing spaces" imposes a hardship in checking my work, then tell me and I will not do that