### PR TITLE
part (b): add "(s)" because its answer has two values, clarify phrasing

### DIFF
--- a/OpenProblemLibrary/LoyolaChicago/Precalc/Chap2Sec1/Q04.pg
+++ b/OpenProblemLibrary/LoyolaChicago/Precalc/Chap2Sec1/Q04.pg
@@ -68,7 +68,7 @@ $BR
 \( y = \) \{ans_rule(20)\}
 \{ AnswerFormatHelp("numbers") \}
 $PAR
-(b) Calculate the exactly the value of \( x \) when \( f(x) = $y1 \).
+(b) Calculate the exact value(s) of \( x \) when \( f(x) = $y1 \).
 Simplify your answer as much as possible.
 $BR
 \(x = \) \{ans_rule(20)\}


### PR DESCRIPTION
Note: I chose to not add a sentence about a comma-separated-list of answers
because "help(numbers)" will show that info [and a single answer gets the
message "There should be more numbers in your list"].