### PR TITLE
Correct small error in display macro.

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_002.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_002.pg
@@ -43,19 +43,29 @@ $dlhs = nicestring([$a,$b,$c],["x_1","x_2","x_3"]);
 $dplane = "$dlhs = $d";
 
 do {
-  $count = 0;
-  $x[0] = random(-4,4,1); 
-  $x[1] = random(-5,5,1);
-  $x[2] = $d - $a*$x[0] - $b*$x[1];
-  for ($i = 0; $i <= 2; $i++) { if ($x[$i] == 0) {$count++;} }
-} until ($count == 1 && abs($x[3]) <= 5);
-
+	$x[1] = random(-4,4,1); 
+	$x[2] = random(-5,5,1);
+	$x[0] = $d - $b*$x[1] - $c*$x[2];
+} until (
+	$x[1]*$x[2] and abs($x[0]) < 10
+);
 do {
-  ($y[0],$y[1],$y[2]) = (non_zero_random(-5,5), (non_zero_random(-5,5)), (non_zero_random(-5,5))); 
-  ($z[0],$z[1],$z[2]) = (non_zero_random(-5,5), (non_zero_random(-5,5)), (non_zero_random(-5,5)));
-  $ev1 = $a*$y[0] + $b*$y[1] + $c*$y[2];
-  $ev2 = $a*$z[0] + $b*$z[1] + $c*$z[2];
-} until (abs($y[0]) != abs($z[0]) && abs($y[0]) != abs($z[0]) && abs($y[0]) != abs($z[0]) && $ev1 != $d && $ev2 != $d);
+	$y[1] = non_zero_random(-7, 7);
+	$y[2] = non_zero_random(-7, 7);
+	$z[1] = non_zero_random(-7, 7);
+	$z[2] = non_zero_random(-7, 7);
+} until (
+	abs($y[1]) - abs($z[1]) and
+	abs($y[2]) - abs($z[2])
+);
+do {
+	$y[0] = non_zero_random(-9, 9);
+	$z[0] = non_zero_random(-9, 9);
+	$ev1 = $y[0] + $b*$y[1] + $c*$y[2];
+	$ev2 = $z[0] + $b*$z[1] + $c*$z[2];
+} until (
+	$ev1 != $d and $ev2 != $d
+);
 
 @q = (Point("($x[0],$x[1],$x[2])"), Point("($y[0],$y[1],$y[2])"), Point("($z[0],$z[1],$z[2])"));
 @p = @q[NchooseK(3,3)];
@@ -84,10 +94,9 @@ ANS($q[0]->cmp());
 ###########################################################################
 Context()->texStrings;
 BEGIN_SOLUTION
-${BBOLD}SOLUTION:${EBOLD} $PAR
-\($a($x[0]) + $b($x[1]) + $c($x[2]) = $d\), so \($q[0]\) lies on the plane \($dplane\) $BR
-\($a($y[0]) + $b($y[1]) + $c($y[2]) = $ev1\), so \($q[1]\) does not lie on the plane \($dplane\)  $BR
-\($a($z[0]) + $b($z[1]) + $c($z[2]) = $ev2\), so \($q[2]\) does not lie on the plane \($dplane\) 
+\($x[0] + $b($x[1]) + $c($x[2]) = $d\), so \($q[0]\) lies on the plane \($dplane\) $BR
+\($y[0] + $b($y[1]) + $c($y[2]) = $ev1\), so \($q[1]\) does not lie on the plane \($dplane\)  $BR
+\($z[0] + $b($z[1]) + $c($z[2]) = $ev2\), so \($q[2]\) does not lie on the plane \($dplane\) 
 END_SOLUTION
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_005.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_005.pg
@@ -50,7 +50,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_008.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_008.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_009.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_009.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_012.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_012.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_015.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_015.pg
@@ -39,7 +39,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_018.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_018.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_024.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_024.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_029.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_029.pg
@@ -42,7 +42,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_032.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_032.pg
@@ -43,7 +43,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_073.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_073.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_076.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_076.pg
@@ -43,7 +43,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_001.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_001.pg
@@ -64,7 +64,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_002.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_002.pg
@@ -64,7 +64,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_004.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_004.pg
@@ -64,7 +64,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_019.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_019.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_021.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_021.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_022.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_022.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_023.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_023.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_024.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_024.pg
@@ -68,7 +68,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_026.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_026.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_027.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_027.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_028.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_028.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_029.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_029.pg
@@ -67,7 +67,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_046.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_02_046.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_001.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_001.pg
@@ -64,7 +64,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_004.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_004.pg
@@ -65,7 +65,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_005.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_005.pg
@@ -179,9 +179,10 @@ with Gaussian elimination with three significant digits of accuracy.
 Then solve the system again with three significant digits of accuracy,
 incorporating partial pivoting. To enter scientific notation,
 use ${BBOLD}x${EBOLD} and ${BBOLD}${CARET}${EBOLD}. For example,
-type ${BBOLD} 2.12 x 10${CARET}(-3) ${EBOLD} to enter \(2.12 \times 10${CARET}{-3}\).
-Note that you ${BITALIC}must${EITALIC} enter all answers in scientific notation,
-even if the power of \(10\) is zero.
+type ${BBOLD} 2.12 x 10${CARET}(-3) ${EBOLD} to enter
+\( 2.12 \times 10^{-3} \).
+Note that you ${BITALIC}must${EITALIC} enter all answers in
+scientific notation, even if the power of \(10\) is zero.
 $PAR
 Gaussian Elimination: \((x_1,x_2) = \bigg(\) \{ans_rule(8)\}, \{ans_rule(8)\} \(\bigg)\)
 $PAR

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_005.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_005.pg
@@ -65,7 +65,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";
@@ -175,7 +175,13 @@ Context()->texStrings;
 BEGIN_TEXT
 First solve the system 
 $PAR \[ $dS \] $PAR
-with Gaussian elimination with three significant digits of accuracy. Then solve the system again with three significant digits of accuracy, incorporating partial pivoting. To enter scientific notation, use ${BBOLD}x${EBOLD} and ${BBOLD}^${EBOLD}. For example, type ${BBOLD} 2.12 x 10^(-3) ${EBOLD} to enter \(2.12 \times 10^{-3}\). Note that you ${BITALIC}must${EITALIC} enter all answers in scientific notation, even if the power of \(10\) is zero.
+with Gaussian elimination with three significant digits of accuracy.
+Then solve the system again with three significant digits of accuracy,
+incorporating partial pivoting. To enter scientific notation,
+use ${BBOLD}x${EBOLD} and ${BBOLD}${CARET}${EBOLD}. For example,
+type ${BBOLD} 2.12 x 10${CARET}(-3) ${EBOLD} to enter \(2.12 \times 10${CARET}{-3}\).
+Note that you ${BITALIC}must${EITALIC} enter all answers in scientific notation,
+even if the power of \(10\) is zero.
 $PAR
 Gaussian Elimination: \((x_1,x_2) = \bigg(\) \{ans_rule(8)\}, \{ans_rule(8)\} \(\bigg)\)
 $PAR

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_007.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_007.pg
@@ -65,7 +65,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";
@@ -255,7 +255,13 @@ Context()->texStrings;
 BEGIN_TEXT
 First solve the system 
 $PAR \[ $dS \] $PAR
-with Gaussian elimination with three significant digits of accuracy. Then solve the system again with three significant digits of accuracy, incorporating partial pivoting. To enter scientific notation, use ${BBOLD}x${EBOLD} and ${BBOLD}^${EBOLD}. For example, type ${BBOLD} 2.12 x 10^(-3) ${EBOLD} to enter \(2.12 \times 10^{-3}\). Note that you ${BITALIC}must${EITALIC} enter all answers in scientific notation, even if the power of \(10\) is zero.
+with Gaussian elimination with three significant digits of accuracy.
+Then solve the system again with three significant digits of accuracy,
+incorporating partial pivoting. To enter scientific notation,
+use ${BBOLD}x${EBOLD} and ${BBOLD}${CARET}${EBOLD}. For example, type
+${BBOLD} 2.12 x 10${CARET}(-3) ${EBOLD} to enter \(2.12 \times 10^{-3}\).
+Note that you ${BITALIC}must${EITALIC} enter all answers in scientific
+notation, even if the power of \(10\) is zero.
 $PAR
 Gaussian Elimination: \((x_1,x_2) = \bigg(\) \{ans_rule(8)\}, \{ans_rule(8)\}, \{ans_rule(8)\} \(\bigg)\)
 $PAR

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_010.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_010.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_012.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_012.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_014.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_014.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_016.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_016.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_017.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_017.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_018.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_018.pg
@@ -42,7 +42,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_019.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_019.pg
@@ -41,7 +41,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_022.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_022.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_026.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_03_026.pg
@@ -40,7 +40,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_007.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_007.pg
@@ -64,7 +64,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_008.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_008.pg
@@ -65,7 +65,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_011.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_011.pg
@@ -65,7 +65,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_012.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_04_012.pg
@@ -65,7 +65,7 @@ sub dispSyst {
   my $b = shift;
   my @d = @_;
   my $dS = "\begin{array}{";
-  for (my $i = 0; $i < $d[0]; $i++) {
+  for (my $i = 0; $i < $d[1]; $i++) {
     $dS = $dS."rc";
   }
   $dS = $dS."r}";


### PR DESCRIPTION
Change (slightly) the definition of
dispSyst so that a hardcopy will be
generated without an error. (In two
files change ^ to $CARET for the
same reason.)