### PR TITLE
display of Correct Answers was wrong;

### DIFF
--- a/OpenProblemLibrary/Michigan/Chap1Sec7/Q13.pg
+++ b/OpenProblemLibrary/Michigan/Chap1Sec7/Q13.pg
@@ -57,7 +57,7 @@ $fone = Compute( "$a - cos(1) + $c" );
 
 $func = Compute("$a*x - cos(x) + $c");
 
-$mp = MultiAnswer( $zero, $one, $fzero, $fone )->with(
+$mp = MultiAnswer( $fzero, $fone, $zero, $one )->with(
     singleResult => 0,
     checker => sub {
 	my ( $correct, $student, $self ) = @_;

--- a/OpenProblemLibrary/Michigan/Chap1Sec8/Q15.pg
+++ b/OpenProblemLibrary/Michigan/Chap1Sec8/Q15.pg
@@ -176,8 +176,8 @@ $BR
 $PAR
 ${BBOLD}(c)$EBOLD
 Graph the function to see if it is consistent with your answers to
-parts (a) and (b).  By graphing, find an interval for \( x \) near
-zero such that the difference between your conjectured limit and the
+parts (a) and (b).  By graphing, find an interval for \( x \) near \( $a \)
+such that the difference between your conjectured limit and the
 value of the function is less than 0.01.  In other words, find a
 window of height 0.02 such that the graph exits the sides of the window
 and not the top or bottom.  What is the window?

--- a/OpenProblemLibrary/Michigan/Chap1Sec8/Q15.pg
+++ b/OpenProblemLibrary/Michigan/Chap1Sec8/Q15.pg
@@ -250,7 +250,7 @@ $ECENTER
 $BR
 This confirms our estimate of the limit.  A reasonable range for \(x\)
 so that the graph of \(f(x)\) enters and leaves a window of height 0.02
-around \(y = $limit\) is \(-$amd \le x \le $apd\) and
+around \(y = $limit\) is \($amd \le x \le $apd\) and
 \($lmd\le y\le $lpd\).
 
 END_SOLUTION


### PR DESCRIPTION
swap pairs in call to MultiAnswer so k-values precede c-values.

Since a common use of the IVT is to infer a continuous function has a zero in an interval provided it changes sign there, I suggest three further changes (each with a weak inequality):
 if ($sk0 <= $stuk[0]) ...
if ($sk1 >= Sstuk[1]) ...
preceded with a check that  $stuk[0] <= $stuk[1].

Afterthought: using weak inequalities for grading might then impose an implicit duty to generalize the Solution accordingly --- perhaps a task for a long ToDo list ;-)