### PR TITLE
Fix bug in NAU function composition problem.

### DIFF
--- a/OpenProblemLibrary/NAU/setFunctionComposition/Composition.pg
+++ b/OpenProblemLibrary/NAU/setFunctionComposition/Composition.pg
@@ -98,9 +98,9 @@ if ($function[0] eq 'h'){
   $heq = "\frac{$n1 x + $n2}{x - $d1}";
 }else {
   $n1 = random(-1,1,2);
-  $n2 = $n1 * random(-4,0,1);
+  $n2 = $n1 * random(-4,-1,1);
   if ($n1 > 0){
-    $heq = "|x| $n2";
+    $heq = "|x| +$n2";
   } else {
     $heq = "-|x| +$n2";
   }


### PR DESCRIPTION
In particular, if h(x) = |x| + $n2, the "+" was omitted from the display.

Also, we remove the possibility of having $n2 = 0, as the 0 is unnecessary
in |x| + 0.