### PR TITLE
Increase width of similar triangle figure.

### DIFF
--- a/OpenProblemLibrary/MC/PreAlgebra/setPreAlgebraC06S03/SimilarTriangles01.pg
+++ b/OpenProblemLibrary/MC/PreAlgebra/setPreAlgebraC06S03/SimilarTriangles01.pg
@@ -60,7 +60,7 @@ $c = $a*$mult;
 $d = $b*$mult;
 
 $vert = $c + 4;
-$horiz = $c+$d+6;
+$horiz = $c+$d+8;
 
 $gr = init_graph(-3,-2,$horiz,$vert, size=>[400,200]);
 


### PR DESCRIPTION
If the length of the leg on the far right is 10, the zero is drawn off the
screen, making students think the length is 1.  We increase the width of the
figure to correct for this.