### PR TITLE
Remark on assumption of 'directional derivatives' for unit vectors only

### DIFF
--- a/OpenProblemLibrary/FortLewis/Calc3/14-4-Gradients-in-plane/HGM4-14-4-48-Gradients-etc/HGM4-14-4-48-Gradients-etc.pg
+++ b/OpenProblemLibrary/FortLewis/Calc3/14-4-Gradients-in-plane/HGM4-14-4-48-Gradients-etc/HGM4-14-4-48-Gradients-etc.pg
@@ -163,6 +163,7 @@ $showPartialCorrectAnswers = 0;
 
 ANS(str_cmp($tf->ra_correct_ans));
 
+COMMENT("Assumes that 'directional derivatives' only make sense with respect to unit vectors.")
 
 ;
 ENDDOCUMENT();


### PR DESCRIPTION
This problem can be very confusing for students using a textbook that allows a "directional derivative" to be taken with respect to any vector, not just a unit vector.  At least the instructor can be warned when selecting problems.