### PR TITLE
Correct answer

### DIFF
--- a/OpenProblemLibrary/Hope/Multi2/12-01-Vector-fields/Vector-fields-07.pg
+++ b/OpenProblemLibrary/Hope/Multi2/12-01-Vector-fields/Vector-fields-07.pg
@@ -38,7 +38,7 @@ $n = random(2,3,1);
 $s = random(-1,1,2);
 @direction = ('toward','away from');
 
-$answer = Compute("<$s*x/(sqrt(x^2+y^2))^$n, $s*y/(sqrt(x^2+y^2))^$n>");
+$answer = Compute("<$s*x/(sqrt(x^2+y^2))^($n+1), $s*y/(sqrt(x^2+y^2))^($n+1)>");
 
 
 ##################################


### PR DESCRIPTION
Either I'm very confused, or the answer to this problem is wrong.  To get a vector field whose magnitude is inversely proportional to the nth power of r, you have to divide r by the (n+1)st power of its magnitude: r/|r| to get a unit vector, and then (r/|r|)/|r|^n to make the magnitude 1/|r|^n.