### PR TITLE
Specify a value to determine the proportionality constant

### DIFF
--- a/OpenProblemLibrary/Hope/Multi2/12-01-Vector-fields/Vector-fields-07.pg
+++ b/OpenProblemLibrary/Hope/Multi2/12-01-Vector-fields/Vector-fields-07.pg
@@ -47,14 +47,12 @@ $answer = Compute("<$s*x/(sqrt(x^2+y^2))^($n+1), $s*y/(sqrt(x^2+y^2))^($n+1)>");
 Context()->texStrings;
 BEGIN_TEXT
 Find a formula \( \vec{F} = \langle\ F_1(x,y),\ F_2(x,y)\ \rangle \) 
-for the vector field in the plane that has the properties that 
-\( \vec{F} \) is not defined at the origin and that at any other point
-\( (x,y) \ne (0,0) \) the vector field
-\( \vec{F} \) points $direction[($s+1)/2] the origin with magnitude 
-inversely proportional to the $type[$n-2] of the distance from \( (x,y) \)
-to the origin.
-$BR
-$BR
+for the vector field in the plane with the following properties:
+$PAR
+1. \( \vec{F} \) is not defined at the origin$BR
+2. At any other point \( (x,y) \ne (0,0) \) the vector field \( \vec{F} \) points $direction[($s+1)/2] the origin with magnitude inversely proportional to the $type[$n-2] of the distance from \( (x,y) \) to the origin.$BR
+3. At the point \( (1,0) \) the vector field \( \vec{F} \) has magnitude \( 1 \).
+$PAR
 \( \vec{F} = \)
 \{ans_rule(50)\}
 END_TEXT


### PR DESCRIPTION
As noted by @paultpearson on #265 , this question also doesn't have a unique correct answer until we determine the proportionality constant.  It would be nice to be able to mark any answer correct as long as it's proportional, the way we can check for "any antiderivative" with `upToConstant`, but I couldn't figure out how to do that.