### PR TITLE
Specify limits for the answer.

### DIFF
--- a/OpenProblemLibrary/OSU/high_school_apcalc/dchmwk4/prob12.pg
+++ b/OpenProblemLibrary/OSU/high_school_apcalc/dchmwk4/prob12.pg
@@ -17,11 +17,7 @@
 DOCUMENT();        # This should be the first executable line in the problem.
 
 loadMacros(
-"PG.pl",
-"PGbasicmacros.pl",
-"PGchoicemacros.pl",
-"PGanswermacros.pl",
-"PGauxiliaryFunctions.pl",
+"PGstandard.pl",
 "MathObjects.pl"
 );
 
@@ -31,14 +27,13 @@ $showPartialCorrectAnswers = 1;
 Context("Numeric");
 $a1 = random(2,5,1);
 $funct1 =Compute("$a1/(x*ln(x))");
+$funct1->{limits} = [2, 3];
 
-TEXT(EV2(<<EOT));
+BEGIN_TEXT
 If \( f(x) = $a1 \ln(\ln(x))  \), find \( f'( x ) \).
 $BR $BR \(f'(x)=\) \{ans_rule(50) \}
-$BR
-EOT
+END_TEXT
 
 ANS($funct1->cmp);
-
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.


### PR DESCRIPTION
With some seeds the checker fails to generate
enough valid points for comparison.  Specify a
closed interval in the domain of the answer so
as to avoid this problem.