### PR TITLE
fix several problems in OpenProblemLibrary/Mizzou/Algebra/functions_e…

### DIFF
--- a/OpenProblemLibrary/Mizzou/Algebra/functions_evaluating/two_graphs_equal_inequal_02.pg
+++ b/OpenProblemLibrary/Mizzou/Algebra/functions_evaluating/two_graphs_equal_inequal_02.pg
@@ -234,19 +234,29 @@ Context()->normalStrings;
 # Check the answer {{{
 ###########################################################
   Context("Interval")->strings->add("none"=>{}, "does not exist"=>{});
-  if ( $ran_func_a == 0 ) {
-    # here $ran_func_a == 0 means random function is f
-    # the other choice is 1 i.e. the function is g
+  if ( $ran_func_a eq "f" ) {
     $x_zeros = List($pfunc_1_x,$sline_middle_x,$pfunc_2_x);
   } else {
     $x_zeros =  List($sline_middle_x);
   }
   ANS($x_zeros->cmp());
 
+  if ( $ran_func_b eq "f" ) {
   $func_greater_zero = Interval("[$pfunc_1_x,$sline_middle_x]U[$pfunc_2_x,$sline_right_x]");
+  }
+  else
+  {
+  $func_greater_zero = Interval("[$sline_middle_x,$sline_right_x]");  
+  }
   ANS($func_greater_zero->cmp());
 
+  if ( $ran_func_c eq "f" ) {
   $func_less_zero = Interval("($sline_left_x,$pfunc_1_x)U($sline_middle_x,$pfunc_2_x)");
+  }
+  else
+  {
+  $func_less_zero = Interval("[$sline_left_x,$sline_middle_x)");
+  }
   ANS($func_less_zero->cmp());
 
   $f_equal_g = List($sline_left_x,$sline_middle_x,$sline_right_x);
@@ -255,14 +265,15 @@ Context()->normalStrings;
   $leq_ans = Interval("[$sline_middle_x,$sline_right_x]");
   ANS($leq_ans->cmp());
 
-  if ($ran_func_f eq 'f') {
-    # if the random function chosen for part f happens to be 'f'
-    # then we know the inequality is f leq g.
-    $gr_ans = List(Interval("($sline_left_x,$sline_middle_x)"));
-  } else {
+#  if ($ran_func_f eq 'f') {
+#    # if the random function chosen for part f happens to be 'f'
+#    # then we know the inequality is f leq g.
+#    $gr_ans = List(Interval("($sline_left_x,$sline_middle_x)"));
+#  } else {
     # if the random function chosen for part f happens to be 'g'
     # then we know the inequality is g leq f.
-    $gr_ans = List(Interval("($sline_middle_x,$sline_right_x)"));  }
+    $gr_ans = List(Interval("($sline_left_x,$sline_middle_x)"));
+#  }
   ANS($gr_ans->cmp());
 #}}}=======================================================
 


### PR DESCRIPTION
…valuating/two_graphs_equal_inequal_02.pg

I think the following should still be improved: The problem expects "discrete" sets such as {0,5} to be entered as a list "0,5", while unions of intervals are supposed to be entered as such. I propose that the problem should expect discrete sets to be entered as such and not as lists.