### PR TITLE
Fix bug in integral test problem.

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/10_Infinite_Series/10.3_Convergence_of_Series_with_Positive_Terms/10.3.13.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/10_Infinite_Series/10.3_Convergence_of_Series_with_Positive_Terms/10.3.13.pg
@@ -29,7 +29,7 @@ $coef = Real(random(2, 9, 1));
 
 $start = 1;
 $func = "\frac{$coef}{$a^{\ln n}}";
-$f = Formula("$coef/($a^{ln(x)})");
+$f = Formula("$coef/($a^{ln(x)})")->with(limits=>[1,5]);
 
 
 if ($a == 2) {


### PR DESCRIPTION
The integrand involves raising a constant to the power of ln x.  This is
undefined when x <= 0, and so we likely will fail generating enough test
points to check students' answers.

We change the limits to [1,5] to avoid this.