### PR TITLE
Make 'all' and 'none' valid (albeit incorrect) responses.

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/2.2.41.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/2.2.41.pg
@@ -99,7 +99,7 @@ Context()->normalStrings;
 
 $showPartialCorrectAnswers = 1;
 
-ANS(num_cmp($h));
+ANS(num_cmp($h, strings => ['all', 'none']));
 
 SOLUTION(EV3(<<'END_SOLUTION'));
 $PAR SOLUTION $PAR


### PR DESCRIPTION
The question instructs the student to enter
these responses in certain cases, they should
not raise 'undefined in this context' warning
messages to the student.