### PR TITLE
Correct rounding issue in answer checking. Clean up answer format.

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_073.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/holt_01_01_073.pg
@@ -92,14 +92,32 @@ do {
 
 $dS = dispSyst($A,Matrix([$b[0]],[$b[1]]),(2,3));
 
-Context()->variables->add(s1 => ["Real", TeX=>"s_1"], s2 => ["Real", TeX=>"s_2"], s3 => ["Real", TeX=>"s_3"]);
+Context('Fraction');
+$f1 = Fraction($b[1], $a[1][1])->reduce;
+$sf1 = ($f1 < 0 ? '-' : ''); $af1 = abs($f1);
+$f2 = Fraction(-$a[1][2], $a[1][1])->reduce;
+$sf2 = ($f2 < 0 ? '-' : '+' ); $af2 = abs($f2);
+$d = Fraction($a[0][1], $a[1][1]);
+$f3 = (
+	Fraction($b[0], $a[0][0]) - Fraction($b[1], $a[0][0])*$d
+)->reduce;
+$sf3 = ($f3 < 0 ? '-' : ''); $af3 = abs($f3);
+$f4 = (
+	$d*Fraction($a[1][2], $a[0][0]) - Fraction($a[0][2], $a[0][0])
+)->reduce;
+$sf4 = ($f4 < 0 ? '-' : '+' ); $af4 = abs($f4);
+
+Context('Numeric')->variables->add(
+	s1 => ["Real", TeX=>"s_1"],
+	s2 => ["Real", TeX=>"s_2"],
+	s3 => ["Real", TeX=>"s_3"]
+);
+Context()->flags->set(
+	reduceConstants => 0
+);
+$x[0] = Formula($sf3 . "($af3)" . $sf4 . "($af4) s1");
+$x[1] = Formula($sf1 . "($af1)" . $sf2 . "($af2) s1");
 $x[2] = Formula("s1");
-$c1 = ($b[1]/$a[1][1]);
-$c2 = $a[1][2]/$a[1][1];
-$c3 = ($a[1][1]*$b[0]-$a[0][1]*$b[1])/($a[0][0]*$a[1][1]);
-$c4 = ($a[0][2]*$a[1][1] - $a[0][1]*$a[1][2])/($a[0][0]*$a[1][1]);
-$x[1] = Formula("$c1 - $c2 s1")->reduce;
-$x[0] = Formula("$c3 - $c4 s1")->reduce;
 
 
 ###########################################################################
@@ -124,15 +142,15 @@ ANS($x[2]->cmp());
 ###########################################################################
 # solution
 ###########################################################################
-Context("Fraction-NoDecimals");
 Context()->texStrings;
-$f1 = Fraction(-$a[1][2],$a[1][1]);
-$f2 = Fraction($b[1],$a[1][1]);
-$f3 = Fraction($a[0][1]*$a[1][2]-$a[0][2]*$a[1][1], $a[0][0]*$a[1][1]);
-$f4 = Fraction($a[1][1]*$b[0] - $a[0][1]*$b[1], $a[0][0]*$a[1][1]);
 BEGIN_SOLUTION
 ${BBOLD}SOLUTION:${EBOLD}
-Note that \(x_3\) is a free variable so let \(x_3 = s_1\). The second equation then gives \($a[1][1]x_2 + $a[1][2] s_1 = $b[1] \Rightarrow x_2 = $f1 s_1 + $f2\). Substitute this into the first equation, \($a[0][0] x_1 + $a[0][1] ($f1 s_1 + $f2) + $a[0][2] s_1 = $b[0] \Rightarrow x_1 = $f3 s_1 + $f4\).
+Note that \(x_3\) is a free variable so let \(x_3 = s_1\).
+The second equation then gives
+\( $a[1][1]x_2 + $a[1][2] s_1 = $b[1] \Rightarrow x_2 = $f1 + $f2 s_1 \).
+Substitute this into the first equation,
+\( $a[0][0] x_1 + $a[0][1] ($f1 + $f2 s_1) + $a[0][2] s_1 = $b[0]
+\Rightarrow x_1 = $f3 + $f4 s_1 \).
 END_SOLUTION
 Context()->normalStrings;
 


### PR DESCRIPTION
With some seeds (e.g., 4040) the checker would reject
correct exact answers.  Fix this, and clean up formatting
of the answer so that it matches that of the solution.