### PR TITLE
change encoding to utf-8 in several files

### DIFF
--- a/OpenProblemLibrary/Rochester/setAppletExamples/PolarApplet.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/PolarApplet.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/PolarApplet.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/PolarApplet.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/PolarApplet.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/PolarApplet.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/appletExamplesHeader.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/appletExamplesHeader.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/appletExamplesHeader.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/appletExamplesHeader.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/appletExamplesHeader.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/appletExamplesHeader.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/gummyGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/gummyGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/gummyGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/gummyGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/gummyGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/gummyGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/scriptGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/scriptGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph2.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph2.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/scriptGraph2.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph2.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/scriptGraph2.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/scriptGraph2.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/sketchGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/sketchGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/sketchGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/sketchGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/sketchGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/sketchGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/sliderGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/sliderGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/sliderGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setAppletExamples/sliderGraph1.pg
+++ b/OpenProblemLibrary/Rochester/setAppletExamples/sliderGraph1.pg
@@ -1,6 +1,6 @@
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setAppletExamples/sliderGraph1.pg,v 1.1 2007/07/20 02:31:45 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setSequentialProblems/sequentialProblem3.pg
+++ b/OpenProblemLibrary/Rochester/setSequentialProblems/sequentialProblem3.pg
@@ -18,7 +18,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright &copy; 2000-2019 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setSequentialProblems/sequentialProblem3.pg,v 1.1 2007/07/20 12:28:28 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/Rochester/setSequentialProblems/sequentialProblem3.pg
+++ b/OpenProblemLibrary/Rochester/setSequentialProblems/sequentialProblem3.pg
@@ -18,7 +18,7 @@
 
 ################################################################################
 # WeBWorK Online Homework Delivery System
-# Copyright © 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
+# Copyright Â© 2000-2003 The WeBWorK Project, http://openwebwork.sf.net/
 # $CVSHeader: database_problems/Rochester/setSequentialProblems/sequentialProblem3.pg,v 1.1 2007/07/20 12:28:28 jjholt Exp $
 # 
 # This program is free software; you can redistribute it and/or modify it under

--- a/OpenProblemLibrary/ma123DB/set6/s9_2_3.pg
+++ b/OpenProblemLibrary/ma123DB/set6/s9_2_3.pg
@@ -36,7 +36,7 @@ $tf = new_match_list();
 # $tf now "contains" the select list object.  
 
 
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "?", T => "True", F => "False"] ); 
 
 $numberOfQuestions = 4;
 $tf -> qa (

--- a/OpenProblemLibrary/ma123DB/set6/s9_2_3.pg
+++ b/OpenProblemLibrary/ma123DB/set6/s9_2_3.pg
@@ -36,7 +36,7 @@ $tf = new_match_list();
 # $tf now "contains" the select list object.  
 
 
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "ÃŠÃŠ?", T => "True", F => "False"] ); 
 
 $numberOfQuestions = 4;
 $tf -> qa (

--- a/OpenProblemLibrary/ma123DB/set6/s9_2_4.pg
+++ b/OpenProblemLibrary/ma123DB/set6/s9_2_4.pg
@@ -46,7 +46,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "ÃŠÃŠ?", T => "True", F => "False"] ); 
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/ma123DB/set6/s9_2_4.pg
+++ b/OpenProblemLibrary/ma123DB/set6/s9_2_4.pg
@@ -46,7 +46,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "?", T => "True", F => "False"] ); 
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_1/ur_de_2_1.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_1/ur_de_2_1.pg
@@ -47,7 +47,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] );
+$tf -> ra_pop_up_list( [ No_answer => "ÃŠÃŠ?", T => "True", F => "False"] );
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_1/ur_de_2_1.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_1/ur_de_2_1.pg
@@ -47,7 +47,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] );
+$tf -> ra_pop_up_list( [ No_answer => "?", T => "True", F => "False"] );
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_2/ur_de_2_2.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_2/ur_de_2_2.pg
@@ -47,7 +47,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] );
+$tf -> ra_pop_up_list( [ No_answer => "ÃŠÃŠ?", T => "True", F => "False"] );
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_2/ur_de_2_2.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_2/ur_de_2_2.pg
@@ -47,7 +47,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] );
+$tf -> ra_pop_up_list( [ No_answer => "?", T => "True", F => "False"] );
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_3.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_3.pg
@@ -48,7 +48,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "ÃŠÃŠ?", T => "True", F => "False"] ); 
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_3.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_3.pg
@@ -48,7 +48,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "?", T => "True", F => "False"] ); 
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_4.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_4.pg
@@ -48,7 +48,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "ÃŠÃŠ?", T => "True", F => "False"] ); 
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_4.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ2DirectionFields/ur_de_2_4.pg
@@ -48,7 +48,7 @@ $tf = new_match_list();
 # To enter T as an answer choose the list element "True"
 # To enter F as an answer choose the list element "False"
 # The first choice is a blank to make the students do SOMETHING!!!
-$tf -> ra_pop_up_list( [ No_answer => "ÊÊ?", T => "True", F => "False"] ); 
+$tf -> ra_pop_up_list( [ No_answer => "?", T => "True", F => "False"] ); 
 # Note how the list is constructed [ answer => list element , answer => list element ]
 
 # Insert some  questions and whether or not they are true.


### PR DESCRIPTION
I converted these pg files to utf-8 in order to prevent problems with the forthcoming utf-8 compatible version of WeBWorK. With the iso-8859 encoding the OPL-update script would complain (and probably these problems would not render properly). Probably this should be pulled when WeBWorK switches to utf-8. On installations that still use the old WeBWorK these problems may cause problems. I fear that this problem is hard to avoid. Fortunately it affects only a few problems.