### PR TITLE
Specify that x should be a real number (any field of characteristic not equal to 2 would be fine)

### DIFF
--- a/OpenProblemLibrary/MontanaState/Equivalence/Equiv2.pg
+++ b/OpenProblemLibrary/MontanaState/Equivalence/Equiv2.pg
@@ -33,7 +33,7 @@ TEXT(beginproblem());
 
 $mc = new_checkbox_multiple_choice();
 
-$mc -> qa ("Select all the sentences that are equivalent to  \( x = 2 \).", 
+$mc -> qa ("Let $x$ be a real number. Select all the sentences that are equivalent to  \( x = 2 \).", 
 "\( 4x = 8 \)$BR",
 "\( x \in \lbrace 2 \rbrace \)$BR"
 );


### PR DESCRIPTION
The reason is that 4x=8 is not equivalent to x=2 in characteristic 0.