### PR TITLE
introduce negate() macro for propositional logic

### DIFF
--- a/OpenProblemLibrary/SDSU/Discrete/Logic/formallogicB16.pg
+++ b/OpenProblemLibrary/SDSU/Discrete/Logic/formallogicB16.pg
@@ -23,7 +23,8 @@ DOCUMENT();
 loadMacros(
 "PGstandard.pl",
 "MathObjects.pl",
-"PGchoicemacros.pl"
+"PGchoicemacros.pl",
+"logicMacros.pl"
 );
 
 TEXT(beginproblem());
@@ -31,11 +32,11 @@ TEXT(beginproblem());
 ############################
 # Setup
 
-$statement = "(p\wedge\sim q)\rightarrow (r\vee s)";
+$statement = "(p\wedge".negate()." q)\rightarrow (r\vee s)";
 
 $radio = new_multiple_choice();
-$radio->qa("Choose the correct statement:","\((p\wedge\sim q)\wedge (\sim r\wedge\sim s)\)");
-$radio->extra("\((p\wedge\sim q)\vee (r\vee s)\)","\((p\wedge\sim q)\vee (\sim r\wedge\sim s)\)","\((\sim p\vee q)\wedge (\sim r\wedge\sim s)\)");
+$radio->qa("Choose the correct statement:","\((p\wedge".negate()." q)\wedge (".negate()." r\wedge".negate()." s)\)");
+$radio->extra("\((p\wedge".negate()." q)\vee (r\vee s)\)","\((p\wedge".negate()." q)\vee (".negate()." r\wedge".negate()." s)\)","\((".negate()." p\vee q)\wedge (".negate()." r\wedge".negate()." s)\)");
 
 ############################
 # Main Text
@@ -69,13 +70,13 @@ $PAR Solution: $PAR
 Original Statement: $BR $BR
 \($statement\) $BR $BR
 In order to negate this statement, first translate it into an \(or\) statement to get rid of the \(implies\) operator. $BR
-\($statement \equiv \sim (p\wedge\sim q)\vee (r\vee s)\) $BR
+\($statement \equiv \{negate()\} (p\wedge \{ negate() \} q)\vee (r\vee s)\) $BR
 Now, negate the statement. $BR
-\(\sim (\sim (p\wedge\sim q)\vee (r\vee s))\) $BR
+\( \{ negate() \} \{ negate() \} (p\wedge \{ negate() \} q)\vee (r\vee s))\) $BR
 Since the two \(not\) operators cancel, only the second half of the statement needs to be negated. $BR
-\((p\wedge\sim q)\wedge\sim (r\vee s)\) $BR
+\((p\wedge\{negate()\} q)\wedge \{ negate()\} (r\vee s)\) $BR
 Thus, the answer is $BR
-\((p\wedge\sim q)\wedge (\sim r\wedge\sim s)\)
+\((p\wedge\{negate()\} q)\wedge (\{negate()\} r\wedge \{ negate() \} s)\)
 END_SOLUTION
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/SDSU/Discrete/Logic/logicMacros.pl
+++ b/OpenProblemLibrary/SDSU/Discrete/Logic/logicMacros.pl
@@ -1,0 +1,5 @@
+sub negate { 
+	#return "\\sim";
+	return "\\lnot";
+};
+


### PR DESCRIPTION
The idea of this pull request is to provide a function negate() to print the negation symbol in formulas of propositional logic. The motivation was the observation that some problems in the OPL use "\sim" for negation, while others use "\lnot" or "\neg". I think it would be nice to have this configurable, similarly as the macros in `macros/UMass-Amherst/algebraMacros.pl`.