### PR TITLE
Fix bug in circle macros.

### DIFF
--- a/OpenProblemLibrary/macros/UW-Stout/stoutSpecialGradersCircle.pl
+++ b/OpenProblemLibrary/macros/UW-Stout/stoutSpecialGradersCircle.pl
@@ -809,7 +809,7 @@ sub TeX{
 }
 
 package stoutGenericEquation;
-
+@stoutGenericEquation::ISA =qw(Value);
 
 # the easier debug block
 # it uses functions from stoutUtils package,


### PR DESCRIPTION
Caused the "context not found...." message in problems such as circle-problem-1-center-radius.pl