### PR TITLE
add subroutine ZmodnZ to output a LaTeX string representing the ring Z/nZ

### DIFF
--- a/OpenProblemLibrary/macros/UMass-Amherst/algebraMacros.pl
+++ b/OpenProblemLibrary/macros/UMass-Amherst/algebraMacros.pl
@@ -31,6 +31,12 @@ sub cyclic {
 
 };
 
+# Macro to display the ring Z/nZ
+sub ZmodnZ {
+	my $n = shift;
+	return "\\mathbb{Z} / $n \\mathbb{Z}";
+}
+
 sub dihedral { 
 
 	my $n = shift;


### PR DESCRIPTION
There is already a subroutine "cyclic" in this file that returns a string representation for finite cyclic groups. However in situations such as

```
Denote by \( \{ cyclic( $modulus ) \} \) the ring whose elements are the integers modulo \( $modulus \). $BR $BR

(a) Determine all units of \( \{ cyclic( $modulus ) \} \). Enter them as a comma-separated list. $BR
\{ ans_rule( 40 ) \} $BR $BR

(b) Determine all zero-divisors of \( \{ cyclic( $modulus ) \} \). Enter them as a comma-separated list. $BR
\{ ans_rule( 40 ) \} $BR $BR
```

in `OpenProblemLibrary/UMass-Amherst/Abstract-Algebra/PS-RingsDefinition/RingsDefinition3.pg` I would not like to read C_n for instance, because the ring structure is crucial and C_n is usually just a group and not the ring Z/nZ. I propose to use the macro `ZmodnZ` in such situations.