### PR TITLE
add macro file "linearAlgebraMacros.pl"

### DIFF
--- a/OpenProblemLibrary/Hope/Multi1/04-01-Linear-transformations/Lin_trans_20.pg
+++ b/OpenProblemLibrary/Hope/Multi1/04-01-Linear-transformations/Lin_trans_20.pg
@@ -26,6 +26,7 @@ loadMacros(
   "parserPopUp.pl",
   "unionLists.pl",
   "PGchoicemacros.pl",
+  "linearAlgebraMacros.pl",
   "PGcourse.pl"
 );
 TEXT(beginproblem());
@@ -107,6 +108,9 @@ $X3 = Matrix([
 
 $CX3 = $C * $X3;
 
+$ve = vectorstyle("e");
+$vv = vectorstyle("v");
+
 Context()->texStrings;
 BEGIN_TEXT
 \{ BeginList('OL',type=>'a') \}
@@ -128,33 +132,33 @@ $ITEMSEP
 $ITEM 
 Suppose \( f : \mathbb{R}^{12} \to \mathbb{R}^{2} \) is a linear transformation such that 
 \[
-f \left( \begin{array}{c} \vec{e}_4 \end{array} \right)
+f \left( \begin{array}{c} {$ve}_4 \end{array} \right)
 =
 \left( \begin{array}{r} $b[1][1] \\ $b[2][1] \end{array} \right),
 \ \ \ 
-f \left( \begin{array}{c} \vec{e}_7 \end{array} \right)
+f \left( \begin{array}{c} {$ve}_7 \end{array} \right)
 =
 \left( \begin{array}{r} $b[1][2] \\ $b[2][2] \end{array} \right),
 \ \ \ 
-f \left( \begin{array}{c} \vec{e}_8 \end{array} \right)
+f \left( \begin{array}{c} {$ve}_8 \end{array} \right)
 =
 \left( \begin{array}{r} $b[1][3] \\ $b[2][3] \end{array} \right).
 \]
-Then \( \displaystyle f ( $w[3] \vec{e}_4 + $w[4] \vec{e}_7 ) - f ( $w[5] \vec{e}_8 + $w[6] \vec{e}_7 )= \)
+Then \( \displaystyle f ( $w[3] {$ve}_4 + $w[4] {$ve}_7 ) - f ( $w[5] {$ve}_8 + $w[6] {$ve}_7 )= \)
 \{ $BX2->ans_array(10) \}.
 
 $ITEMSEP
 $ITEM
-Let \( V \) be a vector space and let \( \vec{v}_1, \vec{v}_2, \vec{v}_3 \in V \).
+Let \( V \) be a vector space and let \( {$vv}_1, {$vv}_2, {$vv}_3 \in V \).
 Suppose \( T : V \to \mathbb{R}^{2} \) is a linear transformation such that 
 \[
-T(\vec{v}_1) = \left( \begin{array}{r} $c[1][1] \\ $c[2][1] \end{array} \right),
+T({$vv}_1) = \left( \begin{array}{r} $c[1][1] \\ $c[2][1] \end{array} \right),
 \ \ \
-T(\vec{v}_2) = \left( \begin{array}{r} $c[1][2] \\ $c[2][2]  \end{array} \right),
+T({$vv}_2) = \left( \begin{array}{r} $c[1][2] \\ $c[2][2]  \end{array} \right),
 \ \ \
-T(\vec{v}_3) = \left( \begin{array}{r} $c[1][3] \\ $c[2][3]  \end{array} \right).
+T({$vv}_3) = \left( \begin{array}{r} $c[1][3] \\ $c[2][3]  \end{array} \right).
 \]
-Then \( $w[7] T(\vec{v}_1) + T($w[8] \vec{v}_2 + $w[9] \vec{v}_3) = \)
+Then \( $w[7] T({$vv}_1) + T($w[8] {$vv}_2 + $w[9] {$vv}_3) = \)
 \{ $CX3->ans_array(10) \}.
 \{ EndList('OL') \}
 END_TEXT
@@ -164,5 +168,6 @@ ANS( $AX1->cmp );
 ANS( $BX2->cmp );
 ANS( $CX3->cmp );
 
+COMMENT("Vectors are formated using the subroutine vectorstyle in linearAlgebraMacros. This can be customized by placing a copy of linearAlgebraMacros.pl in the course directory and modifying the subroutines in that file. Alternatively the subroutine can be overwritten in PGcourse.pl.");
 
 ENDDOCUMENT();

--- a/OpenProblemLibrary/macros/UniSiegen/linearAlgebraMacros.pl
+++ b/OpenProblemLibrary/macros/UniSiegen/linearAlgebraMacros.pl
@@ -1,0 +1,5 @@
+sub vectorstyle {
+	$v = shift;
+	#return "\\vec\{$v\}"
+	return "$v"
+}


### PR DESCRIPTION
Add macro file "linearAlgebraMacros.pl" with the subroutine
"vectorstyle", which is supposed to be used to format vectors. The file
OpenProblemLibrary/Hope/Multi1/04-01-Linear-transformations/Lin_trans_20.pg
is changed to illustrate the use of this subroutine. The motivation is
to allow instructors to easily customize the style of vectors.