### PR TITLE
Fix typo in displayed formula

### DIFF
--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/fourier-cos.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/fourier-cos.pg
@@ -152,7 +152,7 @@ if ($trig eq "cosine") {
      "\(A_n = \)" . ans_rule(60);
   $Series_formula =
      "\(\displaystyle C(x) = " .
-     "\frac{A_0}{2} \, + \, \sum_{n=1}^\infty A_n\,\cos\left(\frac{n\pi}{$L}\,t\right)\)"; 
+     "\frac{A_0}{2} \, + \, \sum_{n=1}^\infty A_n\,\cos\left(\frac{n\pi}{$L}\,x\right)\)"; 
   $Series = "C";
 } else {
   $Coeff_entry = 
@@ -160,7 +160,7 @@ if ($trig eq "cosine") {
      "\(B_n = \)" . ans_rule(60); 
   $Series_formula =
      "\(\displaystyle S(x) = " .
-     "\sum_{n=1}^\infty B_n\,\sin\left(\frac{n\pi}{$L}\,t\right)\)";
+     "\sum_{n=1}^\infty B_n\,\sin\left(\frac{n\pi}{$L}\,x\right)\)";
   $Series = "S";
 }
 

--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/fourier-sin.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/fourier-sin.pg
@@ -152,7 +152,7 @@ if ($trig eq "cosine") {
      "\(A_n = \)" . ans_rule(60);
   $Series_formula =
      "\(\displaystyle C(x) = " .
-     "\frac{A_0}{2} \, + \, \sum_{n=1}^\infty A_n\,\cos\left(\frac{n\pi}{$L}\,t\right)\)"; 
+     "\frac{A_0}{2} \, + \, \sum_{n=1}^\infty A_n\,\cos\left(\frac{n\pi}{$L}\,x\right)\)"; 
   $Series = "C";
 } else {
   $Coeff_entry = 
@@ -160,7 +160,7 @@ if ($trig eq "cosine") {
      "\(B_n = \)" . ans_rule(60); 
   $Series_formula =
      "\(\displaystyle S(x) = " .
-     "\sum_{n=1}^\infty B_n\,\sin\left(\frac{n\pi}{$L}\,t\right)\)";
+     "\sum_{n=1}^\infty B_n\,\sin\left(\frac{n\pi}{$L}\,x\right)\)";
   $Series = "S";
 }
 

--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/fourier-sin_cos.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/fourier-sin_cos.pg
@@ -154,7 +154,7 @@ if ($trig eq "cosine") {
      "\(A_n = \)" . ans_rule(60);
   $Series_formula =
      "\(\displaystyle C(x) = " .
-     "\frac{A_0}{2} \, + \, \sum_{n=1}^\infty A_n\,\cos\left(\frac{n\pi}{$L}\,t\right)\)"; 
+     "\frac{A_0}{2} \, + \, \sum_{n=1}^\infty A_n\,\cos\left(\frac{n\pi}{$L}\,x\right)\)"; 
   $Series = "C";
 } else {
   $Coeff_entry = 
@@ -162,7 +162,7 @@ if ($trig eq "cosine") {
      "\(B_n = \)" . ans_rule(60); 
   $Series_formula =
      "\(\displaystyle S(x) = " .
-     "\sum_{n=1}^\infty B_n\,\sin\left(\frac{n\pi}{$L}\,t\right)\)";
+     "\sum_{n=1}^\infty B_n\,\sin\left(\frac{n\pi}{$L}\,x\right)\)";
   $Series = "S";
 }
 


### PR DESCRIPTION
Very minor typo fix in the displayed formulas, the variable the problem uses is x, but at one point it says "t" instead.  Found this error in 3 files.

I figured this is so minor I'd skip the bugzilla, but if I should just go to bugzilla, just let me know.