### PR TITLE
remove the variable "x" from the context

### DIFF
--- a/OpenProblemLibrary/NAU/setLinearAlgebra/minpoly2.pg
+++ b/OpenProblemLibrary/NAU/setLinearAlgebra/minpoly2.pg
@@ -25,8 +25,7 @@ $showPartialCorrectAnswers = 1;
 TEXT(beginproblem()); 
 
 Context('Numeric');
-Context()->variables->add(t => ['Real']);
-Context()->variables->remove("x");
+Context()->variables->are(t => ['Real']);
 {
 $a=non_zero_random(-9,9,1);
 $b=non_zero_random(-9,9,1);

--- a/OpenProblemLibrary/NAU/setLinearAlgebra/minpoly2.pg
+++ b/OpenProblemLibrary/NAU/setLinearAlgebra/minpoly2.pg
@@ -26,6 +26,7 @@ TEXT(beginproblem());
 
 Context('Numeric');
 Context()->variables->add(t => ['Real']);
+Context()->variables->remove("x");
 {
 $a=non_zero_random(-9,9,1);
 $b=non_zero_random(-9,9,1);


### PR DESCRIPTION
By removing the variable "x" from the context an error message is shown
to the student in case "x" is contained in the answer string (for
instance if he writes "x" instead of "t").