### PR TITLE
Remove the snippet that seeds RNG based on studentLogin

### DIFF
--- a/Contrib/UBC/STAT/STAT443/443HM1/stat443_hw01_01.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM1/stat443_hw01_01.pg
@@ -21,14 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-## warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-#warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-#warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 #warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM1/stat443_hw01_02.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM1/stat443_hw01_02.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric"); 
-#warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-#warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 #warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM1/stat443_hw01_03.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM1/stat443_hw01_03.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM2/stat443_hw02_01.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM2/stat443_hw02_01.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM2/stat443_hw02_02.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM2/stat443_hw02_02.pg
@@ -23,15 +23,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-
-
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_start();

--- a/Contrib/UBC/STAT/STAT443/443HM2/stat443_hw02_03.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM2/stat443_hw02_03.pg
@@ -23,13 +23,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM3/stat443_hw03_01.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM3/stat443_hw03_01.pg
@@ -21,14 +21,8 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
-# warn("seed: " . $seed);
+$seed = random(1, 1000, 1);
+#warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");
 ## do not need to download data
@@ -65,7 +59,7 @@ Provide the following, each to three decimal places.
 $BR
 $BR
 $BBOLD Part (a)  $EBOLD
-\( E(X(t) Z(t − 1))\)
+\( E(X(t) Z(t - 1))\)
 \{ans_rule(7)\}
 $BR
 $BR

--- a/Contrib/UBC/STAT/STAT443/443HM3/stat443_hw03_02.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM3/stat443_hw03_02.pg
@@ -23,17 +23,8 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
-# warn("seed: " . $seed);
-
-rserve_eval("set.seed($seed)");
-## do not need to download data
+$seed = random(1, 1000, 1);
+#warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");
 ## do not need to download data

--- a/Contrib/UBC/STAT/STAT443/443HM3/stat443_hw03_03.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM3/stat443_hw03_03.pg
@@ -23,18 +23,8 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-
-
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
-# warn("seed: " . $seed);
-
-rserve_start();
+$seed = random(1, 1000, 1);
+#warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");
 ## do not need to download data

--- a/Contrib/UBC/STAT/STAT443/443HM4/stat443_hw04_01.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM4/stat443_hw04_01.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM4/stat443_hw04_02.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM4/stat443_hw04_02.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM5/stat443_hw05_01.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM5/stat443_hw05_01.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM5/stat443_hw05_02.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM5/stat443_hw05_02.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM5/stat443_hw05_03.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM5/stat443_hw05_03.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM6/stat443_hw06_01.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM6/stat443_hw06_01.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM6/stat443_hw06_02.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM6/stat443_hw06_02.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/443HM6/stat443_hw06_03.pg
+++ b/Contrib/UBC/STAT/STAT443/443HM6/stat443_hw06_03.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443/Final_Practice/stat443_01.pg
+++ b/Contrib/UBC/STAT/STAT443/Final_Practice/stat443_01.pg
@@ -26,13 +26,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 $q1mc = new_multiple_choice();

--- a/Contrib/UBC/STAT/STAT443_subscripts/Final_Practice/stat443_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/Final_Practice/stat443_01.pg
@@ -26,13 +26,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 $q1mc = new_multiple_choice();

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW01/stat443_hw01_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW01/stat443_hw01_01.pg
@@ -21,14 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-## warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-#warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-#warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 #warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW01/stat443_hw01_02.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW01/stat443_hw01_02.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric"); 
-#warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-#warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 #warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW01/stat443_hw01_03.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW01/stat443_hw01_03.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW02/stat443_hw02_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW02/stat443_hw02_01.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW02/stat443_hw02_02.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW02/stat443_hw02_02.pg
@@ -25,18 +25,8 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-
-
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
-
-rserve_start();
 
 rserve_eval("set.seed($seed)");
 ## do not need to download data

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW02/stat443_hw02_03.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW02/stat443_hw02_03.pg
@@ -25,13 +25,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW03/stat443_hw03_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW03/stat443_hw03_01.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW03/stat443_hw03_02.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW03/stat443_hw03_02.pg
@@ -24,17 +24,8 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
-
-rserve_eval("set.seed($seed)");
-## do not need to download data
 
 rserve_eval("set.seed($seed)");
 ## do not need to download data

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW03/stat443_hw03_03.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW03/stat443_hw03_03.pg
@@ -23,18 +23,8 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-
-
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
-
-rserve_start();
 
 rserve_eval("set.seed($seed)");
 ## do not need to download data

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW04/stat443_hw04_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW04/stat443_hw04_01.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW04/stat443_hw04_02.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW04/stat443_hw04_02.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW05/stat443_hw05_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW05/stat443_hw05_01.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW05/stat443_hw05_02.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW05/stat443_hw05_02.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW05/stat443_hw05_03.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW05/stat443_hw05_03.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW06/stat443_hw06_01.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW06/stat443_hw06_01.pg
@@ -22,13 +22,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW06/stat443_hw06_02.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW06/stat443_hw06_02.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");

--- a/Contrib/UBC/STAT/STAT443_subscripts/HW06/stat443_hw06_03.pg
+++ b/Contrib/UBC/STAT/STAT443_subscripts/HW06/stat443_hw06_03.pg
@@ -21,13 +21,7 @@ loadMacros(
 ## Setup: this is where we use Perl and PG objects (Required)
 
 Context("Numeric");
-# warn("Student name: $studentName, login: $studentLogin, id: $studentID");
-my $hash = crypt($studentLogin, 'a1');
-# warn("crypt: $hash");
-@nums = (0..9,'a'..'z','A'..'Z');
-my %nums = map { $nums[$_] => $_ } 0..$#nums;
-my $seed = 0;
-$seed = $seed * 62 + $nums{$_} foreach split(//, substr($hash, -5, 5));
+$seed = random(1, 1000, 1);
 # warn("seed: " . $seed);
 
 rserve_eval("set.seed($seed)");


### PR DESCRIPTION
The seeding was based on studentLogin. If a specific seed is causing problem, the instructor will not be able make changes easily without affecting all other students.