### PR TITLE
Add possibility of ratio in problem description.

### DIFF
--- a/OpenProblemLibrary/UVA-Stat/setStat212-Homework01/stat212-HW01-13.pg
+++ b/OpenProblemLibrary/UVA-Stat/setStat212-Homework01/stat212-HW01-13.pg
@@ -69,7 +69,7 @@ $ma ->choose(4);
 BEGIN_TEXT
 $PAR
 
-Determine whether the following possible responses should be classified as interval, nominal or ordinal data.
+Determine whether the following possible responses should be classified as ratio, interval, nominal or ordinal data.
 $BR
 
 \{ $ma-> print_q \}


### PR DESCRIPTION
In this problem, "ratio" is one of the four possible responses, but only the
other three are mentioned in the description.  This was confusing at least
one of my students.