### PR TITLE
replace threejs(.....) call with new syntax   

### DIFF
--- a/OpenProblemLibrary/MC/Sage/LinearAlg/Axb_span.pg
+++ b/OpenProblemLibrary/MC/Sage/LinearAlg/Axb_span.pg
@@ -86,6 +86,40 @@ Context()->normalStrings;
 ## single cell server code
 ##
 
+###########################################################
+##
+## PRESERVING INTERACT STATE:
+## this section preserves previous the state of the browser as long as the state
+## can be determined from the previous answer. Basically the method uses the saved
+##  answer to reset the state of the interact.
+
+$answer_value = ${$inputs_ref}{sageAnswer};
+
+#The answer is of the form  (3,5), giving the two coefficients.
+
+# One way to extract the answer is like so:
+# $answer_value =~ m/~~(([^,]*), ([^)]*)~~)/;
+# $X1=1; $X2=1;  #initialize
+# $X1=$1 if ($1);
+# $X2=$2 if ($2);
+
+# This way looks better
+$anstuple = Compute($answer_value);
+$X1=$anstuple->extract(1);
+$X2=$anstuple->extract(2);
+
+# debugging code 
+# TEXT($answer_value, "list version", $anstuple);
+# TEXT("previous old answers", "|${$inputs_ref}{previous_sageAnswer};|", $PAR);
+# TEXT("old answers", "|$answer_value|", $PAR );
+# TEXT(" |X1=$X1, X2=$X2  |");
+
+# Use $X1 and $X2 to initialize sage code
+
+
+## end PRESERVING INTERACT STATE
+##
+###########################################################
 
 $SageCode = <<SAGE_CODE;
 
@@ -97,8 +131,11 @@ At =A.transpose()
 
 var('A1')
 #  Finding when a vector b is in the span of other vectors in 2-space
+
+# NOTICE the initialization using $X1 and $X2 in the slider
+
 ~~@interact
-def _(x1=slider(-3,3,1/20,1), x2=slider(-3,3,1/20,1),zoomin=checkbox(default=false,label='Zoom In')): 
+def _(x1=slider(-3,3,1/20,$X1), x2=slider(-3,3,1/20,$X2),zoomin=checkbox(default=false,label='Zoom In')): 
 
     (b1,b2,a11,a12,a21,a22) = ($b1,$b2,$a11,$a12,$a21,$a22)   # Convert WeBWorK variables to normal Sage variables
     

--- a/OpenProblemLibrary/MC/Sage/LinearAlg/Axb_span3d.pg
+++ b/OpenProblemLibrary/MC/Sage/LinearAlg/Axb_span3d.pg
@@ -90,6 +90,34 @@ Context()->normalStrings;
 ## single cell server code
 ##
 
+###########################################################
+##
+## PRESERVING INTERACT STATE:
+## this section preserves previous the state of the browser as long as the state
+## can be determined from the previous answer. Basically the method uses the saved
+##  answer to reset the state of the interact.
+
+$answer_value = ${$inputs_ref}{sageAnswer};
+
+#The answer is of the form  (3,5,7), giving the two coefficients.
+
+# This way looks better
+$anstuple = Compute($answer_value);
+$X1=$anstuple->extract(1);
+$X2=$anstuple->extract(2);
+$X3=$anstuple->extract(3);
+
+# debugging code 
+# TEXT($answer_value, "list version", $anstuple);
+# TEXT("previous old answers", "|${$inputs_ref}{previous_sageAnswer};|", $PAR);
+# TEXT("old answers", "|$answer_value|", $PAR );
+# TEXT(" |X1=$X1, X2=$X2, X3=$X2  |");
+
+# Use $X1, $X2 and $X3 to initialize sage code
+
+
+## end PRESERVING INTERACT STATE
+##
 $SageCode = <<SAGE_CODE;
 
 b = matrix([[$b1],[$b2],[$b3]])
@@ -101,7 +129,7 @@ At =A.transpose()     # so that we can easily slice the matrix by rows instead o
 
 #  Finding when a vector b is in the span of other vectors in 2-space
 ~~@interact
-def _(x1=slider(-2,2,1/5,1), x2=slider(-2,2,1/5,1), x3=slider(-2,2,1/5,1)): 
+def _(x1=slider(-2,2,1/5,$X1), x2=slider(-2,2,1/5,$X2), x3=slider(-2,2,1/5,$X3)): 
     
     G = line3d([(0,0,0),x1*At[0]],arrow_head=True,rbgcolor=(1,0,0))
     G += line3d([x1*At[0],x1*At[0]+x2*At[1]],arrow_head=True)

--- a/OpenProblemLibrary/MC/Sage/LinearAlg/LinearTransformations.pg
+++ b/OpenProblemLibrary/MC/Sage/LinearAlg/LinearTransformations.pg
@@ -124,6 +124,29 @@ END_TEXT
 ## single cell server code
 ##
 
+###########################################################
+##
+## PRESERVING INTERACT STATE:
+## this section preserves previous the state of the browser as long as the state
+## can be determined from the previous answer. Basically the method uses the saved
+##  answer to reset the state of the interact.
+
+$answer_value = ${$inputs_ref}{sageAnswer};
+
+#The answer is of the form  (3,5), giving the two coefficients.
+
+# The answer is the product of the individual transformations matrices
+# and from that one cannot recover the state of this interact.
+# One would have to rewrite the way the information is recorded
+# in the sageAnswer blank so that the state could be recovered.
+# Won't do that now. 
+
+## end PRESERVING INTERACT STATE
+##
+###########################################################
+
+
+
 
 $SageCode = <<SAGE_CODE;
 

--- a/OpenProblemLibrary/MC/Sage/MultiCal/average_value.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/average_value.pg
@@ -52,6 +52,22 @@ $height = ((4/3)*((3*$r1 - 19)*$r2 - 16)/$r2 + (1/3)*((3*$r1 - 19)*$r2 -
 $volume = $height *($x1-$x0)*($y1-$y0);
 
 $showHint = 3;
+###########################################################
+##
+## PRESERVING INTERACT STATE:
+## this section preserves previous the state of the browser as long as the state
+## can be determined from the previous answer. Basically the method uses the saved
+##  answer to reset the state of the interact.
+
+$answer_value = ${$inputs_ref}{sageAnswer};
+
+## As written this interact is not recording it's state and there is no sageAnswer
+## The interact is just used as a visual aid 
+## for the student.  
+
+## end PRESERVING INTERACT STATE
+##
+###########################################################
 
 $SageCode = <<SAGE_CODE;
 
@@ -69,7 +85,7 @@ zmax = $r1
 f(x,y) = $funct
 
 ~~@interact(layout=dict(bottom=[["z0"],["nojavagraph"]]))
-def _(z0 = slider(1,zmax,label='\(f(x_0,y_0)\)')):
+def _(z0 = slider(1,zmax,label='\(f(x_0,y_0)\)'),):
 
     integ = integrate(integrate(f,y,ymin,ymax),x,xmin,xmax).n()
     box_vol =(xmax-xmin)*(ymax-ymin)*z0    

--- a/OpenProblemLibrary/MC/Sage/MultiCal/average_value.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/average_value.pg
@@ -83,7 +83,7 @@ def _(z0 = slider(1,zmax,label='\(f(x_0,y_0)\)')):
     G += plot3d(z0, (x, xmin, xmax), (y,ymin,ymax),color='green',opacity=0.9)
     G += cube(color=['green', 'green', 'green'],aspect_ratio=[1,1,1], center=(xmid/xdiff, ymid/ydiff,1/2) ,opacity=0.3).scale([xdiff,ydiff,z0])
             
-    threejs(G, figsize=(4,6))
+    G.show(viewer='threejs', figsize=(4,6))
 
 SAGE_CODE
 

--- a/OpenProblemLibrary/MC/Sage/MultiCal/contour2d.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/contour2d.pg
@@ -50,6 +50,23 @@ $showHint = 1;
 
 ####################################################
 
+###########################################################
+##
+## PRESERVING INTERACT STATE:
+## this section preserves previous the state of the browser as long as the state
+## can be determined from the previous answer. Basically the method uses the saved
+##  answer to reset the state of the interact.
+
+$answer_value = ${$inputs_ref}{sageAnswer};
+
+## As written this interact is not recording its state and there is no sageAnswer
+## The interact is just used as a visual aid 
+## for the student.  
+
+## end PRESERVING INTERACT STATE
+##
+###########################################################
+
 $SageCode = <<SAGE_CODE;
 
 var('x,y,z')

--- a/OpenProblemLibrary/MC/Sage/MultiCal/directional_derivative.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/directional_derivative.pg
@@ -114,7 +114,7 @@ def myfun(x0 = input_box(0,width=5,label='\( x_0 \)'), y0=input_box(0,width=5,la
     picture2d += arrow(location.list(),(location+dff).list(),rgbcolor=gradient_color,width=line_thickness)
     show(picture2d, aspect_ratio=1)
     if show_surface:
-        threejs(picture3d,aspect=[1,1,1],axes=True)
+    	picture3d.show(viewer='threejs',aspect=[1,1,1],axes=True)
 
     record_answer(angle)
 

--- a/OpenProblemLibrary/MC/Sage/MultiCal/extrema.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/extrema.pg
@@ -94,7 +94,22 @@ $ECENTER
 EOT
 
 Context()->texStrings;
+###########################################################
+##
+## PRESERVING INTERACT STATE:
+## this section preserves previous the state of the browser as long as the state
+## can be determined from the previous answer. Basically the method uses the saved
+##  answer to reset the state of the interact.
 
+$answer_value = ${$inputs_ref}{sageAnswer};
+
+## As written this interact is not recording its state and there is no sageAnswer
+## The interact is just used as a visual aid 
+## for the student.  
+
+## end PRESERVING INTERACT STATE
+##
+###########################################################
 
 $SageCode = <<SAGE_CODE;
 

--- a/OpenProblemLibrary/MC/Sage/MultiCal/limit2d_no_formula.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/limit2d_no_formula.pg
@@ -160,9 +160,9 @@ def _(num=selector(["f1","f2","f3","f4","f5","f6"],label='\( f  =  \)'),
         pretty_print(html('\n<center><font color="red">\(\lim_{(x,?)\\rightarrow(x_0,y_0)} f(x,y) =%s\)</font>'%str(limit_x)+'  and <font color="red">\(\lim_{(?,y)\\rightarrow(x_0,y_0)} f(x,y) =%s\)</font></center>'%str(limit_y)))
         
     if in_3d:
-        threejs(G,stereo="redcyan",viewer=view_method)
+        G.show(viewer='threejs',stereo="redcyan",viewer=view_method)
     else:
-        threejs(G)
+        G.show(viewer='threejs')
 
 SAGE_CODE
 

--- a/OpenProblemLibrary/MC/Sage/MultiCal/volume.pg
+++ b/OpenProblemLibrary/MC/Sage/MultiCal/volume.pg
@@ -188,7 +188,7 @@ def _(
                 length = end - start
                 p += line([[0]*i+[start-0.08*length]+[0]*(2-i), [0]*i+[end+0.08*length]+[0]*(2-i)], thickness=3, color="brown")
                 p += text3d(v, [0]*i+[end+0.1*length]+[0]*(2-i))        
-        threejs(p, frame=False, aspect_ratio=1 )
+        p.show(viewer='threejs', frame=False, aspect_ratio=1 )
     except ValueError:
         pretty_print(html(r"""<span style="color:red">Cannot draw the plot, is the integral valid?..</span>"""))
 


### PR DESCRIPTION
graphic_object.show(view……er="threejs", ..... )

If you view any of these files
Sage/MultiCal/average_value.pg:    threejs(G, figsize=(4,6))
Sage/MultiCal/directional_derivative.pg:        threejs(picture3d,aspect=[1,1,1],axes=True)
Sage/MultiCal/limit2d_no_formula.pg:        threejs(G,stereo="redcyan",viewer=view_method)
Sage/MultiCal/limit2d_no_formula.pg:        threejs(G)
Sage/MultiCal/volume.pg:        threejs(p, frame=False, aspect_ratio=1 )

you will get an error. 

This PR changes the threejs call to its new format.

This corresponds to bug report 4132
