### PR TITLE
Adding 187 Mathematics of Computer Graphics problems

### DIFF
--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedPolynomials.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedPolynomials.pg
@@ -1,0 +1,82 @@
+## DESCRIPTION
+## Initial and final position and velocity of a vector-valued function of polynomials
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('1')
+## KEYWORDS('vector-valued function','function application','derivatives')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$coeff1 = random( 2, 5 );
+$coeff2 = random( 2, 5 );
+$coeff3 = random( 2, 5 );
+$coeff4 = random( 2, 5 );
+$exp1 = random( 2, 4 );
+$exp2 = random( 2, 4 );
+
+$f1 = Formula("$coeff1*t");
+$f2 = Formula("$coeff2*t^$exp1");
+$f3 = Formula("$coeff3*t^$exp2-$coeff4");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Compute the starting and ending positions (at times [`t = 0`] and [`t = 1`], respectively) for the path of motion described by the following vector-valued function.
+
+Function: [`\vec f(t)=\left([$f1],[$f2],[$f3]\right)`]
+
+Starting point: ([________]{0},[________]{0},[________]{-$coeff4})
+
+Ending point: ([________]{$coeff1},[________]{$coeff2},[________]{$coeff3-$coeff4})
+
+Now compute the derivative of that same vector-valued function.
+
+Answer: [`\langle`][________]{$f1->D('t')},[________]{$f2->D('t')},[________]{$f3->D('t')}[`\rangle`]
+
+Now compute the starting and ending velocities for that same vector-valued function.
+
+Starting velocity: [`\langle`][________]{$f1->D('t')->eval(t=>0)},[________]{$f2->D('t')->eval(t=>0)},[________]{$f3->D('t')->eval(t=>0)}[`\rangle`]
+
+Ending velocity: [`\langle`][________]{$f1->D('t')->eval(t=>1)},[________]{$f2->D('t')->eval(t=>1)},[________]{$f3->D('t')->eval(t=>1)}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec f(0)=\left(
+[$coeff1](0),
+[$coeff2](0)^[$exp1],
+[$coeff3](0)^[$exp2]-[$coeff4]
+\right) = (0,0,[$coeff4*-1])`]
+
+[`\vec f(1)=\left(
+[$coeff1](1),
+[$coeff2](1)^[$exp1],
+[$coeff3](1)^[$exp2]-[$coeff4]
+\right)=([$coeff1],[$coeff2],[$coeff3-$coeff4])`]
+
+[`\vec f'(t)=\frac{d}{dt}\left([$f1],[$f2],[$f3]\right)
+=\left\langle [$f1->D('t')],[$f2->D('t')],[$f3->D('t')] \right\rangle`]
+
+[`\vec f'(0)=\left\langle [$f1->D('t')->eval(t=>0)],[$f2->D('t')->eval(t=>0)],[$f3->D('t')->eval(t=>0)] \right\rangle`]
+
+[`\vec f'(1)=\left\langle [$f1->D('t')->eval(t=>1)],[$f2->D('t')->eval(t=>1)],[$f3->D('t')->eval(t=>1)] \right\rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedPolynomialsAndLogs.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedPolynomialsAndLogs.pg
@@ -1,0 +1,85 @@
+## DESCRIPTION
+## Initial and final position and velocity of a vector-valued function of polynomials and logs
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('1')
+## KEYWORDS('vector-valued function','function application','derivatives')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$coeff1 = random( 2, 5 );
+$coeff2 = random( 2, 5 );
+$coeff3 = random( 2, 5 );
+$coeff4 = random( 2, 5 );
+$exp1 = random( 2, 4 );
+$exp2 = random( 2, 4 );
+
+$f1 = Formula("1-$coeff1*t");
+$f2 = Formula("1-$coeff2*t^$exp1");
+$f3 = Formula("ln($coeff3*t^$exp2+$coeff4)");
+
+$ans1 = ln($coeff4);
+$ans2 = ln($coeff3+$coeff4);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Compute the starting and ending positions (at times [`t = 0`] and [`t = 1`], respectively) for the path of motion described by the following vector-valued function.
+
+Function: [`\vec g(t)=\left([$f1],[$f2],[$f3]\right)`]
+
+Starting point: ([________]{1},[________]{1},[________]{ln($coeff4)})
+
+Ending point: ([________]{1-$coeff1},[________]{1-$coeff2},[________]{ln($coeff3+$coeff4)})
+
+Now compute the derivative of that same vector-valued function.
+
+Answer: [`\langle`][________]{$f1->D('t')},[________]{$f2->D('t')},[________]{$f3->D('t')}[`\rangle`]
+
+Now compute the starting and ending velocities for that same vector-valued function.
+
+Starting velocity: [`\langle`][________]{$f1->D('t')->eval(t=>0)},[________]{$f2->D('t')->eval(t=>0)},[________]{$f3->D('t')->eval(t=>0)}[`\rangle`]
+
+Ending velocity: [`\langle`][________]{$f1->D('t')->eval(t=>1)},[________]{$f2->D('t')->eval(t=>1)},[________]{$f3->D('t')->eval(t=>1)}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec g(0)=\left(
+1-[$coeff1](0),
+1-[$coeff2](0)^[$exp1],
+\ln([$coeff3](0)^[$exp2]+[$coeff4])
+\right) = (1,1,[$ans1])`]
+
+[`\vec g(1)=\left(
+1-[$coeff1](1),
+1-[$coeff2](1)^[$exp1],
+\ln([$coeff3](1)^[$exp2]+[$coeff4])
+\right)=([$coeff1*-1+1],[$coeff2*-1+1],[$ans2])`]
+
+[`\vec g'(t)=\frac{d}{dt}\left([$f1],[$f2],[$f3]\right)
+=\left\langle [$f1->D('t')],[$f2->D('t')],[$f3->D('t')] \right\rangle`]
+
+[`\vec g'(0)=\left\langle [$f1->D('t')->eval(t=>0)],[$f2->D('t')->eval(t=>0)],[$f3->D('t')->eval(t=>0)] \right\rangle`]
+
+[`\vec g'(1)=\left\langle [$f1->D('t')->eval(t=>1)],[$f2->D('t')->eval(t=>1)],[$f3->D('t')->eval(t=>1)] \right\rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedTrigFunctions.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-1-to-3-VectorValuedTrigFunctions.pg
@@ -1,0 +1,75 @@
+## DESCRIPTION
+## Initial and final position and velocity of a vector-valued function of trig functions
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('1')
+## KEYWORDS('vector-valued function','function application','derivatives')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$coeff1 = random( 2, 5 );
+$coeff2 = random( 2, 5 );
+$coeff3 = random( 2, 5 );
+$coeff4 = random( 2, 5 );
+$index1 = random( 0, 2 );
+$fname1 = list_random( 'sin', 'cos', 'tan' );
+$fname2 = list_random( 'sin', 'cos', 'tan' );
+
+$f1 = Formula("$fname1(t)");
+$f2 = Formula("($coeff1*t-$coeff2)/($coeff3*t+$coeff4)");
+$f3 = Formula("$fname2(t)");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Compute the starting and ending positions (at times [`t = 0`] and [`t = 1`], respectively) for the path of motion described by the following vector-valued function.
+
+Function: [`\vec h(t)=\left([$f1],[$f2],[$f3]\right)`]
+
+Starting point: ([________]{$f1->eval(t=>0)},[________]{$f2->eval(t=>0)},[________]{$f3->eval(t=>0)})
+
+Ending point: ([________]{$f1->eval(t=>1)},[________]{$f2->eval(t=>1)},[________]{$f3->eval(t=>1)})
+
+Now compute the derivative of that same vector-valued function.
+
+Answer: [`\langle`][________]{$f1->D('t')},[________]{$f2->D('t')},[________]{$f3->D('t')}[`\rangle`]
+
+Now compute the starting and ending velocities for that same vector-valued function.
+
+Starting velocity: [`\langle`][________]{$f1->D('t')->eval(t=>0)},[________]{$f2->D('t')->eval(t=>0)},[________]{$f3->D('t')->eval(t=>0)}[`\rangle`]
+
+Ending velocity: [`\langle`][________]{$f1->D('t')->eval(t=>1)},[________]{$f2->D('t')->eval(t=>1)},[________]{$f3->D('t')->eval(t=>1)}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec h(0)=\left([$f1->eval(t=>0)],[$f2->eval(t=>0)],[$f3->eval(t=>0)]\right)`]
+
+[`\vec h(0)=\left([$f1->eval(t=>1)],[$f2->eval(t=>1)],[$f3->eval(t=>1)]\right)`]
+
+[`\vec h'(t)=\frac{d}{dt}\left([$f1],[$f2],[$f3]\right)
+=\left\langle [$f1->D('t')],[$f2->D('t')],[$f3->D('t')] \right\rangle`]
+
+[`\vec h'(0)=\left\langle [$f1->D('t')->eval(t=>0)],[$f2->D('t')->eval(t=>0)],[$f3->D('t')->eval(t=>0)] \right\rangle`]
+
+[`\vec h'(1)=\left\langle [$f1->D('t')->eval(t=>1)],[$f2->D('t')->eval(t=>1)],[$f3->D('t')->eval(t=>1)] \right\rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-10-BallisticsProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-10-BallisticsProblem.pg
@@ -1,0 +1,86 @@
+## DESCRIPTION
+## A cannonball follows a vector-valued function's path; answer some questions
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('10')
+## KEYWORDS('vector-valued function','ballistics','gravity','derivative')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$coeff1 = random( 100, 900, 100 );
+$coeff2 = random( 10, 90, 10 );
+$coeff3 = random( 100, 900, 100 );
+$coeff4 = random( -500, -50, 50 );
+$coeff5 = random( 35, 45 );
+$coeff6 = -16;
+$mass = random( 15, 50, 5 );
+
+$f1 = Formula("$coeff1*t+$coeff2");
+$f2 = Formula("$coeff3*t+$coeff4");
+$f3 = Formula("$coeff5*t+$coeff6*t^2");
+
+$ans1 = -$coeff5/$coeff6;
+
+$v1 = $f1->D('t')->eval(t=>$ans1);
+$v2 = $f2->D('t')->eval(t=>$ans1);
+$v3 = $f3->D('t')->eval(t=>$ans1);
+
+$speed = sqrt( $v1**2 + $v2**2 + $v3**2 );
+$momentum = $speed * $mass;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a cannonball launched along the path
+
+>> [`\vec p(t)=([$f1],[$f2],[$f3]),`] <<
+
+with length units in feet and time units in seconds.
+
+When does it return to the height from which it was launched?  (The coordinate system is right-handed, with [`z`] the vertical axis.)
+
+Answer: [`t=`][__________]{$ans1}
+
+What is its velocity then?
+
+Answer: [`\langle`][________]{$v1},[________]{$v2},[________]{$v3}[`\rangle`]
+
+Momentum is mass times speed, usually measured in [`\frac{\text{kg m}}{\text{s}}`], but here we can measure it in [`\frac{\text{kg ft}}{\text{s}}`].  If the cannonball has mass [$mass] kg, what is its momentum upon impact with the ground?
+
+Answer: [________]{$momentum} [`\frac{\text{kg ft}}{\text{s}}`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+It was launched at time [`t=0`], and [`\vec p(0)`] has a [`z`] coordinate of 0.  So the height at which it was launched was [`z=0`].  We ask when it returns to that height by setting the [`z`] component of [`\vec p(t)`] equal to zero, as in [`[$f3]=0`].  This factors as [`t([$coeff5]+[$coeff6]t)=0`], with solutions [`t=0`] and [`t=[$ans1]`].
+
+To find the velocity when [`t=[$ans1]`], we must find the velocity function, [`\vec p'(t)`].  So we differentiate:
+
+[`\vec p'(t)=\frac{d}{dt}\left([$f1],[$f2],[$f3]\right)
+=\left\langle [$f1->D('t')],[$f2->D('t')],[$f3->D('t')] \right\rangle`]
+
+We then plug in [`t=[$ans1]`]:  [`\vec p'([$ans1])=\left\langle [$v1],[$v2],[$v3] \right\rangle`].
+
+Finding momentum requires first finding speed, which is the magnitude of velocity.  So we can take the previous answer and apply the formula for magnitude: [`\sqrt{([$v1])^2+([$v2])^2+([$v3])^2}\approx [$speed]`].
+
+Momentum is mass times speed, so the answer for momentum is [`[$mass]\cdot[$speed]`], or [$momentum]  [`\frac{\text{kg ft}}{\text{s}}`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-11-BaseballProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-11-BaseballProblem.pg
@@ -1,0 +1,87 @@
+## DESCRIPTION
+## A baseball follows a vector-valued function's path; answer some questions
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('11')
+## KEYWORDS('vector-valued function','baseball','gravity','derivative')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$coeff1 = random( 250, 300 );
+$coeff2 = random( -70, -50 );
+$coeff3 = random( 80, 100 );
+$coeff4 = random( -30, -20 );
+$coeff5 = random( 60, 65 );
+$coeff6 = -16;
+$mass = random( 15, 50, 5 );
+
+$f1 = Formula("$coeff1*t+$coeff2");
+$f2 = Formula("$coeff3*t+$coeff4");
+$f3 = Formula("$coeff5*t+$coeff6*t^2");
+
+$v1 = $f1->D('t')->eval(t=>0);
+$v2 = $f2->D('t')->eval(t=>0);
+$v3 = $f3->D('t')->eval(t=>0);
+
+$ans1 = sqrt( $v1**2 + $v2**2 + $v3**2 );
+
+$ans1mph = $ans1 * 3600 / 5280;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a baseball game in which an outfielder picks up a ball from the ground and throws it toward home plate, along the path
+
+>> [`\vec p(t)=([$f1],[$f2],[$f3]),`] <<
+
+with distance measured in feet and time in seconds. This vector-valued function is mostly realistic, except that for simplicity it ignores air resistance.
+
+What is the ball's speed, in feet per second, at the beginning of its arc?
+
+Answer: [__________]{$ans1} feet/second
+
+What is that value in miles per hour?
+
+Answer: [__________]{$ans1mph} miles/hour
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Speed is the magnitude of velocity, so we must first begin by computing the velocity function.
+
+[`\vec p'(t)=\left\langle [$f1->D('t')],[$f2->D('t')],[$f3->D('t')] \right\rangle`]
+
+Then we find the velocity at the beginning of the throw ([`t=0`]).
+
+[`\vec p'(0)=\left\langle [$v1],[$v2],[$v3] \right\rangle`]
+
+The magnitude of that is speed, in feet per second.
+
+[`\sqrt{([$v1])^2+([$v2])^2+([$v3])^2}\approx[$ans1]`]
+
+To convert to miles per hour, we multiply rates as shown below.
+
+[`[$ans1]\frac{\text{feet}}{\text{second}}
+\cdot\frac{1\text{ mile}}{5280\text{ feet}}
+\cdot\frac{3600\text{ seconds}}{1\text{ hour}}
+=[$ans1mph]\frac{\text{miles}}{\text{hour}}`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-12-WhereIsAnObjectAtRest.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-12-WhereIsAnObjectAtRest.pg
@@ -1,0 +1,73 @@
+## DESCRIPTION
+## Where is an object defined by a 2D parametric curve at rest?
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/20/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('12')
+## KEYWORDS('vector-valued function','derivative','velocity','rest')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$index1 = random( 0, 1 );
+$funcname = ( 'sin', 'cos' )[$index1];
+$texname = ( '\sin', '\cos' )[$index1];
+$C1 = non_zero_random( -20, 20 );
+$f1fla = ( Formula( "$C1-cos(t)" ), Formula( "sin(t)+$C1" ) )[$index1];
+$index2 = random( 0, 2 );
+$x1 = ( '0', 'pi/2', 'pi' )[$index2];
+$texx1 = ( '0', '\frac{\pi}{2}', '\pi' )[$index2];
+if ( $index == 0 ) {
+    $y1 = sin( (0,pi/2,pi)[$index2] );
+} else {
+    $y1 = cos( (0,pi/2,pi)[$index2] );
+}
+$m = random( 3, 5 ) * random( -1, 1, 2 );
+$C2 = non_zero_random( -20, 20 );
+$f2fla = Formula( "($m)/2*t^2 + ($y1-$m*$x1)*t + $C2" )->reduce();
+$gr = init_graph(-1,-2,2*pi+1,2,axes=>[0,0],grid=>[10,10],size=>[400,400]);
+$tograph1 = $f1fla->D('t')->substitute(t=>'x');
+$tograph2 = $f2fla->D('t')->substitute(t=>'x');
+add_functions($gr, "$tograph1 for x in <0,6.28> using color:blue and weight:2");
+add_functions($gr, "$tograph2 for x in <0,6.28> using color:red and weight:2");
+#add_functions($gr, "x^2/4 for x in <-1,4> using color:blue and weight:2");
+
+TEXT(beginproblem());
+BEGIN_PGML
+If an object follows the path of the two-dimensional vector-valued function
+[`\vec p(t)=\left( [$f1fla], [$f2fla] \right)`] from [`t = 0`] to [`t = 2\pi`], when is it at rest (zero velocity)?
+
+Answer: [`t=`][__________]{$x1}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The velocity function is [`\vec p'(t)=\left\langle [$f1fla->D('t')],[$f2fla->D('t')] \right\rangle`].  If we set this equal to zero, that means setting it equal to [`\langle 0,0 \rangle`], and so we have two equations.
+
+>> [`[$f1fla->D('t')]=0`] <<
+
+>> [`[$f2fla->D('t')]=0`] <<
+
+These are difficult to solve together, but if we graph them, we find that it is quite obvious that the only point at which they intersect is at the point [`\left([$texx1],[$y1]\right)`], which is when [`t=[$texx1]`].
+
+[@ image(insertGraph($gr), width=>400, height=>400) @]*
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-13-DoesAPathPassThroughPoints.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-13-DoesAPathPassThroughPoints.pg
@@ -1,0 +1,128 @@
+## DESCRIPTION
+## Does a given parametric curve pass through certain points?
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Parameterized curves)
+## Date(03/20/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('13')
+## KEYWORDS('vector-valued function','points','intersection')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$a1 = random( 2, 4 ) * random( -1, 1, 2 );
+$b1 = random( 2, 4 ) * random( -1, 1, 2 );
+$c1 = random( 2, 4 ) * random( -1, 1, 2 );
+$f1 = Formula( "$a1*t^2+$b1*t+$c1" )->reduce();
+$a2 = random( 2, 4 ) * random( -1, 1, 2 );
+$b2 = random( 2, 4 ) * random( -1, 1, 2 );
+$c2 = random( 2, 4 ) * random( -1, 1, 2 );
+$f2 = Formula( "$a2*t^2+$b2*t+$c2" )->reduce();
+$t1 = random( -3, 0 );
+$t2 = random( 1, 4 );
+$t3 = random( 5, 8 );
+$whichOneIsNone = random( 0, 2 );
+$p1x = $f1->eval(t=>$t1);
+$p1y = $f2->eval(t=>$t1);
+$ans1 = $t1;
+$explain1 = "In this case, $t1 also satisfies the second equation.";
+if ( $whichOneIsNone == 0 ) {
+    $p1y += non_zero_random( -3, 3 );
+    $ans1 = 'NONE';
+    $explain1 = "In this case, neither value satisfies the second equation.";
+}
+$p2x = $f1->eval(t=>$t2);
+$p2y = $f2->eval(t=>$t2);
+$ans2 = $t2;
+$explain2 = "In this case, $t2 also satisfies the second equation.";
+if ( $whichOneIsNone == 1 ) {
+    $p2y += non_zero_random( -3, 3 );
+    $ans2 = 'NONE';
+    $explain2 = "In this case, neither value satisfies the second equation.";
+}
+$p3x = $f1->eval(t=>$t3);
+$p3y = $f2->eval(t=>$t3);
+$ans3 = $t3;
+$explain3 = "In this case, $t3 also satisfies the second equation.";
+if ( $whichOneIsNone == 2 ) {
+    $p3y += non_zero_random( -3, 3 );
+    $ans3 = 'NONE';
+    $explain3 = "In this case, neither value satisfies the second equation.";
+}
+$ans4a = -$b1/(2*$a1);
+$ans4b = -$b2/(2*$a2);
+if ( $ans4a == $ans4b ) { $ans4 = $ans4a; } else { $ans4 = 'NONE'; }
+
+$sol1a = (-$b1-sqrt($b1**2-4*$a1*($c1-$p1x)))/(2*$a1);
+$sol1b = (-$b1+sqrt($b1**2-4*$a1*($c1-$p1x)))/(2*$a1);
+$sol2a = (-$b1-sqrt($b1**2-4*$a1*($c1-$p2x)))/(2*$a1);
+$sol2b = (-$b1+sqrt($b1**2-4*$a1*($c1-$p2x)))/(2*$a1);
+$sol3a = (-$b1-sqrt($b1**2-4*$a1*($c1-$p3x)))/(2*$a1);
+$sol3b = (-$b1+sqrt($b1**2-4*$a1*($c1-$p3x)))/(2*$a1);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider an object following the path of the two-dimensional vector-valued function [`\vec p(t)=\left( [$f1],[$f2] \right)`].
+
+When does it pass through the point [`([$p1x],[$p1y])`]?  If it passes through that point, give the [`t`] value.  If it does not pass through that point, enter NONE as the answer.
+
+Answer: [__________]{$ans1}
+
+When does it pass through the point [`([$p2x],[$p2y])`]?  If it passes through that point, give the [`t`] value.  If it does not pass through that point, enter NONE as the answer.
+
+Answer: [__________]{$ans2}
+
+When does it pass through the point [`([$p3x],[$p3y])`]?  If it passes through that point, give the [`t`] value.  If it does not pass through that point, enter NONE as the answer.
+
+Answer: [__________]{$ans3}
+
+When is it at rest?  If it is at rest at some point, give the [`t`] value.  If it is never at rest, enter NONE as the answer.
+
+Answer: [__________]{$ans4}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To see if [`\left([$f1],[$f2]\right)`] passes through [`([$p1x],[$p1y])`], we must solve the equation [`\left([$f1],[$f2]\right)=([$p1x],[$p1y])`], which is really two equations in one:
+
+>> [`[$f1]=[$p1x]`] <<
+
+>> [`[$f2]=[$p1y]`] <<
+
+The first reduces to the quadratic equation [`[$a1]t^2+[$b1]t+[$c1-$p1x]=0`], which we can solve using the quadratic formula as follows.
+
+>> [`t=\frac{-([$b1])\pm\sqrt{([$b1])^2-4([$a1])([$c1-$p1x])}}{2([$a1])}`] <<
+
+>> [`t=[$sol1a]\text{ and }[$sol1b]`] <<
+
+Does either of those [`t`] values work for the second equation?  We can substitute to find out.  [$explain1]
+
+We can then follow the same procedure with the second question, solving the two equations from [`\left([$f1],[$f2]\right)=([$p2x],[$p2y])`] together.  The first equation gives [`t=[$sol2a]`] and [`[$sol2b]`].  [$explain2]
+
+We can then follow the same procedure with the third question, solving the two equations from [`\left([$f1],[$f2]\right)=([$p3x],[$p3y])`] together.  The first equation gives [`t=[$sol3a]`] and [`[$sol3b]`].  [$explain3]
+
+The final equation asks about being "at rest," which is a question about velocity.  We are therefore asking whether the derivative of [`\left([$f1],[$f2]\right)`] is ever equal to [`\langle 0,0 \rangle`].  We compute the derivative as [`\left\langle [$f1->D('t')->reduce()],[$f2->D('t')->reduce()] \right\rangle`] and set it equal to zero.  This gives two equations.
+
+>> [`[$f1->D('t')->reduce()]=0`] <<
+
+>> [`[$f2->D('t')->reduce()]=0`] <<
+
+The first solves to give us [`t=[$ans4a]`] and the second to give [`t=[$ans4b]`].  Thus the answer to the final question is [$ans4].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-14-CreateLinearEquationForSceneTwo.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-14-CreateLinearEquationForSceneTwo.pg
@@ -1,0 +1,71 @@
+## DESCRIPTION
+## Create a linear path for an object in scene two, given scene one
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Derivatives)
+## Date(03/20/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('14')
+## KEYWORDS('vector-valued function','acceleration','velocity','derivatives')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$a = random(2,10) * random(-1,1,2);
+$b = random(2,10) * random(-1,1,2);
+$c = random(2,10) * random(-1,1,2);
+$d = random(2,10) * random(-1,1,2);
+$e = random(2,10) * random(-1,1,2);
+$f = random(2,10) * random(-1,1,2);
+$g = random(2,10) * random(-1,1,2);
+
+TEXT(beginproblem());
+BEGIN_PGML
+An animation has two scenes, each of them being one second long. In the first scene, an object moves along the path
+
+>> [`\vec p_1(t) = \left( [$a]t^2+[$b]t, [$c]t^2+[$d], [$e]t^2+[$f]t+[$g] \right)`] <<
+
+for [`0 \leq t \leq 1`]. At the end of the scene, the object's acceleration immediately becomes zero, and remains zero throughout the second scene.
+
+The vector-valued function [`\vec p_2(t)`] for the object's path in the second scene also uses [`0 \leq t \leq 1`], so that [`t = 0`] in the second scene is the same moment as [`t = 1`] in the first scene. What is [`\vec p_2(t)`]?
+
+Answer: [`\vec p_2(t)=(`][__________]{"$a+$b+($a*2+$b)*t"},[__________]{"$c+$d+$c*2*t"},[__________]{"$e+$f+$g+($e*2+$f)*t"}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Because there is a constant velocity throughout scene two, we know that its equation will be linear.  Thus we just need its starting point and its velocity, and we can use the standard method to create the equation of a line:
+
+>> [`\vec p_2(t) = (\text{starting point}) + (\text{velocity})t`] <<
+
+The starting point of scene two is the ending point of scene one, so we can just compute [`\vec p_1(1)`] to find that value.
+
+[`\vec p_1(1)=([$a](1)^2+[$b](1),[$c](1)^2+[$d],[$e](1)^2+[$f](1)+[$g])=([$a+$b],[$c+$d],[$e+$f+$g])`]
+
+The starting velocity of scene two (which is the velocity throughout all of scene two) is the ending velocity of scene one, so we can compute [`\vec p'_1(1)`] to find that velocity.
+
+[`\vec p'_1(t)=\left\langle 2([$a])t+[$b],2([$c])t,2([$e])t+[$f] \right\rangle`]
+
+[`\vec p'_1(1)=\left\langle [$a*2+$b],[$c*2],[$e*2+$f] \right\rangle`]
+
+Thus the final answer is as follows.
+
+[`\vec p_2(t)=([$a+$b],[$c+$d],[$e+$f+$g])+\left\langle [$a*2+$b],[$c*2],[$e*2+$f] \right\rangle t
+=([$a+$b]+[$a*2+$b]t,[$c+$d]+[$c*2]t,[$e+$f+$g]+[$e*2+$f]t)`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-21-EasingCurves.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-21-EasingCurves.pg
@@ -1,0 +1,137 @@
+## DESCRIPTION
+## Inspecting and classifying several easing curves
+## ENDDESCRIPTION
+
+## DBsubject(Algebra)
+## DBchapter(Functions)
+## DBsection(Compositions and combinations of functions)
+## Date(03/20/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('21')
+## KEYWORDS('easing curves','function composition','graphs')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGgraphmacros.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$graph = init_graph(-0.5,-0.5,1.5,1.5,axes=>[0,0],grid=>[8,8],size=>[400,400]);
+add_functions($graph, "3*x^2-2*x^3 for x in <0,1> using color:red and weight:2");
+add_functions($graph, "x^3 for x in <0,1> using color:green and weight:2");
+add_functions($graph, "3*x-3*x^2+x^3 for x in <0,1> using color:blue and weight:2");
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is/contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+In Chapters 11 and 12 of the textbook, we will explore easing curves, which can be composed with a vector-valued function to make a new vector-valued function whose animation starts or stops more gently than that of the original. If an easing curve [`e : [0, 1]\to[0, 1]`] is a function of one variable and [`\vec f : \Bbb{R}\to\Bbb{R}^3`] is a vector-valued function, we can create a composite function [`\vec g = \vec f \circ e`], whose formula is [`\vec g(t) = \vec f(e(t))`].
+
+Here I graph for you the following functions on the interval [`[0,1]`]:
+
+- [`e_1(t) = 3t^2-2t^3`] (the red curve)
+- [`e_2(t) = t^3`] (the green curve)
+- [`e_3(t) = 3t-3t^2+t^3`] (the blue curve)
+
+[@ image(insertGraph($graph), width=>400, height=>400) @]*
+
+At what points in the interval [`[0, 1]`] is [`e_1'(t) = 0`]?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'That derivative is never equal to 0 on the interval [0,1].',
+  'At t=0 and nowhere else on the interval [0,1].',
+  'At t=0.5 and nowhere else on the interval [0,1].',
+  'At t=1 and nowhere else on the interval [0,1].',
+  'At t=0 and t=0.5 and nowhere else on the interval [0,1].',
+  'At t=0 and t=1 and nowhere else on the interval [0,1].',
+  'At t=0.5 and t=1 and nowhere else on the interval [0,1].',
+  'At t=0, t=0.5, and t=1 and nowhere else on the interval [0,1].',
+  'It is not possible to determine this from the information in the problem.'
+) ], 'At t=0 and t=1 and nowhere else on the interval [0,1].' )}
+
+At what points in the interval [`[0, 1]`] is [`e_2'(t) = 0`]?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'That derivative is never equal to 0 on the interval [0,1].',
+  'At t=0 and nowhere else on the interval [0,1].',
+  'At t=0.5 and nowhere else on the interval [0,1].',
+  'At t=1 and nowhere else on the interval [0,1].',
+  'At t=0 and t=0.5 and nowhere else on the interval [0,1].',
+  'At t=0 and t=1 and nowhere else on the interval [0,1].',
+  'At t=0.5 and t=1 and nowhere else on the interval [0,1].',
+  'At t=0, t=0.5, and t=1 and nowhere else on the interval [0,1].',
+  'It is not possible to determine this from the information in the problem.'
+) ], 'At t=0 and nowhere else on the interval [0,1].' )}
+
+At what points in the interval [`[0, 1]`] is [`e_3'(t) = 0`]?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'That derivative is never equal to 0 on the interval [0,1].',
+  'At t=0 and nowhere else on the interval [0,1].',
+  'At t=0.5 and nowhere else on the interval [0,1].',
+  'At t=1 and nowhere else on the interval [0,1].',
+  'At t=0 and t=0.5 and nowhere else on the interval [0,1].',
+  'At t=0 and t=1 and nowhere else on the interval [0,1].',
+  'At t=0.5 and t=1 and nowhere else on the interval [0,1].',
+  'At t=0, t=0.5, and t=1 and nowhere else on the interval [0,1].',
+  'It is not possible to determine this from the information in the problem.'
+) ], 'At t=1 and nowhere else on the interval [0,1].' )}
+
+One of the curves [`e_1`], [`e_2`], or [`e_3`] is an ease-in curve, meaning that the motion begins slowly.  Another is an ease-out curve, meaning that the motion ends slowly. Another is an ease-in-out curve, meaning that the motion begins and ends slowly. Which is which?
+
+Pick your answer for [`e_1`] from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'That function is an ease-in curve.',
+  'That function is an ease-out curve.',
+  'That function is an ease-in-out curve.',
+  'It is not possible to determine this from the information in the problem.'
+) ], 'That function is an ease-in-out curve.' )}
+
+Pick your answer for [`e_2`] from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'That function is an ease-in curve.',
+  'That function is an ease-out curve.',
+  'That function is an ease-in-out curve.',
+  'It is not possible to determine this from the information in the problem.'
+) ], 'That function is an ease-in curve.' )}
+
+Pick your answer for [`e_3`] from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'That function is an ease-in curve.',
+  'That function is an ease-out curve.',
+  'That function is an ease-in-out curve.',
+  'It is not possible to determine this from the information in the problem.'
+) ], 'That function is an ease-out curve.' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Because [`e_1(t)=3t^2-2t^3`], we have [`e'_1(t)=6t-6t^2`].  Setting that equal to zero and solving gives [`6t(1-t)=0`], which has only two solutions, 0 and 1.
+
+Because [`e_2(t)=t^3`], we have [`e'_2(t)=3t^2`].  Setting that equal to zero and solving gives only [`t=0`].
+
+Because [`e_3(t)=3t-3t^2+t^3`], we have [`e'_3(t)=3-6t+3t^2`].  Setting that equal to zero and solving gives [`3(1-t)(1-t)=0`], which has only one solution, [`t=1`].
+
+The red curve [`e_1`] has initial and final velocity 0, meaning that it starts from rest and ends at rest, for a gentle beginning and ending, making it the ease-in-out curve.
+
+The green curve [`e_2`] has initial velocity 0, but final velocity higher (note its sharp upward slope at [`t=1`] on the graph).  Thus it is the ease-in curve.
+
+The blue curve [`e_3`] has final velocity 0, but initial velocity higher (note its sharp upward slope at [`t=0`] on the graph).  Thus it is the ease-out curve.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-22-CreatingEasingCurves.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-22-CreatingEasingCurves.pg
@@ -1,0 +1,80 @@
+## DESCRIPTION
+## Creating some easing curves
+## ENDDESCRIPTION
+
+## DBsubject(Algebra)
+## DBchapter(Functions)
+## DBsection(Compositions and combinations of functions)
+## Date(03/20/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('22')
+## KEYWORDS('easing curves','function composition')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$graph1 = init_graph(-0.5,-0.5,1.5,1.5,axes=>[0,0],grid=>[8,8],size=>[400,400]);
+add_functions($graph1, "2*x for x in <0,0.5> using color:blue and weight:2");
+add_functions($graph1, "2-2*x for x in <0.5,1> using color:blue and weight:2");
+
+$graph2 = init_graph(-0.5,-0.5,1.5,1.5,axes=>[0,0],grid=>[8,8],size=>[400,400]);
+add_functions($graph2, "-4*x*(x-1) for x in <0,1> using color:blue and weight:2");
+
+$graph3 = init_graph(-0.5,-0.5,1.5,1.5,axes=>[0,0],grid=>[8,8],size=>[400,400]);
+add_functions($graph3, "1-x for x in <0,1> using color:blue and weight:2");
+
+TEXT(beginproblem());
+BEGIN_PGML
+The previous problem in this set introduced the concept of a function [`h : [0, 1]\to[0, 1]`] that can be composed with a vector-valued function to create a new vector-valued function. In that exercise, the purpose was to smooth (or "ease") a vector-valued function's motion, but there are other uses to which such a function [`h`] could be put. You'll explore some in this problem. As always, assume the motion of [`\vec f`] we care about is when [`0 \leq t \leq 1`].
+
+Create a function [`h_1`] such that [`\vec f \circ h_1`] follows the same path as [`\vec f`], but in reverse.
+
+Answer: [`h_1(t)=`][_______________]{"1-t"}
+
+Create a function [`h_2`], whose graph is shown below, such that [`\vec f \circ h_2`] follows the same path as [`\vec f`], then reverses direction and returns to [`\vec f(0)`].
+
+[@ image(insertGraph($graph1), width=>400, height=>400) @]*
+
+Answer: [`h_2(t)`] is a piecewise-defined function.
+
+When [`t \leq \frac12`], [`h_2(t)=`][_______________]{"2t"}.
+
+When [`t > \frac12`], [`h_2(t)=`][_______________]{"2-2t"}.
+
+Create a parabolic function [`h_3`], whose graph is shown below, such that [`\vec f \circ h_3`] behaves like [`\vec f \circ h_2`], but with a smoother transition at [`t = \frac12`].
+
+[@ image(insertGraph($graph2), width=>400, height=>400) @]*
+
+Answer: [`h_3(t)=`][_______________]{"-4t(t-1)"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To swap [`t=0`] with [`t=1`] and transition smoothly between them, use [`h_1(t)=1-t`].  See the graph below to help your intuition for this answer.
+
+[@ image(insertGraph($graph3), width=>400, height=>400) @]*
+
+Each half of [`h_2`] is a straight line segment, so you can simply use the endpoints to find a slope and use ordinary techniques from algebra.
+
+First half: [`(0,0)`] to [`\left(\frac12,1\right)`], slope 2, formula [`2t`].
+
+Second half: [`\left(\frac12,1\right)`] to [`(1,0)`], slope -2, formula [`2-2t1`].
+
+For the parabola, note that its x intercepts are 0 and 1.  So we could create the formula [`t(t-1)`] as a start, then notice that at [`t=\frac12`], its value is not 1 (as desired), but [`-\frac14`].  If we multiply it by -4 to correct this problem, we have [`h_3(t)=-4t(t-1)=4t-4t^2`].  This has the desired shape.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-4-VectorValuedFunctionDistance.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-4-VectorValuedFunctionDistance.pg
@@ -1,0 +1,80 @@
+## DESCRIPTION
+## Considering distance regarding a vector-valued function
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Parameterized curves)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('4')
+## KEYWORDS('vector-valued function','distance','derivatives')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$coeff1 = random( 2, 9 ) * random( -1, 1, 2 );
+$coeff2 = random( 2, 9 ) * random( -1, 1, 2 );
+$coeff3 = random( 2, 9 ) * random( -1, 1, 2 );
+$coeff4 = random( 2, 9 ) * random( -1, 1, 2 );
+$coeff5 = random( 2, 9 ) * random( -1, 1, 2 );
+$coeff6 = random( 2, 9 ) * random( -1, 1, 2 );
+
+$f1 = Formula("$coeff1*t+$coeff2");
+$f2 = Formula("$coeff3*t^2+$coeff4");
+$f3 = Formula("$coeff5*t^2+$coeff6*t");
+
+$f1d = $f1->eval(t=>1) - $f1->eval(t=>0);
+$f2d = $f2->eval(t=>1) - $f2->eval(t=>0);
+$f3d = $f3->eval(t=>1) - $f3->eval(t=>0);
+$ans1 = sqrt( $f1d**2 + $f2d**2 + $f3d**2 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is/contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+Consider an object following the path of the following vector-valued function.
+
+Function: [`\vec f(t)=\left([$f1],[$f2],[$f3]\right)`]
+
+What is the distance *along a straight line* from its starting point to its ending point?
+
+Answer: [__________]{$ans1}
+
+Is that equal to the distance the object would travel from time [`t=0`] to time [`t=1`]?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'Yes, the object would travel the same distance',
+  'The object would travel a different distance, but it may be more or less',
+  'The object would travel a lesser distance',
+  'The object would travel a greater distance',
+  'It is not possible to tell from the information given'
+) ], 'The object would travel a greater distance' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Starting point: [`\vec f(0)=\left([$f1->eval(t=>0)],[$f2->eval(t=>0)],[$f3->eval(t=>0)]\right)`]
+
+Ending point: [`\vec f(1)=\left([$f1->eval(t=>1)],[$f2->eval(t=>1)],[$f3->eval(t=>1)]\right)`]
+
+Distance between those points: [`\sqrt{([$f1->eval(t=>1)]-[$f1->eval(t=>0)])^2+([$f2->eval(t=>1)]-[$f2->eval(t=>0)])^2+([$f3->eval(t=>1)]-[$f3->eval(t=>0)])^2}=\sqrt{([$f1d])^2+([$f2d])^2+([$f3d])^2}\approx[$ans1]`]
+
+The shortest distance between two points is a straight line, but [`\vec f`] is clearly nonlinear (because it has exponents on the parameter) and thus an object following that path will cover a greater distance than [$ans1] from [`t=0`] to [`t=1`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-5-CreateLinearVectorFunction.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch10/10-5-CreateLinearVectorFunction.pg
@@ -1,0 +1,50 @@
+## DESCRIPTION
+## Create a linear vector-valued function
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - multivariable)
+## DBchapter(Calculus of vector valued functions)
+## DBsection(Parameterized curves)
+## Date(03/19/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('10')
+## Problem1('5')
+## KEYWORDS('vector-valued function','line')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$Ax = random(-10,10);
+$Ay = random(-10,10);
+$Az = random(-10,10);
+$Bx = random(-10,10);
+$By = random(-10,10);
+$Bz = random(-10,10);
+$vx = $Bx - $Ax;
+$vy = $By - $Ay;
+$vz = $Bz - $Az;
+
+TEXT(beginproblem());
+BEGIN_PGML
+In the race track shown in Figure 10.1 of the textbook, assume point [`A`] is [`([$Ax],[$Ay],[$Az])`] and point [`B`] is [`([$Bx],[$By],[$Bz])`].  If the car is to be at [`A`] when [`t=0`] and at [`B`] when [`t=1`], what linear vector-valued function describes the car's path when [`0\leq t\leq 1`]?
+
+Answer: ([________]{"$Ax+$vx*t"},[________]{"$Ay+$vy*t"},[________]{"$Az+$vz*t"})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The object begins at [`A`], and moves in the direction of [`B`], that is to say, following the vector [`B-A`], which is [`\vec v =([$Bx],[$By],[$Bz])-([$Ax],[$Ay],[$Az])=\langle [$vx],[$vy],[$vz] \rangle`].  Thus it follows the path [`A+\vec v t`], or [`([$Ax],[$Ay],[$Az])+\langle [$vx],[$vy],[$vz] \rangle t=([$Ax]+[$vx]t,[$Ay]+[$vy]t,[$Az]+[$vz]t)`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-1-CreateCubicBezier.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-1-CreateCubicBezier.pg
@@ -1,0 +1,150 @@
+##DESCRIPTION
+## Given positions and velocities, create a cubic BÃÂ©zier curve with them
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('1')
+##KEYWORDS('Bezier curves','position','velocity')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$p1x = 0;
+$p1y = 0;
+$p1z = 0;
+$v1x = 1;
+$v1y = 0;
+$v1z = 0;
+$p2x = non_zero_random( -10, 10 );
+$p2y = non_zero_random( -10, 10 );
+$p2z = non_zero_random( -10, 10 );
+$v2x = 0;
+$v2y = 0;
+$v2z = 0;
+$which = random( 1, 3 );
+if ( $which == 1 ) { $v2x = 1; }
+if ( $which == 2 ) { $v2y = 1; }
+if ( $which == 3 ) { $v2z = 1; }
+$t = random( 0.1, 0.9, 0.1 );
+
+$C1x = $p1x;
+$C1y = $p1y;
+$C1z = $p1z;
+$C2x = $p1x+$v1x/3;
+$C2y = $p1y+$v1y/3;
+$C2z = $p1z+$v1z/3;
+$C3x = $p2x-$v2x/3;
+$C3y = $p2y-$v2y/3;
+$C3z = $p2z-$v2z/3;
+$C4x = $p2x;
+$C4y = $p2y;
+$C4z = $p2z;
+
+$Ax = 3*$C2x-3*$C1x;
+$Bx = 2*(3*$C3x-6*$C2x+3*$C1x);
+$Cx = 3*($C4x-3*$C3x+3*$C2x-$C1x);
+$Ay = 3*$C2y-3*$C1y;
+$By = 2*(3*$C3y-6*$C2y+3*$C1y);
+$Cy = 3*($C4y-3*$C3y+3*$C2y-$C1y);
+$Az = 3*$C2z-3*$C1z;
+$Bz = 2*(3*$C3z-6*$C2z+3*$C1z);
+$Cz = 3*($C4z-3*$C3z+3*$C2z-$C1z);
+
+$velx = $Ax + $Bx*$t + $Cx*$t**2;
+$vely = $Ay + $By*$t + $Cy*$t**2;
+$velz = $Az + $Bz*$t + $Cz*$t**2;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume we have an object whose path of motion should satisfy the following
+conditions.
+
+>> [`
+P_1=([$p1x],[$p1y],[$p1z])
+\hspace{1cm}
+\vec v_1=\langle [$v1x],[$v1y],[$v1z] \rangle
+\hspace{1cm}
+P_2=([$p2x],[$p2y],[$p2z])
+\hspace{1cm}
+\vec v_2=\langle [$v2x],[$v2y],[$v2z] \rangle
+`] <<
+
+What should its control points be?
+
+[`C_1=`]([__________]{$C1x},[__________]{$C1y},[__________]{$C1z})
+
+[`C_2=`]([__________]{$C2x},[__________]{$C2y},[__________]{$C2z})
+
+[`C_3=`]([__________]{$C3x},[__________]{$C3y},[__________]{$C3z})
+
+[`C_4=`]([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+
+What is the corresponding cubic B[$e]*zier curve vector-valued function [`\vec f(t)`]?
+
+[`\vec f(t)=`](
+[__________]{"(1-t)^3*$C1x + 3t*(1-t)^2*$C2x + 3t^2*(1-t)*$C3x + t^3*$C4x"},
+[__________]{"(1-t)^3*$C1y + 3t*(1-t)^2*$C2y + 3t^2*(1-t)*$C3y + t^3*$C4y"},
+[__________]{"(1-t)^3*$C1z + 3t*(1-t)^2*$C2z + 3t^2*(1-t)*$C3z + t^3*$C4z"}
+)
+
+What is the velocity of an object following the path at time [`t=[$t]`]?
+
+Answer: [`\langle`][________]{$velx},[________]{$vely},[________]{$velz}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`C_1=P_1=([$p1x],[$p1y],[$p1z])`]
+
+[`C_2=P_1+\frac13\vec v_1=([$p1x],[$p1y],[$p1z])+\langle [$v1x],[$v1y],[$v1z] \rangle = ([$C2x],[$C2y],[$C2z])`]
+
+[`C_3=P_2-\frac13\vec v_2=([$p2x],[$p2y],[$p2z])-\langle [$v2x],[$v2y],[$v2z] \rangle = ([$C3x],[$C3y],[$C3z])`]
+
+[`C_4=P_2=([$p2x],[$p2y],[$p2z])`]
+
+[`\vec f(t)=(1-t)^3 C_1 + 3t(1-t)^2 C_2 + 3t^2(1-t) C_3 + t^3C_4`], and so its components (unsimplified) look like the following, but you could simplify them if you prefer.
+
+[`\vec f_1(t)=(1-t)^3([$C1x])+3t(1-t)^2([$C2x])+3t^2(1-t)([$C3x])+t^3([$C4x])`]
+
+[`\vec f_2(t)=(1-t)^3([$C1y])+3t(1-t)^2([$C2y])+3t^2(1-t)([$C3y])+t^3([$C4y])`]
+
+[`\vec f_3(t)=(1-t)^3([$C1z])+3t(1-t)^2([$C2z])+3t^2(1-t)([$C3z])+t^3([$C4z])`]
+
+To compute the velocity when [`t=[$t]`], we must compute the derivative.  We can use the form given in the text:
+
+[`\vec f'(t)=(3C_2-3C_1)+2(3C_3-6C_2+3C_1)t+3(C_4-3C_3+3C_2-C_1)t^2`]
+
+Therefore, with our numbers, we have these components:
+
+[`\vec f'_1(t)=[$Ax]+[$Bx]t+[$Cx]t^2`]
+
+[`\vec f'_2(t)=[$Ay]+[$By]t+[$Cy]t^2`]
+
+[`\vec f'_3(t)=[$Az]+[$Bz]t+[$Cz]t^2`]
+
+Plugging in [`t=[$t]`], we get:
+
+[`\vec f([$t])=\langle [$velx],[$vely],[$velz] \rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-14-EssayOnContinuity.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-14-EssayOnContinuity.pg
@@ -1,0 +1,55 @@
+##DESCRIPTION
+## Essay discussing the effects of continuity from one scene to the next
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('14')
+##KEYWORDS('Bezier curves','continuity')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+In one of the exercises in the textbook, it discusses an animation of a race car swerving around an obstacle, over two scenes, each governed by its own B[$e]*zier curve (as in Figure 11.12).  It requires the reader to connect the scenes so that *the final velocity of the first scene matches the initial velocity of the second scene.*
+
+In another exercise in the textbook, it discusses an animation of a tennis ball bouncing in a tennis court, over two scenes, one before the bounce and one after (as in Figure 11.11).  In that example *the initial velocity of the second scene is _not_ equal to the final velocity of the first scene.*
+
+Explain what effect this difference has, and why it is appropriate.
+
+[@ ANS(essay_cmp); essay_box(10,75) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+If the velocity changes suddenly at the point where scene 1 touches scene 2, then the car will seem to jerk as if struck by some outside object or force. This is desirable when a collision or other sudden force occurs at that moment.
+
+That did not happen with the car, so we wanted to keep the velocities the same.  It did happen with the tennis ball, which collided with the ground, so we wanted the velocities different.
+
+More details are covered in Chapter 13.
+
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-15-BernsteinPolynomialsPreview.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-15-BernsteinPolynomialsPreview.pg
@@ -1,0 +1,124 @@
+##DESCRIPTION
+## Preliminary investigation of Bernstein polynomials
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('15')
+##KEYWORDS('Bezier curves','Bernstein polynomials')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$e = "&eacute;";
+
+$graph = init_graph(-0.2,-0.2,1.2,1.2,axes=>[0,0],grid=>[6,6],size=>[400,400]); # xmin,ymin,xmax,ymax
+add_functions($graph, "(1-x)^3 for x in <0,1> using color:red and weight:2");
+add_functions($graph, "3*x*(1-x)^2 for x in <0,1> using color:green and weight:2");
+add_functions($graph, "3*x^2*(1-x) for x in <0,1> using color:blue and weight:2");
+add_functions($graph, "x^3 for x in <0,1> using color:black and weight:2");
+
+TEXT(beginproblem());
+BEGIN_PGML
+The four polynomials used as coefficients on the control points of a cubic B[$e]*ier curve are [`(1-t)^3`], [`3t(1-t)^2`], [`3t^2(1-t)`], and [`t^3`]. The B[$e]*zer curve can be considered as a weighted average, with these four values as the weights. Answer each of the following questions, restricting your attention only to [`t`] values in the interval [`[0, 1]`].
+
+For reference, see the following graph of all four functions.  The polynomials listed above are colored red, green, blue, and black, in the order listed above.
+
+[@ image(insertGraph($graph), width=>400, height=>400, tex_size=>480) @]*
+
+What is the maximum value of [`(1-t)^3`] on the interval, and where is it attained?  (This is the red curve.)
+
+Maximum value: [`y=`][__________]{1}
+
+Attained at: [`t=`][__________]{0}
+
+What is the maximum value of [`3t(1-t)^2`] on the interval, and where is it attained?  (This is the green curve.)
+
+Maximum value: [`y=`][__________]{4/9}
+
+Attained at: [`t=`][__________]{1/3}
+
+What is the maximum value of [`3t^2(1-t)`] on the interval, and where is it attained?  (This is the blue curve.)
+
+Maximum value: [`y=`][__________]{4/9}
+
+Attained at: [`t=`][__________]{2/3}
+
+What is the maximum value of [`t^3`] on the interval, and where is it attained?  (This is the black curve.)
+
+Maximum value: [`y=`][__________]{1}
+
+Attained at: [`t=`][__________]{1}
+
+At what [`t`] value does the second weight, [`3t(1-t)^2`], become larger than the first weight, [`(1-t)^3`]?
+
+Answer: [`t=`][__________]{1/4}
+
+At what [`t`] value does the third weight, [`3t^2(1-t)`], become larger than the second weight, [`3t(1-t)^2`]?
+
+Answer: [`t=`][__________]{1/2}
+
+At what [`t`] value does the fourth weight, [`t^3`], become larger than the third weight, [`3t^2(1-t)`]?
+
+Answer: [`t=`][__________]{3/4}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+On the interval, the maximum value of [`(1-t)^3`] is at the left end, when [`t = 0`]. It is [`y = 1`].
+
+To answer the second part, we must do some calculus.  The derivative of [`3t(1-t)^2`], using the product rule (not shown here), gives [`9t^2-12t+3`].  Setting that equal to zero we can solve by factoring into [`(3t-1)(t-1)=0`], and obtain [`t=\frac13`] or [`t=1`].  Clearly from the graph, [`t=1`] is not the maximum, but [`t=\frac13`] is.  Substituting [`t=\frac13`] into [`3t(1-t)^2`] gives us [`y=\frac49`].
+
+A similar technique solves the third part, giving [`y=\frac49`] as a maximum for [`3t^2(1-t)`] at [`t=\frac23`].
+
+On the interval, the maximum value of [`t^3`] is at the right end, when [`t=1`].  It is [`y=1`].
+
+To find where [`3t(1-t)^2`] surpasses [`(1-t)^3`], we can set them equal to one another.
+
+>> [`3t(1-t)^2=(1-t)^3`] <<
+
+>> [`4t^3-9t^2+6t-1=0`] <<
+
+This is difficult to solve with algebra (though not impossible).  You could guess that the solution is at about [`t=\frac14`], and confirm this by substitution.  Or you could use a computer algebra system (such as WolframAlpha) to find all solutions, which would give [`t=\frac14`] and [`t=1`], from which we're obviously concernd with just the first one.
+
+To find where [`3t^2(1-t)`] surpasses [`3t(1-t)^2`], we set them equal.
+
+>> [`3t^2(1-t)=3t(1-t)^2`] <<
+
+>> [`6t^3-9t^2+3t=0`] <<
+
+>> [`t(2t-1)(t-1)=0`] <<
+
+Thus [`t=0`] or [`t=\frac12`] or [`t=1`].  The one of these we care about is obviously [`t=\frac12`].
+
+To find where [`t^3`] surpasses [`3t^2(1-t)`], we set them equal.
+
+>> [`t^3=3t^2(1-t)`] <<
+
+>> [`4t^3-3t^2=0`] <<
+
+>> [`t^2(4t-3)=0`] <<
+
+Thus [`t=0`] or [`t=\frac34`].  The one of these we care about is obviously [`t=\frac34`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-2-CreateCubicBezier2.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-2-CreateCubicBezier2.pg
@@ -1,0 +1,146 @@
+##DESCRIPTION
+## Given positions and velocities, create a cubic Bezier curve with them
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('2')
+##KEYWORDS('Bezier curves','position','velocity')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$p1x = non_zero_random( -10, 10 );
+$p1y = non_zero_random( -10, 10 );
+$p1z = random( -10, 10 );
+$v1x = non_zero_random( -5, 5 );
+$v1y = random( -5, 5 );
+$v1z = random( -5, 5 );
+$p2x = random( -10, 10 );
+$p2y = non_zero_random( -10, 10 );
+$p2z = non_zero_random( -10, 10 );
+$v2x = non_zero_random( -10, 10 );
+$v2y = random( -10, 10 );
+$v2z = random( -10, 10 );
+$t = random( 0.1, 0.9, 0.1 );
+
+$C1x = $p1x;
+$C1y = $p1y;
+$C1z = $p1z;
+$C2x = $p1x+$v1x/3;
+$C2y = $p1y+$v1y/3;
+$C2z = $p1z+$v1z/3;
+$C3x = $p2x-$v2x/3;
+$C3y = $p2y-$v2y/3;
+$C3z = $p2z-$v2z/3;
+$C4x = $p2x;
+$C4y = $p2y;
+$C4z = $p2z;
+
+$Ax = 3*$C2x-3*$C1x;
+$Bx = 2*(3*$C3x-6*$C2x+3*$C1x);
+$Cx = 3*($C4x-3*$C3x+3*$C2x-$C1x);
+$Ay = 3*$C2y-3*$C1y;
+$By = 2*(3*$C3y-6*$C2y+3*$C1y);
+$Cy = 3*($C4y-3*$C3y+3*$C2y-$C1y);
+$Az = 3*$C2z-3*$C1z;
+$Bz = 2*(3*$C3z-6*$C2z+3*$C1z);
+$Cz = 3*($C4z-3*$C3z+3*$C2z-$C1z);
+
+$velx = $Ax + $Bx*$t + $Cx*$t**2;
+$vely = $Ay + $By*$t + $Cy*$t**2;
+$velz = $Az + $Bz*$t + $Cz*$t**2;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume we have an object whose path of motion should satisfy the following
+conditions.
+
+>> [`
+P_1=([$p1x],[$p1y],[$p1z])
+\hspace{1cm}
+\vec v_1=\langle [$v1x],[$v1y],[$v1z] \rangle
+\hspace{1cm}
+P_2=([$p2x],[$p2y],[$p2z])
+\hspace{1cm}
+\vec v_2=\langle [$v2x],[$v2y],[$v2z] \rangle
+`] <<
+
+What should its control points be?
+
+[`C_1=`]([__________]{$C1x},[__________]{$C1y},[__________]{$C1z})
+
+[`C_2=`]([__________]{$C2x},[__________]{$C2y},[__________]{$C2z})
+
+[`C_3=`]([__________]{$C3x},[__________]{$C3y},[__________]{$C3z})
+
+[`C_4=`]([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+
+What is the corresponding cubic B[$e]*zier curve vector-valued function [`\vec f(t)`]?
+
+[`\vec f(t)=`](
+[__________]{"(1-t)^3*$C1x + 3t*(1-t)^2*$C2x + 3t^2*(1-t)*$C3x + t^3*$C4x"},
+[__________]{"(1-t)^3*$C1y + 3t*(1-t)^2*$C2y + 3t^2*(1-t)*$C3y + t^3*$C4y"},
+[__________]{"(1-t)^3*$C1z + 3t*(1-t)^2*$C2z + 3t^2*(1-t)*$C3z + t^3*$C4z"}
+)
+
+What is the velocity of an object following the path at time [`t=[$t]`]?
+
+Answer: [`\langle`][________]{$velx},[________]{$vely},[________]{$velz}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`C_1=P_1=([$p1x],[$p1y],[$p1z])`]
+
+[`C_2=P_1+\frac13\vec v_1=([$p1x],[$p1y],[$p1z])+\langle [$v1x],[$v1y],[$v1z] \rangle = ([$C2x],[$C2y],[$C2z])`]
+
+[`C_3=P_2-\frac13\vec v_2=([$p2x],[$p2y],[$p2z])-\langle [$v2x],[$v2y],[$v2z] \rangle = ([$C3x],[$C3y],[$C3z])`]
+
+[`C_4=P_2=([$p2x],[$p2y],[$p2z])`]
+
+[`\vec f(t)=(1-t)^3 C_1 + 3t(1-t)^2 C_2 + 3t^2(1-t) C_3 + t^3C_4`], and so its components (unsimplified) look like the following, but you could simplify them if you prefer.
+
+[`\vec f_1(t)=(1-t)^3([$C1x])+3t(1-t)^2([$C2x])+3t^2(1-t)([$C3x])+t^3([$C4x])`]
+
+[`\vec f_2(t)=(1-t)^3([$C1y])+3t(1-t)^2([$C2y])+3t^2(1-t)([$C3y])+t^3([$C4y])`]
+
+[`\vec f_3(t)=(1-t)^3([$C1z])+3t(1-t)^2([$C2z])+3t^2(1-t)([$C3z])+t^3([$C4z])`]
+
+To compute the velocity when [`t=[$t]`], we must compute the derivative.  We can use the form given in the text:
+
+[`\vec f'(t)=(3C_2-3C_1)+2(3C_3-6C_2+3C_1)t+3(C_4-3C_3+3C_2-C_1)t^2`]
+
+Therefore, with our numbers, we have these components:
+
+[`\vec f'_1(t)=[$Ax]+[$Bx]t+[$Cx]t^2`]
+
+[`\vec f'_2(t)=[$Ay]+[$By]t+[$Cy]t^2`]
+
+[`\vec f'_3(t)=[$Az]+[$Bz]t+[$Cz]t^2`]
+
+Plugging in [`t=[$t]`], we get:
+
+[`\vec f([$t])=\langle [$velx],[$vely],[$velz] \rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-3-CreateControlPoints.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-3-CreateControlPoints.pg
@@ -1,0 +1,82 @@
+##DESCRIPTION
+## Given positions and velocities, create a cubic Bezier curve control points
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('3')
+##KEYWORDS('Bezier curves','position','velocity','control points')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$p1x = 0;
+$p1y = 0;
+$p1z = 0;
+$v1x = 0;
+$v1y = 0;
+$v1z = 0;
+$p2x = non_zero_random( -20, 20 );
+$p2y = non_zero_random( -20, 20 );
+$p2z = non_zero_random( -20, 20 );
+$v2x = 0;
+$v2y = 0;
+$v2z = 0;
+
+$C1x = $p1x;
+$C1y = $p1y;
+$C1z = $p1z;
+$C2x = $p1x+$v1x/3;
+$C2y = $p1y+$v1y/3;
+$C2z = $p1z+$v1z/3;
+$C3x = $p2x-$v2x/3;
+$C3y = $p2y-$v2y/3;
+$C3z = $p2z-$v2z/3;
+$C4x = $p2x;
+$C4y = $p2y;
+$C4z = $p2z;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+What are the control points for a cubic B[$e]*zier curve from the origin to [`([$p2x],[$p2y],[$p2z])`] with initial and final velocities zero?
+
+[`C_1=`]([__________]{$C1x},[__________]{$C1y},[__________]{$C1z})
+
+[`C_2=`]([__________]{$C2x},[__________]{$C2y},[__________]{$C2z})
+
+[`C_3=`]([__________]{$C3x},[__________]{$C3y},[__________]{$C3z})
+
+[`C_4=`]([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`C_1=P_1=([$p1x],[$p1y],[$p1z])`]
+
+[`C_2=P_1+\frac13\vec v_1=([$p1x],[$p1y],[$p1z])+\langle [$v1x],[$v1y],[$v1z] \rangle = ([$C2x],[$C2y],[$C2z])`]
+
+[`C_3=P_2-\frac13\vec v_2=([$p2x],[$p2y],[$p2z])-\langle [$v2x],[$v2y],[$v2z] \rangle = ([$C3x],[$C3y],[$C3z])`]
+
+[`C_4=P_2=([$p2x],[$p2y],[$p2z])`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-4-InferControlPointsEtc.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-4-InferControlPointsEtc.pg
@@ -1,0 +1,133 @@
+##DESCRIPTION
+## Given a cubic Bezier curve, infer its control points and other information
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('4')
+##KEYWORDS('Bezier curves','position','velocity','control points')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$p1x = non_zero_random( -9, 9 );
+$p1y = non_zero_random( -9, 9 );
+$p1z = non_zero_random( -9, 9 );
+$v1x = non_zero_random( -3, 3 )*3;
+$v1y = non_zero_random( -3, 3 )*3;
+$v1z = non_zero_random( -3, 3 )*3;
+$p2x = non_zero_random( -9, 9 );
+$p2y = non_zero_random( -9, 9 );
+$p2z = non_zero_random( -9, 9 );
+$v2x = non_zero_random( -3, 3 )*3;
+$v2y = non_zero_random( -3, 3 )*3;
+$v2z = non_zero_random( -3, 3 )*3;
+
+$C1x = $p1x;
+$C1y = $p1y;
+$C1z = $p1z;
+$C2x = $p1x+$v1x/3;
+$C2y = $p1y+$v1y/3;
+$C2z = $p1z+$v1z/3;
+$C3x = $p2x-$v2x/3;
+$C3y = $p2y-$v2y/3;
+$C3z = $p2z-$v2z/3;
+$C4x = $p2x;
+$C4y = $p2y;
+$C4z = $p2z;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the cubic B[$e]*zier curve
+
+>> [`(1-t)^3([$C1x],[$C1y],[$C1z])
+    +3t(1-t)^2([$C2x],[$C2y],[$C2z])
+    +3t^2(1-t)([$C3x],[$C3y],[$C3z])
+    +t^3([$C4x],[$C4y],[$C4z])`] <<
+
+What are its control points?
+
+[`C_1=`]([__________]{$C1x},[__________]{$C1y},[__________]{$C1z})
+
+[`C_2=`]([__________]{$C2x},[__________]{$C2y},[__________]{$C2z})
+
+[`C_3=`]([__________]{$C3x},[__________]{$C3y},[__________]{$C3z})
+
+[`C_4=`]([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+
+What are its initial and final positions?
+
+[`P_1=`]([__________]{$C1x},[__________]{$C1y},[__________]{$C1z})
+
+[`P_2=`]([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+
+What are its initial and final velocities?
+
+[`\vec v_1=`]([__________]{$v1x},[__________]{$v1y},[__________]{$v1z})
+
+[`\vec v_2=`]([__________]{$v2x},[__________]{$v2y},[__________]{$v2z})
+
+Write it in simplified form.
+
+[`\vec f(t)=\left( f_1(t), f_2(t), f_3(t) \right)`], with
+
+[`f_1(t)=`][____________________]{"(1-t)^3*$C1x+3*t*(1-t)^2*$C2x+3*t^2*(1-t)*$C3x+t^3*$C4x"}
+
+[`f_2(t)=`][____________________]{"(1-t)^3*$C1y+3*t*(1-t)^2*$C2y+3*t^2*(1-t)*$C3y+t^3*$C4y"}
+
+[`f_3(t)=`][____________________]{"(1-t)^3*$C1z+3*t*(1-t)^2*$C2z+3*t^2*(1-t)*$C3z+t^3*$C4z"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Lifting them directly from the formula, we have these control points:
+
+[`C_1=([$p1x],[$p1y],[$p1z])`]
+
+[`C_2=([$C2x],[$C2y],[$C2z])`]
+
+[`C_3=([$C3x],[$C3y],[$C3z])`]
+
+[`C_4=([$p2x],[$p2y],[$p2z])`]
+
+We therefore know the initial and final positions:
+
+[`P_1=C_1=([$p1x],[$p1y],[$p1z])`]
+
+[`P_2=C_4=([$p2x],[$p2y],[$p2z])`]
+
+We can then use the equations [`C_2=P_1+\frac13\vec v_1`] and [`C_3=P_2-\frac13\vec v_2`] to figure out [`\vec v_1`] and [`\vec v_2`]:
+
+[`\vec v_1=3(C_2-P_1)=3(([$C2x],[$C2y],[$C2z])-([$p1x],[$p1y],[$p1z]))=\langle [$v1x],[$v1y],[$v1z] \rangle`]
+
+[`\vec v_2=3(P_2-C_3)=3(([$p2x],[$p2y],[$p2z])-([$C3x],[$C3y],[$C3z]))=\langle [$v2x],[$v2y],[$v2z] \rangle`]
+
+We can also rewrite the equation into three components, [`x`], [`y`], and [`z`], as follows.
+
+[`f_1(t)=(1-t)^3([$C1x])+3t(1-t)^2([$C2x])+3t^2(1-t)([$C3x])+t^3([$C4x])`]
+
+[`f_2(t)=(1-t)^3([$C1y])+3t(1-t)^2([$C2y])+3t^2(1-t)([$C3y])+t^3([$C4y])`]
+
+[`f_3(t)=(1-t)^3([$C1z])+3t(1-t)^2([$C2z])+3t^2(1-t)([$C3z])+t^3([$C4z])`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-6-LinearBezierCurve.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-6-LinearBezierCurve.pg
@@ -1,0 +1,67 @@
+##DESCRIPTION
+## Given starting and ending points, write a linear Bezier curve
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('6')
+##KEYWORDS('Bezier curves','linear')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+Context()->variables->add(A=>Real);
+Context()->variables->add(B=>Real);
+$showPartialCorrectAnswers = 1;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+A linear B[$e]*zier curve between two points [`A`] and [`B`] is the straight line function from Chapter 6 of the textbook.  (In Chapter 12 of the text, we will see all the types of B[$e]*zier curves, beyond cubic linear.)
+
+What is the formula for that vector-valued function?
+
+Answer: [_________________]{"(1-t)*A+t*B"}
+
+What is the formula for its derivative?
+
+Answer: [_________________]{"B-A"}
+
+What is the initial velocity of an object following the linear path?
+
+Answer: [_________________]{"B-A"}
+
+What is the final velocity of an object following the linear path?
+
+Answer: [_________________]{"B-A"}
+
+What is the acceleration of that vector-valued function?
+
+Answer: [_________________]{0}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A linear path of motion from [`A`] to [`B`] has initial position [`A`] and velocity [`B-A`], and so it can be written as [`\vec f(t)=A+(B-A)t`], or [`(1-t)A+tB`].
+
+Its derivative is therefore just [`B-A`], which means both the initial and final velocities are [`B-A`].  Its second derivative (acceleration) is therefore zero.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-8-ConnectBezierToNextScene.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/11-8-ConnectBezierToNextScene.pg
@@ -1,0 +1,114 @@
+##DESCRIPTION
+## Given one cubic Bezier curve, compute control points starting the next scene
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('03/26/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('11')
+## Problem1('8')
+##KEYWORDS('Bezier curves','position','velocity','continuity')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+$p1x = 0;
+$p1y = 0;
+$p1z = 0;
+$v1x = random(3,6,3)*random(-1,1,2);
+$v1y = 0;
+$v1z = 0;
+$p2x = non_zero_random( -10, 10 );
+$p2y = non_zero_random( -10, 10 );
+$p2z = non_zero_random( -10, 10 );
+$v2x = 0;
+$v2y = 0;
+$v2z = 0;
+$which = random( 1, 3 );
+if ( $which == 1 ) { $v2x = random(3,6,3)*random(-1,1,2); }
+if ( $which == 2 ) { $v2y = random(3,6,3)*random(-1,1,2); }
+if ( $which == 3 ) { $v2z = random(3,6,3)*random(-1,1,2); }
+$t = random( 0.1, 0.9, 0.1 );
+
+$C1x = $p1x;
+$C1y = $p1y;
+$C1z = $p1z;
+$C2x = $p1x+$v1x/3;
+$C2y = $p1y+$v1y/3;
+$C2z = $p1z+$v1z/3;
+$C3x = $p2x-$v2x/3;
+$C3y = $p2y-$v2y/3;
+$C3z = $p2z-$v2z/3;
+$C4x = $p2x;
+$C4y = $p2y;
+$C4z = $p2z;
+
+$Ax = 3*$C2x-3*$C1x;
+$Bx = 2*(3*$C3x-6*$C2x+3*$C1x);
+$Cx = 3*($C4x-3*$C3x+3*$C2x-$C1x);
+$Ay = 3*$C2y-3*$C1y;
+$By = 2*(3*$C3y-6*$C2y+3*$C1y);
+$Cy = 3*($C4y-3*$C3y+3*$C2y-$C1y);
+$Az = 3*$C2z-3*$C1z;
+$Bz = 2*(3*$C3z-6*$C2z+3*$C1z);
+$Cz = 3*($C4z-3*$C3z+3*$C2z-$C1z);
+
+$velx = $Ax = $Bx*$t + $Cx*$t**2;
+$vely = $Ay = $By*$t + $Cy*$t**2;
+$velz = $Az = $Bz*$t + $Cz*$t**2;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume we have an object whose path of motion is given by the following cubic B[$e]*zier curve.
+
+>> [`\vec f(t)=(1-t)^3([$C1x],[$C1y],[$C1z])
+              +3t(1-t)^2([$C2x],[$C2y],[$C2z])
+              +3t^2(1-t)([$C3x],[$C3y],[$C3z])
+              +t^3([$C4x],[$C4y],[$C4z])`] <<
+
+Now imagine we animate an object along that path, and then need to make it connect smoothly to the next scene.
+
+What must the object's initial position be for the second scene?
+
+Answer: ([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+
+What must its initial velocity be for the second scene?
+
+Answer: [`\langle`][__________]{$v2x},[__________]{$v2y},[_________]{$v2z}[`\rangle`]
+
+If the second scene is also animated along a cubic B[$e]*zier curve, what will [`C_1`] and [`C_2`] be in the second scene?
+
+Second scene [`C_1=`]([__________]{$C4x},[__________]{$C4y},[__________]{$C4z})
+
+Second scene [`C_2=`]([__________]{$C4x+$v2x/3},[__________]{$C4y+$v2y/3},[_________]{$C4z+$v2z/3})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The initial position for the second scene is the final position for the first scene, which is the fourth control point, [`([$C4x],[$C4y],[$C4z])`].
+
+The initial velocity fo the second scene is the final velocity for the first scene, which we can compute from the last two control points of the first scene.  They are [`C_3=([$C3x],[$C3y],[$C3z])`] and [`C_4=([$C4x],[$C4y],[$C4z])`].  Recall that [`C_3=C_4-\frac13\vec v_2`], so [`v_2=3(C_4-C_3)=3(([$C4x],[$C4y],[$C4z])-([$C3x],[$C3y],[$C3z]))=\langle [$v2x],[$v2y],[$v3z] \rangle`].
+
+In the second scene, the first control point is the initial position, [`([$C4x],[$C4y],[$C4z])`].
+
+The second control point can be computed from the initial position and velocity.  [`C_2=P_1+\frac13\vec v_1=([$C4x],[$C4y],[$C4z])+\frac13\langle [$v2x],[$v2y],[$v2z] \rangle=([$C4x+$v2x/3],[$C4y+$v2y/3],[$C4z+$v2z/3])`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch11/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-11-BerinsteinMaxima.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-11-BerinsteinMaxima.pg
@@ -1,0 +1,114 @@
+##DESCRIPTION
+## Where do the various Bernstein polynomials have their maximum values
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - single variable')
+## DBchapter('Applications of differentiation')
+## DBsection('Optimization - general')
+## Date('04/04/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('12')
+## Problem1('11')
+##KEYWORDS('Bezier curves','maxima')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$e = "&eacute;";
+
+$graph1 = init_graph(-0.25,-0.25,1.25,1.25,axes=>[0,0],grid=>[6,6],size=>[400,400]); # xmin,ymin,xmax,ymax
+add_functions($graph1, "1-x for x in <0,1> using weight:2");
+add_functions($graph1, "x for x in <0,1> using weight:2");
+
+$graph2 = init_graph(-0.25,-0.25,1.25,1.25,axes=>[0,0],grid=>[6,6],size=>[400,400]); # xmin,ymin,xmax,ymax
+add_functions($graph2, "(1-x)^2 for x in <0,1> using weight:2");
+add_functions($graph2, "2x(1-x) for x in <0,1> using weight:2");
+add_functions($graph2, "x^2 for x in <0,1> using weight:2");
+
+$graph3 = init_graph(-0.25,-0.25,1.25,1.25,axes=>[0,0],grid=>[6,6],size=>[400,400]); # xmin,ymin,xmax,ymax
+add_functions($graph3, "(1-x)^3 for x in <0,1> using weight:2");
+add_functions($graph3, "3x(1-x)^2 for x in <0,1> using weight:2");
+add_functions($graph3, "3x^2(1-x) for x in <0,1> using weight:2");
+add_functions($graph3, "x^3 for x in <0,1> using weight:2");
+
+TEXT(beginproblem());
+BEGIN_PGML
+At what [`t`] value does each linear Bernstein polynomial achieve its maximum on the interval [`[0,1]`]?
+
+Answer: [`1-t`] achieves its maximum at [__________]{0}.
+
+Answer: [`t`] achieves its maximum at [__________]{1}.
+
+At what [`t`] value does each quadratic Bernstein polynomial achieve its maximum on the interval [`[0,1]`]?
+
+Answer: [`(1-t)^2`] achieves its maximum at [__________]{0}.
+
+Answer: [`2t(1-t)`] achieves its maximum at [__________]{1/2}.
+
+Answer: [`t^2`] achieves its maximum at [__________]{1}.
+
+At what [`t`] value does each cubic Bernstein polynomial achieve its maximum on the interval [`[0,1]`]?
+
+Answer: [`(1-t)^3`] achieves its maximum at [__________]{0}.
+
+Answer: [`3t(1-t)^2`] achieves its maximum at [__________]{1/3}.
+
+Answer: [`3t^2(1-t)`] achieves its maximum at [__________]{2/3}.
+
+Answer: [`t^3`] achieves its maximum at [__________]{1}.
+
+Based on the answers you gave above, make a conjecture about the general pattern for where the maxima will exist for Bernstein polynomials of any degree.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+In each case, the answer is either one extreme end of the interval (which can be seen clearly from a graph of the Bernstein polynomials) or it is where the polynomial's derivative is equal to zero.
+
+In the linear case, the graph clearly shows there are no local maxima, but only maxima on the endpoints of the interval.  Thus the maximum for [`1-t`] is at [`t=0`] and for [`t`] is at [`t=1`].
+
+[@ image(insertGraph($graph1), width=>400, height=>400, tex_size=>480) @]*
+
+In the quadratic case, the graph clearly shows there are no local maxima for [`(1-t)^2`] or [`t^2`], but only maxima on the endpoints of the interval.  Thus the maximum for [`(1-t)^2`] is at [`t=0`] and for [`t^2`] is at [`t=1`].
+
+[@ image(insertGraph($graph2), width=>400, height=>400, tex_size=>480) @]*
+
+That leaves us with [`2t(1-t)`].  We simplify it to [`2t-2t^2`], compute its derivative as [`2-4t`], and ask where that derivative is zero.  The answer is at [`t=\frac12`], which fits with the graph we see above.
+
+In the cubic case, the graph clearly shows there are no local maxima for [`(1-t)^3`] or [`t^3`], but only maxima on the endpoints of the interval.  Thus the maximum for [`(1-t)^3`] is at [`t=0`] and for [`t^3`] is at [`t=1`].
+
+[@ image(insertGraph($graph3), width=>400, height=>400, tex_size=>480) @]*
+
+That leaves us with [`3t(1-t)^2`] and [`3t^2(1-t)`].  We simplify the first of these to [`3t-6t^2+3t^3`], compute its derivative as [`3-12t+9t^2`], and ask where that derivative is zero.  The quadratic formula tells us it happens at [`t=\frac13`] and [`t=1`], and [`t=\frac13`] is the maximum in the graph we see above.
+
+We simplify the second of these to [`3t^2-3t^3`], compute its derivative as [`6t-9t^2`], and ask where that derivative is zero.  Factoring into [`3t(2-3t)`] tells us it happens at [`t=0`] and [`t=\frac23`], and [`t=\frac23`] is the maximum in the graph we see above.
+
+So in general, we see this pattern:
+
+Linear maxima at 0 and 1
+
+Quadratic maxima at 0, [`\frac12`], and 1
+
+Cubic maxima at 0, [`\frac13`], [`\frac23`], and 1
+
+So we conjecture that the maxima will always be at 0, [`\frac1n`], [`\frac2n`], [`\ldots`], and [`\frac{n-1}n`], for the [`n`]th degree Bernstein polynomials.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-2-PascalsTriangle.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-2-PascalsTriangle.pg
@@ -1,0 +1,83 @@
+##DESCRIPTION
+## Compute a few rows of Pascal's Triangle
+##ENDDESCRIPTION
+
+## DBsubject('Combinatorics')
+## DBchapter('Counting')
+## DBsection('Combinations')
+## Date('04/03/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('12')
+## Problem1('2')
+##KEYWORDS('Pascal\'s Triangle')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "niceTables.pl"
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Complete the next few rows of Pascal's Triangle.
+
+[@
+  DataTable([
+    ['','','','','','','','1','','','','','','',''],
+    ['','','','','','','1','','1','','','','','',''],
+    ['','','','','','1','','2','','1','','','','',''],
+    ['','','','','1','','3','','3','','1','','','',''],
+    ['','','','1','','4','','6','','4','','1','','',''],
+    ['','',PGML('[___]{1}'),'',
+           PGML('[___]{5}'),'',
+           PGML('[___]{10}'),'',
+           PGML('[___]{10}'),'',
+           PGML('[___]{5}'),'',
+           PGML('[___]{1}'),'',''],
+    ['',PGML('[___]{1}'),'',
+        PGML('[___]{6}'),'',
+        PGML('[___]{15}'),'',
+        PGML('[___]{20}'),'',
+        PGML('[___]{15}'),'',
+        PGML('[___]{6}'),'',
+        PGML('[___]{1}'),''],
+    [PGML('[___]{1}'),'',
+     PGML('[___]{7}'),'',
+     PGML('[___]{21}'),'',
+     PGML('[___]{35}'),'',
+     PGML('[___]{35}'),'',
+     PGML('[___]{21}'),'',
+     PGML('[___]{7}'),'',
+     PGML('[___]{1}')]
+  ])
+@]***
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[@
+  DataTable([
+    ['','','','','','','','1','','','','','','',''],
+    ['','','','','','','1','','1','','','','','',''],
+    ['','','','','','1','','2','','1','','','','',''],
+    ['','','','','1','','3','','3','','1','','','',''],
+    ['','','','1','','4','','6','','4','','1','','',''],
+    ['','','1','','5','','10','','10','','5','','1','',''],
+    ['','1','','6','','15','','20','','15','','6','','1',''],
+    ['1','','7','','21','','35','','35','','21','','7','','1']
+  ])
+@]***
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-4-BernsteinFormulas.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-4-BernsteinFormulas.pg
@@ -1,0 +1,122 @@
+##DESCRIPTION
+## Write out several Bernstein polynomials
+##ENDDESCRIPTION
+
+## DBsubject('Algebra')
+## DBchapter('Polynomial equations and functions')
+## DBsection('Polynomial functions')
+## Date('04/03/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('12')
+## Problem1('4')
+##KEYWORDS('Bernstein polynomials','degree')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl"
+);
+
+Context("Numeric");
+Context()->variables->add(t=>'Real');
+$showPartialCorrectAnswers = 1;
+$deg1 = random( 2, 3 );
+$deg2 = $deg1 + random( 0, 1 );
+$deg3 = $deg2 + random( 0, 1 );
+$deg4 = random( 5, 7 );
+$deg5 = random( 8, 10 );
+$i1 = random( 0, $deg1 );
+$i2 = ( $i1 + 1 ) % $deg2;
+$i3 = ( $i1 + 2 ) % $deg3;
+$i4 = $deg4 - 1;
+$i5 = random( 4, $deg5 - 4 );
+sub suffix {
+  my $num = shift(@_);
+  if ( $num == 1 ) { return 'st'; }
+  if ( $num == 2 ) { return 'nd'; }
+  if ( $num == 3 ) { return 'rd'; }
+  return 'th';
+}
+sub suffixed {
+  my $num = shift(@_);
+  return $num . suffix($num);
+}
+sub fact {
+  my $num = shift(@_);
+  if ( $num <= 1 ) { return 1; }
+  return $num * fact( $num - 1 );
+}
+sub choose {
+  my $n = shift(@_);
+  my $k = shift(@_);
+  return fact( $n ) / fact( $k ) / fact( $n - $k );
+}
+$ith1 = suffixed($i1);
+$ith2 = suffixed($i2);
+$ith3 = suffixed($i3);
+$ith4 = suffixed($i4);
+$ith5 = suffixed($i5);
+
+$c1 = choose( $deg1, $i1 );
+$c2 = choose( $deg2, $i2 );
+$c3 = choose( $deg3, $i3 );
+$c4 = choose( $deg4, $i4 );
+$c5 = choose( $deg5, $i5 );
+
+$ans1 = Formula("$c1(t^$i1)(1-t)^($deg1-$i1)");
+$ans2 = Formula("$c2(t^$i2)(1-t)^($deg2-$i2)");
+$ans3 = Formula("$c3(t^$i3)(1-t)^($deg3-$i3)");
+$ans4 = Formula("$c4(t^$i4)(1-t)^($deg4-$i4)");
+$ans5 = Formula("$c5(t^$i5)(1-t)^($deg5-$i5)");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write the formula for the [$ith1] Bernstein polynomial of degree [$deg1].
+
+Answer: [_______________________]{"$ans1"}
+
+Write the formula for the [$ith2] Bernstein polynomial of degree [$deg2].
+
+Answer: [_______________________]{"$ans2"}
+
+Write the formula for the [$ith3] Bernstein polynomial of degree [$deg3].
+
+Answer: [_______________________]{"$ans3"}
+
+Write the formula for the [$ith4] Bernstein polynomial of degree [$deg4].
+
+Answer: [_______________________]{"$ans4"}
+
+Write the formula for the [$ith5] Bernstein polynomial of degree [$deg5].
+
+Answer: [_______________________]{"$ans5"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The generic solution for the [`i^{\text{th}}`] Bernstein polynomial of degree [`n`] is [`{n \choose i}t^i(1-t)^{n-i}`].  That gives these answers to the questions above.
+
+[`{[$deg1] \choose [$i1]}t^{[$i1]}(1-t)^{[$deg1]-[$i1]}
+ =[$c1]t^{[$i1]}(1-t)^{[$deg1-$i1]}`]
+
+[`{[$deg2] \choose [$i2]}t^{[$i2]}(1-t)^{[$deg2]-[$i2]}
+ =[$c2]t^{[$i2]}(1-t)^{[$deg2-$i2]}`]
+
+[`{[$deg3] \choose [$i3]}t^{[$i3]}(1-t)^{[$deg3]-[$i3]}
+ =[$c3]t^{[$i3]}(1-t)^{[$deg3-$i3]}`]
+
+[`{[$deg4] \choose [$i4]}t^{[$i4]}(1-t)^{[$deg4]-[$i4]}
+ =[$c4]t^{[$i4]}(1-t)^{[$deg4-$i4]}`]
+
+[`{[$deg5] \choose [$i5]}t^{[$i5]}(1-t)^{[$deg5]-[$i5]}
+ =[$c5]t^{[$i5]}(1-t)^{[$deg5-$i5]}`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-5-BernsteinIntervals.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-5-BernsteinIntervals.pg
@@ -1,0 +1,118 @@
+##DESCRIPTION
+## Analyze cubic Bernstein polynomials
+##ENDDESCRIPTION
+
+## DBsubject('Algebra')
+## DBchapter('Polynomial equations and functions')
+## DBsection('Polynomial functions')
+## Date('04/03/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('12')
+## Problem1('5')
+##KEYWORDS('Bernstein polynomials','cubic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$e = "&eacute;";
+
+$graph = init_graph(-0.2,-0.2,1.2,1.2,axes=>[0,0],grid=>[6,6],size=>[400,400]); # xmin,ymin,xmax,ymax
+add_functions($graph, "(1-x)^3 for x in <0,1> using color:red and weight:2");
+add_functions($graph, "3*x*(1-x)^2 for x in <0,1> using color:green and weight:2");
+add_functions($graph, "3*x^2*(1-x) for x in <0,1> using color:blue and weight:2");
+add_functions($graph, "x^3 for x in <0,1> using color:black and weight:2");
+
+TEXT(beginproblem());
+BEGIN_PGML
+The four Bernstein polynomials of degree 3 are shown in the following graph.  Red shows [`(1-t)^3`], green shows [`3t(1-t)^2`], blue shows [`3t^2(1-t)`], and black shows [`t^3`].
+
+[@ image(insertGraph($graph), width=>400, height=>400, tex_size=>480) @]*
+
+On which interval is the first polynomial the greatest of the four?
+
+Answer: \[[_____]{0},[_____]{1/4})
+
+What percentage of [`[0,1]`] does that interval cover?
+
+Answer: [_____]{25}%
+
+On which interval is the second polynomial the greatest of the four?
+
+Answer: ([_____]{1/4},[_____]{1/2})
+
+What percentage of [`[0,1]`] does that interval cover?
+
+Answer: [_____]{25}%
+
+On which interval is the third polynomial the greatest of the four?
+
+Answer: ([_____]{1/2},[_____]{3/4})
+
+What percentage of [`[0,1]`] does that interval cover?
+
+Answer: [_____]{25}%
+
+On which interval is the fourth polynomial the greatest of the four?
+
+Answer: ([_____]{3/4},[_____]{1}\]
+
+What percentage of [`[0,1]`] does that interval cover?
+
+Answer: [_____]{25}%
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We can find where [`3t(1-t)^2`] surpasses [`(1-t)^3`] by setting them equal to one another.
+
+>> [`3t(1-t)^2=(1-t)^3`] <<
+
+>> [`4t^3-9t^2+6t-1=0`] <<
+
+This is difficult to solve with algebra (though not impossible).  You could guess that the solution is at about [`t=\frac14`], and confirm this by substitution.  Or you could use a computer algebra system (such as WolframAlpha) to find all solutions, which would give [`t=\frac14`] and [`t=1`], from which we're obviously concerned with just the first one.
+
+So the interval is [`\left[0,\frac14\right]`].  This is 25% of the entire interval [`[0,1]`].
+
+We can find where [`3t^2(1-t)`] surpasses [`3t(1-t)^2`] by setting them equal.
+
+>> [`3t^2(1-t)=3t(1-t)^2`] <<
+
+>> [`6t^3-9t^2+3t=0`] <<
+
+>> [`t(2t-1)(t-1)=0`] <<
+
+Thus [`t=0`] or [`t=\frac12`] or [`t=1`].  The one of these we care about is obviously [`t=\frac12`].
+
+Thus the interval is [`\left(\frac14,\frac12\right)`], which is 25% of the entire interval [`[0,1]`].
+
+We can find where [`t^3`] surpasses [`3t^2(1-t)`] by setting them equal.
+
+>> [`t^3=3t^2(1-t)`] <<
+
+>> [`4t^3-3t^2=0`] <<
+
+>> [`t^2(4t-3)=0`] <<
+
+Thus [`t=0`] or [`t=\frac34`].  The one of these we care about is obviously [`t=\frac34`].
+
+Thus the interval is [`\left(\frac12,\frac34\right)`], which is 25% of the entire interval [`[0,1]`].
+
+And furthermore the final interval is therefore [`\left(\frac34,1\right]`], another 25% of the whole.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-7-QuadraticAndQuarticBezierCurves.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-7-QuadraticAndQuarticBezierCurves.pg
@@ -1,0 +1,100 @@
+##DESCRIPTION
+## Given control points, create quadratic and quartic Bezier curves
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('04/04/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('12')
+## Problem1('7')
+##KEYWORDS('Bezier curves','control points','quadratic','quartic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+$showPartialCorrectAnswers = 1;
+
+$C1x = random( -9, 9 );
+$C1y = random( -9, 9 );
+$C2x = random( -9, 9 );
+$C2y = random( -9, 9 );
+$C3x = random( -9, 9 );
+$C3y = random( -9, 9 );
+
+$C4x = random( -9, 9 );
+$C4y = random( -9, 9 );
+$C4z = random( -9, 9 );
+$C5x = random( -9, 9 );
+$C5y = random( -9, 9 );
+$C5z = random( -9, 9 );
+$C6x = random( -9, 9 );
+$C6y = random( -9, 9 );
+$C6z = random( -9, 9 );
+$C7x = random( -9, 9 );
+$C7y = random( -9, 9 );
+$C7z = random( -9, 9 );
+$C8x = random( -9, 9 );
+$C8y = random( -9, 9 );
+$C8z = random( -9, 9 );
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write the formula for a quadratic B[$e]*zier curve with [`C_1=([$C1x],[$C1y])`], [`C_2=([$C2x],[$C2y])`], and [`C_3=([$C3x],[$C3y])`].
+
+[`\vec f(t)=`](
+[______________________________]{"(1-t)^2*$C1x + 2t*(1-t)*$C2x + t^2*$C3x"},
+[______________________________]{"(1-t)^2*$C1y + 2t*(1-t)*$C2y + t^2*$C3y"}
+)
+
+Write the formula for a quartic B[$e]*zier curve with [`C_1=([$C4x],[$C4y],[$C4z])`], [`C_2=([$C5x],[$C5y],[$C5z])`], [`C_3=([$C6x],[$C6y],[$C6z])`], [`C_4=([$C7x],[$C7y],[$C7z])`], and [`C_5=([$C8x],[$C8y],[$C8z])`].
+
+[`\vec g(t)=`](
+[______________________________]{"(1-t)^4*$C4x + 4t(1-t)^3*$C5x + 6t^2(1-t)^2*$C6x + 4t^3(1-t)*$C7x + t^4*$C8x"},
+[______________________________]{"(1-t)^4*$C4y + 4t(1-t)^3*$C5y + 6t^2(1-t)^2*$C6y + 4t^3(1-t)*$C7y + t^4*$C8y"},
+[______________________________]{"(1-t)^4*$C4z + 4t(1-t)^3*$C5z + 6t^2(1-t)^2*$C6z + 4t^3(1-t)*$C7z + t^4*$C8z"}
+)
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The generic formula for a quadratic B[$e]*zier curve:
+
+[`\vec f(t)=(1-t)^2C_1+2t(1-t)C_2+t^2C_3`]
+
+So in this case, using the control points in the problem, we have:
+
+[`\vec f(t)=\left((1-t)^2([$C1x])+2t(1-t)([$C2x])+t^2([$C3x]),
+             (1-t)^2([$C1y])+2t(1-t)([$C2y])+t^2([$C3y])\right)`]
+
+The generic formula for a quartic B[$e]*zier curve:
+
+[`\vec g(t)=(1-t)^4C_1+4t(1-t)^3C_2+6t^2(1-t)^2C_3+4t^3(1-t)C_4+t^4C_5`]
+
+So in this case, using the control points in the problem, we have:
+
+[`\vec g(t)=\Big(
+    (1-t)^4([$C4x])+4t(1-t)^3([$C5x])+6t^2(1-t)^2([$C6x])+4t^3(1-t)([$C7x])+t^4([$C8x]),`]
+
+>> [`(1-t)^4([$C4y])+4t(1-t)^3([$C5y])+6t^2(1-t)^2([$C6y])+4t^3(1-t)([$C7y])+t^4([$C8y]),`] <<
+
+>> [`(1-t)^4([$C4z])+4t(1-t)^3([$C5z])+6t^2(1-t)^2([$C6z])+4t^3(1-t)([$C7z])+t^4([$C8z])
+\Big)`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-9-QuinticBezierCurve.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/12-9-QuinticBezierCurve.pg
@@ -1,0 +1,52 @@
+##DESCRIPTION
+## Write the generic quintic Bezier curve formula
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Parameterized curves')
+## Date('04/04/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('12')
+## Problem1('9')
+##KEYWORDS('Bezier curves','control points','quintic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>Real);
+Context()->variables->add(A=>Real);
+Context()->variables->add(B=>Real);
+Context()->variables->add(C=>Real);
+Context()->variables->add(D=>Real);
+Context()->variables->add(E=>Real);
+Context()->variables->add(F=>Real);
+$showPartialCorrectAnswers = 1;
+
+$e = "&eacute;";
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write the formula for a quintic B[$e]*zier curve with control points [`A`], [`B`], [`C`], [`D`], [`E`], and [`F`].
+
+[`\vec f(t)=`]
+[____________________________________________________________]{"(1-t)^5*A + 5t(1-t)^4*B + 10t^2(1-t)^3*C + 10t^3(1-t)^2*D + 5t^4(1-t)*E + t^5*F"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec f(t)=(1-t)^5A + 5t(1-t)^4B + 10t^2(1-t)^3C + 10t^3(1-t)^2D + 5t^4(1-t)E + t^5F`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch12/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-1-CheckingBezierContinuity.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-1-CheckingBezierContinuity.pg
@@ -1,0 +1,306 @@
+##DESCRIPTION
+## Given control points for two Bezier curves, answer continuity questions
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - single variable')
+## DBchapter('Limits and continuity')
+## DBsection('Continuity - concept of')
+## Date('04/04/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('1')
+##KEYWORDS('Bezier curves','continuity','joining','scenes')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+# we will store the values of all points in one array, like so:
+# ( part a control point C1 x component,
+#   part a control point C1 y component,
+#   ...and so on through C4 y component,
+#   part a control point D1 x component,
+#   ...and so on through D4 y component,
+#   ...and so on through part d )
+@pts = ();
+for ( my $i = 0 ; $i < 64 ; $i++ ) { push( @pts, random( -5, 5 ) ); }
+
+# now we need to choose one of them that won't have even C^0 continuity
+@indices = ( 0, 1, 2, 3 );
+$which = random( 0, 3 );
+$notC0idx = $indices[$which];
+splice( @indices, $which, 1 );
+# now we need to ensure that it doesn't have that continuity
+$D1xi = 16 * $notC0idx + 8;
+$D1x = $pts[$D1xi];
+$C4x = $pts[$D1xi-2];
+if ( $D1x == $C4x ) { $pts[$D1xi]++; } # changes D1x
+
+# now we need to choose one of them that will be C^0 but not C^1
+$which = random( 0, 2 );
+$notC1idx = $indices[$which];
+splice( @indices, $which, 1 );
+# now we need to ensure that it has C^0 continuity
+$D1xi = 16 * $notC1idx + 8;
+$D1x = $pts[$D1xi];
+$D1y = $pts[$D1xi+1];
+$pts[$D1xi-2] = $D1x; # changes C4x
+$pts[$D1xi-1] = $D1y; # changes C4y
+# now we need to ensure that it does not have C^1 continuity
+$C3x = $pts[$D1xi-4];
+$C4x = $pts[$D1xi-2];
+$D2x = $pts[$D1xi+2];
+if ( $C4x - $C3x == $D2x - $D1x ) { $pts[$D1x+2]++; } # changes D2x
+
+# now we need to choose one of them that will be C^0 and C^1 but not C^2
+$which = random( 0, 1 );
+$notC2idx = $indices[$which];
+splice( @indices, $which, 1 );
+# now we need to ensure that it has C^0 continuity
+$D1xi = 16 * $notC2idx + 8;
+$D1x = $pts[$D1xi];
+$D1y = $pts[$D1xi+1];
+$pts[$D1xi-2] = $D1x; # changes C4x
+$pts[$D1xi-1] = $D1y; # changes C4y
+# now we need to ensure that it has C^1 continuity
+$C3x = $pts[$D1xi-4];
+$C3y = $pts[$D1xi-3];
+$C4x = $pts[$D1xi-2];
+$C4y = $pts[$D1xi-1];
+$pts[$D1xi+2] = $D1x + $C4x - $C3x; # changes D2x
+$pts[$D1xi+3] = $D1y + $C4y - $C3y; # changes D2y
+# now we need to ensure that it does not have C^2 continuity
+$C2x = $pts[$D1xi-6];
+$D2x = $pts[$D1xi+2];
+$D3x = $pts[$D1xi+4];
+if ( $C3x + ( $C3x - $C2x ) == $D2x + ( $D2x - $D3x ) ) {
+    $pts[$D1x+4]++; # changes D3x
+}
+
+# and the last one of them that will be C^0 and C^1 and C^2
+$allCidx = $indices[0];
+# now we need to ensure that it has C^0 continuity
+$D1xi = 16 * $allCidx + 8;
+$D1x = $pts[$D1xi];
+$D1y = $pts[$D1xi+1];
+$pts[$D1xi-2] = $D1x; # changes C4x
+$pts[$D1xi-1] = $D1y; # changes C4y
+# now we need to ensure that it has C^1 continuity
+$C3x = $pts[$D1xi-4];
+$C3y = $pts[$D1xi-3];
+$C4x = $pts[$D1xi-2];
+$C4y = $pts[$D1xi-1];
+$pts[$D1xi+2] = $D1x + $C4x - $C3x; # changes D2x
+$pts[$D1xi+3] = $D1y + $C4y - $C3y; # changes D2y
+# now we need to ensure that it has C^2 continuity
+$C2x = $pts[$D1xi-6];
+$C2y = $pts[$D1xi-5];
+$D2x = $pts[$D1xi+2];
+$D2y = $pts[$D1xi+3];
+$pts[$D1xi+4] = $C2x + 2*( $D2x - $C3x ); # changes D3x
+$pts[$D1xi+5] = $C2y + 2*( $D2y - $C3y ); # changes D3y
+
+$e = '&eacute;';
+
+@cs = ();
+@ds = ();
+for ( my $i = 0 ; $i < 4 ; $i++ ) {
+    my $cpart = '';
+    my $dpart = '';
+    for ( my $j = 0 ; $j < 4 ; $j++ ) {
+        $cpart = $cpart . 'C_' . ($j+1)
+                        . '=(' . $pts[16*$i+2*$j]
+                         . ',' . $pts[16*$i+2*$j+1] . ') ~ ~ ~ ~ ~';
+        $dpart = $dpart . 'D_' . ($j+1)
+                        . '=(' . $pts[16*$i+2*$j+8]
+                         . ',' . $pts[16*$i+2*$j+9] . ') ~ ~ ~ ~ ~';
+    }
+    push( @cs, '>> [`' . $cpart . '`] <<' );
+    push( @ds, '>> [`' . $dpart . '`] <<' );
+}
+
+@answerOptions = (
+    '(make a choice)',
+    'The joined curve would not have even C0 continuity.',
+    'The joined curve would have C0 continuity but not C1 continuity.',
+    'The joined curve would have C0 and C1 continuity but not C2 continuity.',
+    'The joined curve would have C0, C1, and C2 continuity.',
+    'None of the above.'
+);
+@correctAnswers = ( 0, 0, 0, 0 );
+$correctAnswers[$notC0idx] = 1;
+$correctAnswers[$notC1idx] = 2;
+$correctAnswers[$notC2idx] = 3;
+$correctAnswers[$allCidx] = 4;
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is/contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+Assume that you want to stitch together two cubic B[$e]*ier curves, the first with control points [`C_1`] through [`C_4`] and the second with control points [`D_1`] through [`D_4`]. For each set of control points given below, choose which of the levels of continuity discussed in this chapter ([`C^0`], [`C^1`], [`C^2`]) a path would have if we produced it by joining the two curves in succession.
+
+Part 1:
+
+[@ PGML($cs[0]) @]***
+
+[@ PGML($ds[0]) @]***
+
+Pick your answer from here:
+[___]{PopUp( [ @answerOptions ], $correctAnswers[0] )}
+
+Part 2:
+
+[@ PGML($cs[1]) @]***
+
+[@ PGML($ds[1]) @]***
+
+Pick your answer from here:
+[___]{PopUp( [ @answerOptions ], $correctAnswers[1] )}
+
+Part 3:
+
+[@ PGML($cs[2]) @]***
+
+[@ PGML($ds[2]) @]***
+
+Pick your answer from here:
+[___]{PopUp( [ @answerOptions ], $correctAnswers[2] )}
+
+Part 4:
+
+[@ PGML($cs[3]) @]***
+
+[@ PGML($ds[3]) @]***
+
+Pick your answer from here:
+[___]{PopUp( [ @answerOptions ], $correctAnswers[3] )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We can see that the control points from Part [$notC0idx+1] would not create a curve with even [`C^0`] continuity, because [`C_4\neq D_1`].
+
+>> [`C_4=([$pts[$notC0idx*16+6]],[$pts[$notC0idx*16+7]])`] <<
+
+>> [`D_1=([$pts[$notC0idx*16+8]],[$pts[$notC0idx*16+7]])`] <<
+
+We can see that the control points from Part [$notC1idx+1] would create a curve with [`C^0`] continuity but not [`C^1`] continuity, as follows.
+
+First, [`C_4 = D_1`].
+
+>> [`C_4=([$pts[$notC1idx*16+6]],[$pts[$notC1idx*16+7]])`] <<
+
+>> [`D_1=([$pts[$notC1idx*16+8]],[$pts[$notC1idx*16+7]])`] <<
+
+Second, [`C_4-C_3\neq D_2-D_1`].
+
+>> [`C_4-C_3=([$pts[$notC1idx*16+6]],[$pts[$notC1idx*16+7]])
+            -([$pts[$notC1idx*16+4]],[$pts[$notC1idx*16+5]])
+            =([$pts[$notC1idx*16+6]]-[$pts[$notC1idx*16+4]],
+              [$pts[$notC1idx*16+7]]-[$pts[$notC1idx*16+5]])
+            =([$pts[$notC1idx*16+6]-$pts[$notC1idx*16+4]],
+              [$pts[$notC1idx*16+7]-$pts[$notC1idx*16+5]])`] <<
+
+>> [`D_2-D_1=([$pts[$notC1idx*16+10]],[$pts[$notC1idx*16+11]])
+            -([$pts[$notC1idx*16+8]],[$pts[$notC1idx*16+9]])
+            =([$pts[$notC1idx*16+10]]-[$pts[$notC1idx*16+8]],
+              [$pts[$notC1idx*16+11]]-[$pts[$notC1idx*16+9]])
+            =([$pts[$notC1idx*16+10]-$pts[$notC1idx*16+8]],
+              [$pts[$notC1idx*16+11]-$pts[$notC1idx*16+9]])`] <<
+
+We can see that the control points from Part [$notC2idx+1] would create a curve with [`C^0`] and [`C^1`] continuity but not [`C^2`] continuity, as follows.
+
+First, [`C_4 = D_1`].
+
+>> [`C_4=([$pts[$notC2idx*16+6]],[$pts[$notC2idx*16+7]])`] <<
+
+>> [`D_1=([$pts[$notC2idx*16+8]],[$pts[$notC2idx*16+7]])`] <<
+
+Second, [`C_4-C_3 = D_2-D_1`].
+
+>> [`C_4-C_3=([$pts[$notC2idx*16+6]],[$pts[$notC2idx*16+7]])
+            -([$pts[$notC2idx*16+4]],[$pts[$notC2idx*16+5]])
+            =([$pts[$notC2idx*16+6]]-[$pts[$notC2idx*16+4]],
+              [$pts[$notC2idx*16+7]]-[$pts[$notC2idx*16+5]])
+            =([$pts[$notC2idx*16+6]-$pts[$notC2idx*16+4]],
+              [$pts[$notC2idx*16+7]-$pts[$notC2idx*16+5]])`] <<
+
+>> [`D_2-D_1=([$pts[$notC2idx*16+10]],[$pts[$notC2idx*16+11]])
+            -([$pts[$notC2idx*16+8]],[$pts[$notC2idx*16+9]])
+            =([$pts[$notC2idx*16+10]]-[$pts[$notC2idx*16+8]],
+              [$pts[$notC2idx*16+11]]-[$pts[$notC2idx*16+9]])
+            =([$pts[$notC2idx*16+10]-$pts[$notC2idx*16+8]],
+              [$pts[$notC2idx*16+11]-$pts[$notC2idx*16+9]])`] <<
+
+Finally, [`C_3+(C_3-C_2)\neq D_2+(D_2-D_3)`], which we can rephrase as [`2C_3-C_2\neq 2D_2-D_3`].
+
+>> [`2C_3-C_2=2([$pts[$notC2idx*16+4]],[$pts[$notC2idx*16+5]])
+             -([$pts[$notC2idx*16+2]],[$pts[$notC2idx*16+3]])
+             =(2\cdot[$pts[$notC2idx*16+4]]-[$pts[$notC2idx*16+2]],
+               2\cdot[$pts[$notC2idx*16+5]]-[$pts[$notC2idx*16+3]])
+             =([$pts[$notC2idx*16+4]*2-$pts[$notC2idx*16+2]],
+               [$pts[$notC2idx*16+5]*2-$pts[$notC2idx*16+3]])`] <<
+
+>> [`2D_2-D_3=2([$pts[$notC2idx*16+2+8]],[$pts[$notC2idx*16+3+8]])
+             -([$pts[$notC2idx*16+4+8]],[$pts[$notC2idx*16+5+8]])
+             =(2\cdot[$pts[$notC2idx*16+2+8]]-[$pts[$notC2idx*16+4+8]],
+               2\cdot[$pts[$notC2idx*16+3+8]]-[$pts[$notC2idx*16+5+8]])
+             =([$pts[$notC2idx*16+2+8]*2-$pts[$notC2idx*16+4+8]],
+               [$pts[$notC2idx*16+3+8]*2-$pts[$notC2idx*16+5+8]])`] <<
+
+We can see that the control points from Part [$allCidx+1] would create a curve with [`C^0`], [`C^1`], and [`C^2`] continuity, as follows.
+
+First, [`C_4 = D_1`].
+
+>> [`C_4=([$pts[$allCidx*16+6]],[$pts[$allCidx*16+7]])`] <<
+
+>> [`D_1=([$pts[$allCidx*16+8]],[$pts[$allCidx*16+7]])`] <<
+
+Second, [`C_4-C_3 = D_2-D_1`].
+
+>> [`C_4-C_3=([$pts[$allCidx*16+6]],[$pts[$allCidx*16+7]])
+            -([$pts[$allCidx*16+4]],[$pts[$allCidx*16+5]])
+            =([$pts[$allCidx*16+6]]-[$pts[$allCidx*16+4]],
+              [$pts[$allCidx*16+7]]-[$pts[$allCidx*16+5]])
+            =([$pts[$allCidx*16+6]-$pts[$allCidx*16+4]],
+              [$pts[$allCidx*16+7]-$pts[$allCidx*16+5]])`] <<
+
+>> [`D_2-D_1=([$pts[$allCidx*16+10]],[$pts[$allCidx*16+11]])
+            -([$pts[$allCidx*16+8]],[$pts[$allCidx*16+9]])
+            =([$pts[$allCidx*16+10]]-[$pts[$allCidx*16+8]],
+              [$pts[$allCidx*16+11]]-[$pts[$allCidx*16+9]])
+            =([$pts[$allCidx*16+10]-$pts[$allCidx*16+8]],
+              [$pts[$allCidx*16+11]-$pts[$allCidx*16+9]])`] <<
+
+Finally, [`C_3+(C_3-C_2) = D_2+(D_2-D_3)`], which we can rephrase as [`2C_3-C_2 = 2D_2-D_3`].
+
+>> [`2C_3-C_2=2([$pts[$allCidx*16+4]],[$pts[$allCidx*16+5]])
+             -([$pts[$allCidx*16+2]],[$pts[$allCidx*16+3]])
+             =(2\cdot[$pts[$allCidx*16+4]]-[$pts[$allCidx*16+2]],
+               2\cdot[$pts[$allCidx*16+5]]-[$pts[$allCidx*16+3]])
+             =([$pts[$allCidx*16+4]*2-$pts[$allCidx*16+2]],
+               [$pts[$allCidx*16+5]*2-$pts[$allCidx*16+3]])`] <<
+
+>> [`2D_2-D_3=2([$pts[$allCidx*16+2+8]],[$pts[$allCidx*16+3+8]])
+             -([$pts[$allCidx*16+4+8]],[$pts[$allCidx*16+5+8]])
+             =(2\cdot[$pts[$allCidx*16+2+8]]-[$pts[$allCidx*16+4+8]],
+               2\cdot[$pts[$allCidx*16+3+8]]-[$pts[$allCidx*16+5+8]])
+             =([$pts[$allCidx*16+2+8]*2-$pts[$allCidx*16+4+8]],
+               [$pts[$allCidx*16+3+8]*2-$pts[$allCidx*16+5+8]])`] <<
+
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-10a-CubicBezierFromPosVelAcc.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-10a-CubicBezierFromPosVelAcc.pg
@@ -1,0 +1,84 @@
+##DESCRIPTION
+## Compute a cubic Bezier curve from position, velocity, and acceleration data
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Integrals')
+## Date('04/05/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('9')
+##KEYWORDS('Bezier curves','integrals','cubic','position','velocity','acceleration')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>'Real');
+Context()->variables->add(P=>'Real');
+Context()->variables->add(Q=>'Real');
+Context()->variables->add(V=>'Real');
+Context()->variables->add(A=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+What are the control point of the cubic B[$e]*zier curve with initial position [`P`], final position [`Q`], initial velocity [`V`], and initial acceleration [`A`]?
+
+Answer:
+
+[`C_1`]=[_______________]{"P"}
+[`C_2`]=[_______________]{"P+V/3"}
+[`C_3`]=[_______________]{"A/6+P+2V/3"}
+[`C_4`]=[_______________]{"Q"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To guarantee the desired initial and final positions, we set [`C_1=P`] and [`C_4=Q`].  To guarantee the desired initial velocity, we set [`C_2=P+\frac13V`].  To guarantee the desired acceleration, we would like to substitute [`t=0`] into the acceleration formula for cubic B[$e]*zier curves.
+
+Recall that the cubic B[$e]*zier formula looks like this:
+
+>> [`\vec f(t)=(1-t)^3C_1+3t(1-t)^2C_2+3t^2(1-t)C_3+t^3C_4,`] <<
+
+which we can rearrange into a more easily differentiable form (as the textbook does),
+
+>> [`\vec f(t)=C_1+(3C_2-3C_1)t+(3C_3-6C_2+3C_1)t^2
+              +(C_4-3C_3+3C_2-C_1)t^3.`] <<
+
+This lets us compute a velocity function
+
+>> [`\vec f'(t)=(3C_2-3C_1)+2(3C_3-6C_2+3C_1)t+3(C_4-3C_3+3C_2-C_1)t^2`] <<
+
+and an acceleration function
+
+>> [`\vec f''(t)=2(3C_3-6C_2+3C_1)+6(C_4-3C_3+3C_2-C_1)t.`] <<
+
+Now we can use [`t=0`] in that function.
+
+>> [`\vec f''(0)=2(3C_3-6C_2+3C_1)=6C_3-12\left(P+\frac13V\right)+6P
+    =6C_3-6P-4V`] <<
+
+Setting [`\vec f''(0)=A`] gives [`C_3=\frac16A+P+\frac23V`].
+
+Thus our final answers are these:
+
+>> [`C_1=P ~ ~ ~ ~ ~ C_2=P+\frac13V ~ ~ ~ ~ ~
+     C_3=\frac16A+P+\frac23V ~ ~ ~ ~ ~ C_4=Q`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-2-EnsuringBezierContinuity.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-2-EnsuringBezierContinuity.pg
@@ -1,0 +1,162 @@
+##DESCRIPTION
+## Given some control points for two Bezier curves, provide others that ensure continuity
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - single variable')
+## DBchapter('Limits and continuity')
+## DBsection('Continuity - concept of')
+## Date('04/05/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('2')
+##KEYWORDS('Bezier curves','continuity','joining','scenes')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+# we will store the values of all points in one array, like so:
+# ( part a control point C1 x component,
+#   part a control point C1 y component,
+#   part a control point C1 z component,
+#   ...and so on through C4 z component,
+#   part a control point D1 x component,
+#   ...and so on through D4 z component,
+#   ...and so on through part c )
+@pts = ();
+for ( my $i = 0 ; $i < 72 ; $i++ ) { push( @pts, random( -9, 9 ) ); }
+
+# now for each part, make the desired type of continuity
+for ( my $i = 0 ; $i < 3 ; $i++ ) {
+    # in all cases, we have to fix C4 to be D1
+    $center = 24*$i + 12; # index of D1x
+    $pts[$center-3] = $pts[$center+0];
+    $pts[$center-2] = $pts[$center+1];
+    $pts[$center-1] = $pts[$center+2];
+    # in parts b and c, we have to choose D2 such that C4-C3=D2-D1,
+    # so we set D2=D1+C4-C3
+    if ( $i > 0 ) {
+        $pts[$center+3] = $pts[$center+0] + $pts[$center-3] - $pts[$center-6];
+        $pts[$center+4] = $pts[$center+1] + $pts[$center-2] - $pts[$center-5];
+        $pts[$center+5] = $pts[$center+2] + $pts[$center-1] - $pts[$center-4];
+    }
+    # in part c, we have to choose D3 such that C3+(C3-C2)=D2+(D2-D3),
+    # so we set D3=C2+2(D2-C3)
+    if ( $i > 1 ) {
+        $pts[$center+6] = $pts[$center-9]
+                        + 2*( $pts[$center+3] - $pts[$center-6] );
+        $pts[$center+7] = $pts[$center-8]
+                        + 2*( $pts[$center+4] - $pts[$center-5] );
+        $pts[$center+8] = $pts[$center-7]
+                        + 2*( $pts[$center+5] - $pts[$center-4] );
+    }
+}
+
+$e = '&eacute;';
+
+# now create the output we'll use to show the points to the reader
+@cs = ();
+@ds = ();
+for ( my $i = 0 ; $i < 3 ; $i++ ) {
+    my $cpart = '';
+    my $dpart = '';
+    for ( my $j = 0 ; $j < 4 ; $j++ ) {
+        if ( $j < 3 ) {
+            $cpart = $cpart . 'C_' . ($j+1)
+                            . '=(' . $pts[24*$i+3*$j]
+                             . ',' . $pts[24*$i+3*$j+1]
+                             . ',' . $pts[24*$i+3*$j+2] . ') ~ ~ ~ ~ ~';
+        }
+        if ( ( $i == 0 ) || ( $j == 0 ) || ( $j == 3 )
+          || ( ( $j == 2 ) && ( $i == 1 ) ) ) {
+            $dpart = $dpart . 'D_' . ($j+1)
+                            . '=(' . $pts[24*$i+3*$j+12]
+                             . ',' . $pts[24*$i+3*$j+13]
+                             . ',' . $pts[24*$i+3*$j+14] . ') ~ ~ ~ ~ ~';
+        }
+    }
+    push( @cs, '>> [`' . $cpart . '`] <<' );
+    push( @ds, '>> [`' . $dpart . '`] <<' );
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume that you want to stitch together two cubic B[$e]*ier curves, the first with control points [`C_1`] through [`C_4`] and the second with control points [`D_1`] through [`D_4`].
+
+Given the following control points, what must be the value of [`C_4`] to ensure [`C^0`] continuity (but not necessarily any other type of continuity)?
+
+[@ PGML($cs[0]) @]***
+
+[@ PGML($ds[0]) @]***
+
+Answer:
+
+[`C_4=`]([________]{$pts[9]},[________]{$pts[10]},[________]{$pts[11]})
+
+Given the following control points, what must be the values of [`C_4`] and [`D_2`] to ensure both [`C^0`] continuity and [`C^1`] continuity (but not necessarily any other type of continuity)?
+
+[@ PGML($cs[1]) @]***
+
+[@ PGML($ds[1]) @]***
+
+Answer:
+
+[`C_4=`]([________]{$pts[33]},[________]{$pts[34]},[________]{$pts[35]})
+
+[`D_2=`]([________]{$pts[39]},[________]{$pts[40]},[________]{$pts[41]})
+
+Given the following control points, what must be the values of [`C_4`], [`D_2`], and [`D_3`] to ensure [`C^0`] continuity, [`C^1`] continuity, and [`C^2`] continuity?
+
+[@ PGML($cs[2]) @]***
+
+[@ PGML($ds[2]) @]***
+
+Answer:
+
+[`C_4=`]([________]{$pts[57]},[________]{$pts[58]},[________]{$pts[59]})
+
+[`D_2=`]([________]{$pts[63]},[________]{$pts[64]},[________]{$pts[65]})
+
+[`D_3=`]([________]{$pts[66]},[________]{$pts[67]},[________]{$pts[68]})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+In part 1, to ensure [`C^0`] continuity, we must ensure [`C_4=D_1`], so we let [`C_4=([$pts[9]],[$pts[10]],[$pts[11]])`].
+
+In part 2, to ensure [`C^0`] continuity, we must ensure [`C_4=D_1`], so we let [`C_4=([$pts[33]],[$pts[34]],[$pts[35]])`].  In that same part, to ensure [`C^1`] continuity, we must ensure [`C_4-C_3=D_2-D_1`], so we let [`D_2=D_1+C_4-C_3`].
+
+>> [`D_2=([$pts[36]],[$pts[37]],[$pts[38]])
+        +([$pts[33]],[$pts[34]],[$pts[35]])
+        -([$pts[30]],[$pts[31]],[$pts[32]])
+        =([$pts[39]],[$pts[40]],[$pts[41]])`] <<
+
+In part 3, to ensure [`C^0`] continuity, we must ensure [`C_4=D_1`], so we let [`C_4=([$pts[57]],[$pts[58]],[$pts[59]])`].  In that same part, to ensure [`C^1`] continuity, we must ensure [`C_4-C_3=D_2-D_1`], so we let [`D_2=D_1+C_4-C_3`].
+
+>> [`D_2=([$pts[60]],[$pts[61]],[$pts[62]])
+        +([$pts[57]],[$pts[58]],[$pts[59]])
+        -([$pts[54]],[$pts[55]],[$pts[56]])
+        =([$pts[63]],[$pts[64]],[$pts[65]])`] <<
+
+In that same part, to ensure [`C^2`] continuity, we must ensure [`C_3+(C_3-C_2)=D_2+(D_2-D_3)`], so we let [`D_3=C_2+2(D_2-C_3)`].
+
+>> [`D_3=([$pts[51]],[$pts[52]],[$pts[53]])
+        +2(([$pts[63]],[$pts[64]],[$pts[65]])
+          -([$pts[54]],[$pts[55]],[$pts[56]]))
+        =([$pts[66]],[$pts[67]],[$pts[68]])`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-3-AdjustingBezierContinuity.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-3-AdjustingBezierContinuity.pg
@@ -1,0 +1,233 @@
+##DESCRIPTION
+## Given control points for two Bezier curves, change some to ensure continuity
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - single variable')
+## DBchapter('Limits and continuity')
+## DBsection('Continuity - concept of')
+## Date('04/05/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('3')
+##KEYWORDS('Bezier curves','continuity','joining','scenes')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+# we will store the values of all points in one array, like so:
+# ( part a control point C1 x component,
+#   part a control point C1 y component,
+#   part a control point C1 z component,
+#   ...and so on through C4 z component,
+#   part a control point D1 x component,
+#   ...and so on through D4 z component )
+@pts = ();
+for ( my $i = 0 ; $i < 24 ; $i++ ) { push( @pts, random( -9, 9 ) ); }
+
+# get('C',1,'x') is the x coordinate of point C1, etc.
+sub get {
+    my $CorD = shift( @_ );
+    my $subscript = shift( @_ );
+    my $coordinate = shift( @_ );
+    my $i = ( $CorD eq 'C' ) ? 0 : 1;
+    my $j = $subscript - 1;
+    my $k = ( $coordinate eq 'x' ) ? 0 :
+            ( $coordinate eq 'y' ) ? 1 : 2;
+    return $pts[$i*12+$j*3+$k];
+}
+# corresponding setter
+sub set {
+    my $CorD = shift( @_ );
+    my $subscript = shift( @_ );
+    my $coordinate = shift( @_ );
+    my $val = shift( @_ );
+    my $i = ( $CorD eq 'C' ) ? 0 : 1;
+    my $j = $subscript - 1;
+    my $k = ( $coordinate eq 'x' ) ? 0 :
+            ( $coordinate eq 'y' ) ? 1 : 2;
+    $pts[$i*12+$j*3+$k] = $val;
+}
+
+# ensure no C^0 continuity
+if ( get('C',4,'x') == get('D',1,'x') ) {
+    set('D',1,'x',get('D',1,'x')+1);
+}
+# ensure no C^1 continuity
+if ( get('C',4,'x')-get('C',3,'x') == get('D',2,'x')-get('D',1,'x') ) {
+    set('D',2,'x',get('D',2,'x')+1);
+}
+# ensure no C^2 continuity
+if ( 2*get('C',3,'x')-get('C',2,'x') == 2*get('D',2,'x')-get('D',3,'x') ) {
+    set('D',3,'x',get('D',3,'x')+1);
+}
+
+$e = '&eacute;';
+$stupid = 0;
+
+# now create the output we'll use to show the points to the reader
+$cpart = '';
+$dpart = '';
+for ( my $j = 0 ; $j < 4 ; $j++ ) {
+    $cpart = $cpart . 'C_' . ($j+1)
+                    . '=(' . $pts[24*$i+3*$j]
+                     . ',' . $pts[24*$i+3*$j+1]
+                     . ',' . $pts[24*$i+3*$j+2] . ') ~ ~ ~ ~ ~';
+    $dpart = $dpart . 'D_' . ($j+1)
+                    . '=(' . $pts[24*$i+3*$j+12]
+                     . ',' . $pts[24*$i+3*$j+13]
+                     . ',' . $pts[24*$i+3*$j+14] . ') ~ ~ ~ ~ ~';
+}
+$cpart = '[`' . $cpart . '`]';
+$dpart = '[`' . $dpart . '`]';
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume that you want to stitch together two cubic B[$e]*ier curves, the first with control points [`C_1`] through [`C_4`] and the second with control points [`D_1`] through [`D_4`], given here.
+
+[@ PGML($cpart) @]***
+
+[@ PGML($dpart) @]***
+
+---
+
+Assume we would like to modify the second curve to create some continuity between the two.
+Where would you put [`D_1`] to ensure [`C^0`] continuity?
+
+Answer:
+
+[`D_1=`]([________]{get('C',4,'x')},[________]{get('C',4,'y')},[________]{get('C',4,'z')})
+
+---
+
+Now instead assume we would like to modify the first curve to create some continuity between the two.
+Where would you put [`C_4`] instead to ensure [`C^0`] continuity?
+
+Answer:
+
+[`C_4=`]([________]{get('D',1,'x')},[________]{get('D',1,'y')},[________]{get('D',1,'z')})
+
+---
+
+Now thinking again about modifying the second curve rather than the first, where would you put [`D_1`] and [`D_2`] to ensure [`C^1`] continuity?
+
+Answer:
+
+[`D_1=`]([________]{get('C',4,'x')},[________]{get('C',4,'y')},[________]{get('C',4,'z')})
+
+[`D_2=`]([________]{get('C',4,'x')+get('C',4,'x')-get('C',3,'x')},[________]{get('C',4,'y')+get('C',4,'y')-get('C',3,'y')},[________]{get('C',4,'z')+get('C',4,'z')-get('C',3,'z')})
+
+---
+
+Now thinking again about modifying the first curve rather than the second, where would you put [`C_3`] and [`C_4`] instead to ensure [`C^1`] continuity?
+
+Answer:
+
+[`C_3=`]([________]{get('D',1,'x')+get('D',1,'x')-get('D',2,'x')},[________]{get('D',1,'y')+get('D',1,'y')-get('D',2,'y')},[________]{get('D',1,'z')+get('D',1,'z')-get('D',2,'z')})
+
+[`C_4=`]([________]{get('D',1,'x')},[________]{get('D',1,'y')},[________]{get('D',1,'z')})
+
+---
+
+Now thinking again about modifying the second curve rather than the first, where would you put [`D_1`], [`D_2`], and [`D_3`] to ensure [`C^2`] continuity?
+
+Answer:
+
+[`D_1=`]([________]{get('C',4,'x')},[________]{get('C',4,'y')},[________]{get('C',4,'z')})
+
+[`D_2=`]([________]{get('C',4,'x')+get('C',4,'x')-get('C',3,'x')},[________]{get('C',4,'y')+get('C',4,'y')-get('C',3,'y')},[________]{get('C',4,'z')+get('C',4,'z')-get('C',3,'z')})
+
+[`D_3=`]([________]{get('C',2,'x')+4*(get('C',4,'x')-get('C',3,'x'))},[________]{get('C',2,'y')+4*(get('C',4,'y')-get('C',3,'y'))},[________]{get('C',2,'z')+4*(get('C',4,'z')-get('C',3,'z'))})
+
+---
+
+Now thinking again about modifying the first curve rather than the second, where would you put [`C_2`], [`C_3`], and [`C_4`] instead to ensure [`C^2`] continuity?
+
+Answer:
+
+[`C_2=`]([________]{get('D',3,'x')+4*(get('D',1,'x')-get('D',2,'x'))},[________]{get('D',3,'y')+4*(get('D',1,'y')-get('D',2,'y'))},[________]{get('D',3,'z')+4*(get('D',1,'z')-get('D',2,'z'))})
+
+[`C_3=`]([________]{2*get('D',1,'x')-get('D',2,'x')},[________]{2*get('D',1,'y')-get('D',2,'y')},[________]{2*get('D',1,'z')-get('D',2,'z')})
+
+[`C_4=`]([________]{get('D',1,'x')},[________]{get('D',1,'y')},[________]{get('D',1,'z')})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To ensure [`C^0`] continuity by moving [`D_1`], we let [`D_1=C_4`], and [`C_4=([$stupid+get('C',4,'x')],[$stupid+get('C',4,'y')],[$stupid+get('C',4,'z')])`].
+
+To ensure [`C^0`] continuity by moving [`C_4`], we let [`C_4=D_1`], and [`D_1=([$stupid+get('D',1,'x')],[$stupid+get('D',1,'y')],[$stupid+get('D',1,'z')])`].
+
+To ensure [`C^1`] continuity by moving [`D_1`] and [`D_2`], we start the same way as before, setting [`D_1=C_4`], with [`D_1=([$stupid+get('C',4,'x')],[$stupid+get('C',4,'y')],[$stupid+get('C',4,'z')])`].  Then we satisfy [`C_4-C_3=D_2-D_1`] as follows.
+
+>> [`D_2=D_1+C_4-C_3=C_4+C_4-C_3=2C_4-C_3
+=2([$stupid+get('C',4,'x')],[$stupid+get('C',4,'y')],[$stupid+get('C',4,'z')])
+-([$stupid+get('C',3,'x')],[$stupid+get('C',3,'y')],[$stupid+get('C',3,'z')])
+=([$stupid+2*get('C',4,'x')-get('C',3,'x')],
+  [$stupid+2*get('C',4,'y')-get('C',3,'y')],
+  [$stupid+2*get('C',4,'z')-get('C',3,'z')])`] <<
+
+To ensure [`C^1`] continuity by moving [`C_3`] and [`C_4`], we start the same way as before, setting [`C_4=D_1`], with [`C_4=([$stupid+get('D',1,'x')],[$stupid+get('D',1,'y')],[$stupid+get('D',1,'z')])`].  Then we satisfy [`C_4-C_3=D_2-D_1`] as follows.
+
+>> [`C_3=C_4+D_1-D_2=D_1+D_1-D_2=2D_1-D_2
+=2([$stupid+get('D',1,'x')],[$stupid+get('D',1,'y')],[$stupid+get('D',1,'z')])
+-([$stupid+get('D',2,'x')],[$stupid+get('D',2,'y')],[$stupid+get('D',2,'z')])
+=([$stupid+2*get('D',1,'x')-get('D',2,'x')],
+  [$stupid+2*get('D',1,'y')-get('D',2,'y')],
+  [$stupid+2*get('D',1,'z')-get('D',2,'z')])`] <<
+
+To ensure [`C^2`] continuity by moving [`D_1`], [`D_2`], and [`D_3`], we start the same way as before, setting [`D_1=C_4`], with [`D_1=([$stupid+get('C',4,'x')],[$stupid+get('C',4,'y')],[$stupid+get('C',4,'z')])`].  Then we satisfy [`C_4-C_3=D_2-D_1`] the same way as before:
+
+>> [`D_2=D_1+C_4-C_3=C_4+C_4-C_3=2C_4-C_3
+=2([$stupid+get('C',4,'x')],[$stupid+get('C',4,'y')],[$stupid+get('C',4,'z')])
+-([$stupid+get('C',3,'x')],[$stupid+get('C',3,'y')],[$stupid+get('C',3,'z')])
+=([$stupid+2*get('C',4,'x')-get('C',3,'x')],
+  [$stupid+2*get('C',4,'y')-get('C',3,'y')],
+  [$stupid+2*get('C',4,'z')-get('C',3,'z')])`] <<
+
+But now we must also satisfy [`C_3+(C_3-C_2)=D_2+(D_2-D_3)`], which we do as follows.
+
+>> [`D_3=C_2+2(D_2-C_3)=C_2+2((D_1+C_4-C_3)-C_3)=C_2+2((C_4+C_4-C_3)-C_3)=C_2+4(C_4-C_3)`] <<
+
+>> [`=([$stupid+get('C',2,'x')],[$stupid+get('C',2,'y')],[$stupid+get('C',2,'z')])
++4(([$stupid+get('C',4,'x')],[$stupid+get('C',4,'y')],[$stupid+get('C',4,'z')])
+  -([$stupid+get('C',3,'x')],[$stupid+get('C',3,'y')],[$stupid+get('C',3,'z')]))
+=([$stupid+get('C',2,'x')+4*(get('C',4,'x')-get('C',3,'x'))],
+  [$stupid+get('C',2,'y')+4*(get('C',4,'y')-get('C',3,'y'))],
+  [$stupid+get('C',2,'z')+4*(get('C',4,'z')-get('C',3,'z'))])`] <<
+
+To ensure [`C^2`] continuity by moving [`C_2`], [`C_3`], and [`C_4`], we start the same way as before, setting [`C_4=D_1`], with [`C_4=([$stupid+get('D',1,'x')],[$stupid+get('D',1,'y')],[$stupid+get('D',1,'z')])`].  Then we satisfy [`C_4-C_3=D_2-D_1`] as follows.
+
+>> [`C_3=C_4+D_1-D_2=D_1+D_1-D_2=2D_1-D_2
+=2([$stupid+get('D',1,'x')],[$stupid+get('D',1,'y')],[$stupid+get('D',1,'z')])
+-([$stupid+get('D',2,'x')],[$stupid+get('D',2,'y')],[$stupid+get('D',2,'z')])
+=([$stupid+2*get('D',1,'x')-get('D',2,'x')],
+  [$stupid+2*get('D',1,'y')-get('D',2,'y')],
+  [$stupid+2*get('D',1,'z')-get('D',2,'z')])`] <<
+
+But now we must also satisfy [`C_3+(C_3-C_2)=D_2+(D_2-D_3)`], which we do as follows.
+
+>> [`C_2=D_3+2(C_3-D_2)=D_3+2((C_4+D_1-D_2)-D_2)=D_3+2((D_1+D_1-D_2)-D_2)=D_3+4(D_1-D_2)`] <<
+
+>> [`=([$stupid+get('D',3,'x')],[$stupid+get('D',3,'y')],[$stupid+get('D',3,'z')])
++4(([$stupid+get('D',1,'x')],[$stupid+get('D',1,'y')],[$stupid+get('D',1,'z')])
+  -([$stupid+get('D',2,'x')],[$stupid+get('D',2,'y')],[$stupid+get('D',2,'z')]))
+=([$stupid+get('D',3,'x')+4*(get('D',1,'x')-get('D',2,'x'))],
+  [$stupid+get('D',3,'y')+4*(get('D',1,'y')-get('D',2,'y'))],
+  [$stupid+get('D',3,'z')+4*(get('D',1,'z')-get('D',2,'z'))])`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-5-HigherBezierDerivatives.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-5-HigherBezierDerivatives.pg
@@ -1,0 +1,66 @@
+##DESCRIPTION
+## Consider higher-order derivatives of a cubic Bezier curve
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Differentiation of multivariable functions')
+## DBsection('Partial derivatives')
+## Date('04/05/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('5')
+##KEYWORDS('Bezier curves','derivatives','quadratic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>'Real');
+Context()->variables->add(A=>'Real');
+Context()->variables->add(B=>'Real');
+Context()->variables->add(C=>'Real');
+Context()->variables->add(D=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a cubic B[$e]*zier curve with control points [`A`], [`B`], [`C`], and [`D`].
+
+The third derivative of position is sometimes called *jerk*.  What is the formula for the jerk of a cubic B[$e]*zier curve in terms of its control points?
+
+Answer: [____________________________________]{"6*(D-3*C+3*B-A)"}
+
+What is the fourth derivative of a cubic B[$e]*zier curve?
+
+Answer: [____________________________________]{"0"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+From the text, we know that
+
+>> [`\vec f'(t) = (3B-3A)+2(3C-6B+3A)t + 3(D-3C+3B-A)t^2`] <<
+
+We can differentiate twice to obtain the first answer.
+
+>> [`\vec f''(t) = 2(3C-6B+3A) + 6(D-3C+3B-A)t`] <<
+
+>> [`\vec f'''(t) = 6(D-3C+3B-A)`] <<
+
+The fourth derivative is the second answer to the problem, and because there are no [`t`]'s in [`\vec f'''(t)`], we know that [`\vec f''''(t)=0`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-6-QuadraticBezierDerivatives.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-6-QuadraticBezierDerivatives.pg
@@ -1,0 +1,70 @@
+##DESCRIPTION
+## Compute various derivatives of a quadratic Bezier curve
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Differentiation of multivariable functions')
+## DBsection('Partial derivatives')
+## Date('04/05/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('6')
+##KEYWORDS('Bezier curves','derivatives','quadratic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>'Real');
+Context()->variables->add(A=>'Real');
+Context()->variables->add(B=>'Real');
+Context()->variables->add(C=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a quadratic B[$e]*zier curve with control points [`A`], [`B`], and [`C`].
+
+What is its first derivative?
+
+Answer: [____________________________________]{"(2B-2A)+2(C-2B+A)t"}
+
+What is its second derivative?
+
+Answer: [____________________________________]{"2(C-2B+A)"}
+
+What is its third derivative?
+
+Answer: [____________________________________]{"0"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The quadratic B[$e]*zier curve can be simplified as follows.
+
+>> [`\vec f(t)=(1-t)^2A + 2t(1-t)B + t^2C
+              =A+(2B-2A)t + (C-2B+A)t^2`] <<
+
+We can then differentiate to find all the answers requested.
+
+>> [`\vec f'(t)=(2B-2A) + 2(C-2B+A)t`] <<
+
+>> [`\vec f''(t)=2(C-2B+A)`] <<
+
+>> [`\vec f'''(t)=0`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-9-CubicBezierFromAccelerationData.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/13-9-CubicBezierFromAccelerationData.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+## Compute a cubic Bezier curve from acceleration data
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Calculus of vector valued functions')
+## DBsection('Integrals')
+## Date('04/05/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('13')
+## Problem1('9')
+##KEYWORDS('Bezier curves','integrals','cubic','acceleration')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>'Real');
+Context()->variables->add(A=>'Real');
+Context()->variables->add(B=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+What are the control point of the cubic B[$e]*zier curve with initial position at the origin, initial velocity zero, and constant acceleration [`A`]?
+
+Answer:
+
+[`C_1`]=[_______________]{"0"}
+[`C_2`]=[_______________]{"0"}
+[`C_3`]=[_______________]{"A/6"}
+[`C_4`]=[_______________]{"A/2"}
+
+What are the control points of the cubic B[$e]*zier curve with initial position at the origin, initial velocity zero, and acceleration [`\vec a(t)=At+B`]?
+
+Answer:
+
+[`C_1`]=[_______________]{"0"}
+[`C_2`]=[_______________]{"0"}
+[`C_3`]=[_______________]{"B/6"}
+[`C_4`]=[_______________]{"A/6+B/2"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+With initial position and velocity zero, we have [`C_1 = C_2 = 0`], giving
+
+>> [`\vec f(t) = 3t^2(1-t)C_3 + t^3C_4 = 3C_3t^2 + (C4-3C_3)t^3.`] <<
+
+The corresponding acceleration function is [`6C_3+6(C_4-3C_3)t`].  For that to be a constant, we must have [`C4-3C_3 = 0`], and thus [`6C_3 = A`], or [`C_3 = \frac16A`]. Substituting that into [`C_4-3C_3 = 0`] gives us that [`C4 = \frac12A`]. Thus the answer is as follows.
+
+>> [`C_1=0 ~ ~ ~ ~ ~ C_2=0 ~ ~ ~ ~ ~ C_3=\frac16A ~ ~ ~ ~ ~ C_4=\frac12A`] <<
+
+Using the same formula as above, we set [`6C_3+6(C_4-3C_3)t=At+B`].  When [`t=0`] this gives us that [`6C_3=B`], or [`C_3=\frac16B`].  Choosing any other value of [`t`] will let us solve for [`C_4`], and teh result will be [`C_4=\frac16A+\frac12B`].
+
+>> [`C_1=0 ~ ~ ~ ~ ~ C_2=0 ~ ~ ~ ~ ~ C_3=\frac16B ~ ~ ~ ~ ~ C_4=\frac16A+\frac12B`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch13/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-1-ComputePointsOnBezierSurface.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-1-ComputePointsOnBezierSurface.pg
@@ -1,0 +1,240 @@
+##DESCRIPTION
+## Given a control net for a Bezier surface, compute some points on it
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Concepts for multivariable functions')
+## DBsection('Parameterized surfaces')
+## Date('04/19/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('14')
+## Problem1('1')
+##KEYWORDS('Bezier surfaces','parameterized surfaces')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+# we will store the values of all points in one array, like so:
+# ( C_{1,1}.x, C_{1,1}.y, C_{1,1}.z,
+#   C_{1,2}.x, C_{1,2}.y, C_{1,2}.z,
+#   C_{1,3}.x, C_{1,3}.y, C_{1,3}.z,
+#   C_{2,1}.x, C_{2,1}.y, C_{2,1}.z,
+#   ...
+#   C_{3,3}.x, C_{3,3}.y, C_{3,3}.z )
+@pts = ();
+$nrows = 3;
+$ncols = 3;
+$ndims = 3;
+sub set {
+    my $row = shift( @_ );
+    my $col = shift( @_ );
+    my $coord = shift( @_ ); # 0=x, 1=y, 2=z
+    my $val = shift( @_ );
+    $pts[$ndims*($ncols*$row+$col)+$coord] = $val;
+}
+sub get {
+    my $row = shift( @_ );
+    my $col = shift( @_ );
+    my $coord = shift( @_ ); # 0=x, 1=y, 2=z
+    return $pts[$ndims*($ncols*$row+$col)+$coord];
+}
+for ( my $r = 0 ; $r < $nrows ; $r++ ) {
+    for ( my $c = 0 ; $c < $ncols ; $c++ ) {
+        for ( my $d = 0 ; $d < $ndims ; $d++ ) {
+            set( $r, $c, $d, random( -9, 9 ) );
+        }
+    }
+}
+
+$e = '&eacute;';
+
+@showRows = ();
+for ( my $r = 0 ; $r < $nrows ; $r++ ) {
+    my $thisrow = '';
+    for ( my $c = 0 ; $c < $ncols ; $c++ ) {
+        if ( $c > 0 ) { $thisrow .= '~ ~ ~ ~ ~'; }
+        $thisrow .= 'C_{' . ($r+1) . ',' . ($c+1) . '}=('
+                  . get($r,$c,0) . ','
+                  . get($r,$c,1) . ','
+                  . get($r,$c,2) . ')';
+    }
+    push( @showRows, $thisrow );
+}
+
+$u1 = random( 0, 1 );
+$v1 = random( 0, 1 );
+$u2 = random( 0, 1 );
+$v2 = random( 0, 1 );
+$u3 = random( 0.1, 0.9, 0.1 );
+$v3 = random( 0.1, 0.9, 0.1 );
+
+sub deg2bez {
+    my $C1 = shift( @_ );
+    my $C2 = shift( @_ );
+    my $C3 = shift( @_ );
+    my $t = shift( @_ );
+    return (1-$t)**2*$C1 + 2*$t*(1-$t)*$C2 + $t**2*$C3;
+}
+sub g {
+    my $u = shift( @_ );
+    my $v = shift( @_ );
+    my $coord = shift( @_ );
+    return deg2bez(
+        deg2bez( get(0,0,$coord), get(0,1,$coord), get(0,2,$coord), $v ),
+        deg2bez( get(1,0,$coord), get(1,1,$coord), get(1,2,$coord), $v ),
+        deg2bez( get(2,0,$coord), get(2,1,$coord), get(2,2,$coord), $v ),
+        $u
+    );
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a B[$e]*zier surface defined by the following control net.
+
+>> [`[$showRows[0]]`] <<
+
+>> [`[$showRows[1]]`] <<
+
+>> [`[$showRows[2]]`] <<
+
+Assume the surface is described by the function [`\vec g(u,v)`].
+
+What is [`\vec g([$u1],[$v1])?`]
+Answer:
+([________]{g($u1,$v1,0)},[________]{g($u1,$v1,1)},[________]{g($u1,$v1,2)})
+
+What is [`\vec g([$u2],[$v2])?`]
+Answer:
+([________]{g($u2,$v2,0)},[________]{g($u2,$v2,1)},[________]{g($u2,$v2,2)})
+
+What is [`\vec g([$u3],[$v3])?`]
+Answer:
+([________]{g($u3,$v3,0)},[________]{g($u3,$v3,1)},[________]{g($u3,$v3,2)})
+END_PGML
+
+$z = 0;
+
+BEGIN_PGML_SOLUTION
+We do here just the third of the three questions, which is the most difficult.  The others can be solved just by choosing the appropriate corner of the control net.
+
+To compute [`\vec g([$u3],[$v3])`], let's use formula 14.4 from the text.
+
+>> [`\vec g([$u3],[$v3])
+    =\sum_{i=0}^2 b_{2,i}([$u3]) \sum_{j=0}^2 b_{2,j}([$v3]) C_{i+1,j+1}`] <<
+
+Let's work on the inner summation first.
+
+>> [`\sum_{j=0}^2 b_{2,j}([$v3]) C_{i+1,j+1}
+    =b_{2,0}([$v3])C_{i+1,1} + b_{2,1}([$v3])C_{i+1,2} + b_{2,2}([$v3])C_{i+1,3}`] <<
+
+>> [`=(1-[$v3])^2C_{i+1,1} + 2([$v3])(1-[$v3])C_{i+1,2} + [$v3]^2C_{i+1,3}`] <<
+
+>> [`=[$z+(1-$v3)**2]C_{i+1,1} + [$z+2*$v3*(1-$v3)]C_{i+1,2} + [$v3**2]C_{i+1,3}`] <<
+
+We can now place this inside the outer sum.
+
+>> [`\vec g([$u3],[$v3])
+    =\sum_{i=0}^2 b_{2,i}([$u3])
+    \left(
+        [$z+(1-$v3)**2]C_{i+1,1} + [$z+2*$v3*(1-$v3)]C_{i+1,2} + [$v3**2]C_{i+1,3}
+    \right)`] <<
+
+>> [`=b_{2,0}([$u3])\left(
+        [$z+(1-$v3)**2]C_{1,1} + [$z+2*$v3*(1-$v3)]C_{1,2} + [$v3**2]C_{1,3}
+    \right)`] <<
+
+>> [`+b_{2,1}([$u3])\left(
+        [$z+(1-$v3)**2]C_{2,1} + [$z+2*$v3*(1-$v3)]C_{2,2} + [$v3**2]C_{2,3}
+    \right)`] <<
+
+>> [`+b_{2,2}([$u3])\left(
+        [$z+(1-$v3)**2]C_{3,1} + [$z+2*$v3*(1-$v3)]C_{3,2} + [$v3**2]C_{3,3}
+    \right)`] <<
+
+>> [`=[$z+(1-$u3)**2]\left(
+        [$z+(1-$v3)**2](
+            [$z+get(0,0,0)],
+            [$z+get(0,0,1)],
+            [$z+get(0,0,2)]
+        )
+      + [$z+2*$v3*(1-$v3)](
+            [$z+get(0,1,0)],
+            [$z+get(0,1,1)],
+            [$z+get(0,1,2)]
+        )
+      + [$v3**2](
+            [$z+get(0,2,0)],
+            [$z+get(0,2,1)],
+            [$z+get(0,2,2)]
+        )
+    \right)`] <<
+
+>> [`+[$z+2*$u3*(1-$u3)]\left(
+        [$z+(1-$v3)**2](
+            [$z+get(1,0,0)],
+            [$z+get(1,0,1)],
+            [$z+get(1,0,2)]
+        )
+      + [$z+2*$v3*(1-$v3)](
+            [$z+get(1,1,0)],
+            [$z+get(1,1,1)],
+            [$z+get(1,1,2)]
+        )
+      + [$v3**2](
+            [$z+get(1,2,0)],
+            [$z+get(1,2,1)],
+            [$z+get(1,2,2)]
+        )
+    \right)`] <<
+
+>> [`+[$u3**2]\left(
+        [$z+(1-$v3)**2](
+            [$z+get(2,0,0)],
+            [$z+get(2,0,1)],
+            [$z+get(2,0,2)]
+        )
+      + [$z+2*$v3*(1-$v3)](
+            [$z+get(2,1,0)],
+            [$z+get(2,1,1)],
+            [$z+get(2,1,2)]
+        )
+      + [$v3**2](
+            [$z+get(2,2,0)],
+            [$z+get(2,2,1)],
+            [$z+get(2,2,2)]
+        )
+    \right)`] <<
+
+>> [`=[$z+(1-$u3)**2]\left(
+        [$z+deg2bez(get(0,0,0),get(0,1,0),get(0,2,0),$v3)],
+        [$z+deg2bez(get(0,0,1),get(0,1,1),get(0,2,1),$v3)],
+        [$z+deg2bez(get(0,0,2),get(0,1,2),get(0,2,2),$v3)]
+    \right)+[$z+2*$u3*(1-$u3)]\left(
+        [$z+deg2bez(get(1,0,0),get(1,1,0),get(1,2,0),$v3)],
+        [$z+deg2bez(get(1,0,1),get(1,1,1),get(1,2,1),$v3)],
+        [$z+deg2bez(get(1,0,2),get(1,1,2),get(1,2,2),$v3)]
+    \right)+[$u3**2]\left(
+        [$z+deg2bez(get(2,0,0),get(2,1,0),get(2,2,0),$v3)],
+        [$z+deg2bez(get(2,0,1),get(2,1,1),get(2,2,1),$v3)],
+        [$z+deg2bez(get(2,0,2),get(2,1,2),get(2,2,2),$v3)]
+    \right)`] <<
+
+>> [`=([$z+g($u3,$v3,0)],[$z+g($u3,$v3,1)],[$z+g($u3,$v3,2)])`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-3-CanFormTranslationalSurface.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-3-CanFormTranslationalSurface.pg
@@ -1,0 +1,164 @@
+##DESCRIPTION
+## Given two sets of control points, can we form a translational Bezier surface?
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Concepts for multivariable functions')
+## DBsection('Parameterized surfaces')
+## Date('04/19/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('14')
+## Problem1('3')
+##KEYWORDS('Bezier surfaces','parameterized surfaces','translational surfaces')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$C11x = random( -9, 9 );
+$C12x = random( -9, 9 );
+$C13x = random( -9, 9 );
+$C14x = random( -9, 9 );
+$C11y = random( -9, 9 );
+$C12y = random( -9, 9 );
+$C13y = random( -9, 9 );
+$C14y = random( -9, 9 );
+$C11z = random( -9, 9 );
+$C12z = random( -9, 9 );
+$C13z = random( -9, 9 );
+$C14z = random( -9, 9 );
+
+$C21x = random( -9, 9 );
+$C22x = random( -9, 9 );
+$C23x = random( -9, 9 );
+$C24x = random( -9, 9 );
+$C21y = random( -9, 9 );
+$C22y = random( -9, 9 );
+$C23y = random( -9, 9 );
+$C24y = random( -9, 9 );
+$C21z = random( -9, 9 );
+$C22z = random( -9, 9 );
+$C23z = random( -9, 9 );
+$C24z = random( -9, 9 );
+
+$C31x = random( -9, 9 );
+$C32x = random( -9, 9 );
+$C33x = random( -9, 9 );
+$C34x = random( -9, 9 );
+$C31y = random( -9, 9 );
+$C32y = random( -9, 9 );
+$C33y = random( -9, 9 );
+$C34y = random( -9, 9 );
+$C31z = random( -9, 9 );
+$C32z = random( -9, 9 );
+$C33z = random( -9, 9 );
+$C34z = random( -9, 9 );
+
+$C41x = random( -9, 9 );
+$C42x = random( -9, 9 );
+$C43x = random( -9, 9 );
+$C44x = random( -9, 9 );
+$C41y = random( -9, 9 );
+$C42y = random( -9, 9 );
+$C43y = random( -9, 9 );
+$C44y = random( -9, 9 );
+$C41z = random( -9, 9 );
+$C42z = random( -9, 9 );
+$C43z = random( -9, 9 );
+$C44z = random( -9, 9 );
+
+$which = random( 1, 2 );
+if ( $which == 1 ) {
+    $C21x = $C11x;
+    $C21y = $C11y;
+    $C21z = $C11z;
+    $C41x = $C31x + non_zero_random( -3, 3 );
+    $C41y = $C31y + non_zero_random( -3, 3 );
+    $C41z = $C31z + non_zero_random( -3, 3 );
+} else {
+    $C21x = $C11x + non_zero_random( -3, 3 );
+    $C21y = $C11y + non_zero_random( -3, 3 );
+    $C21z = $C11z + non_zero_random( -3, 3 );
+    $C41x = $C31x;
+    $C41y = $C31y;
+    $C41z = $C31z;
+}
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is multiple choice, you are permitted ONLY ONE ATTEMPT.  Use it wisely.*
+
+Consider two B[$e]*zier curves, one defined by the control points
+
+>> [`([$C11x],[$C11y],[$C11z]),
+     ([$C12x],[$C12y],[$C12z]),
+     ([$C13x],[$C13y],[$C13z]),
+     ([$C14x],[$C14y],[$C14z])`] <<
+
+and one defined by the control points
+
+>> [`([$C21x],[$C21y],[$C21z]),
+     ([$C22x],[$C22y],[$C22z]),
+     ([$C23x],[$C23y],[$C23z]),
+     ([$C24x],[$C24y],[$C24z]).`] <<
+
+Are these two curves ready to be used to form a translational surface?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'Yes',
+  'No',
+  'Not enough information is available to answer'
+) ], ($which==1)?'Yes':'No' )}
+
+Consider another two B[$e]*zier curves, one defined by the control points
+
+>> [`([$C31x],[$C31y],[$C31z]),
+     ([$C32x],[$C32y],[$C32z]),
+     ([$C33x],[$C33y],[$C33z]),
+     ([$C34x],[$C34y],[$C34z])`] <<
+
+and one defined by the control points
+
+>> [`([$C41x],[$C41y],[$C41z]),
+     ([$C42x],[$C42y],[$C42z]),
+     ([$C43x],[$C43y],[$C43z]),
+     ([$C44x],[$C44y],[$C44z]).`] <<
+
+Are these two curves ready to be used to form a translational surface?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'Yes',
+  'No',
+  'Not enough information is available to answer'
+) ], ($which==2)?'Yes':'No' )}
+END_PGML
+
+$z = '';
+
+BEGIN_PGML_SOLUTION
+We compare the first control point of each curve to see if they match.  If so, then we are able to form a translational surface from the two curves.
+
+For the first question, the two starting control points are [`([$C11x],[$C11y],[$C11z])`] and [`([$C21x],[$C21y],[$C21z])`], which are [$z.(($which==1)?'equal':'not equal')], so we [$z.(($which==1)?'can':'cannot')] form a translational surface.
+
+For the second question, the two starting control points are [`([$C31x],[$C31y],[$C31z])`] and [`([$C41x],[$C41y],[$C41z])`], which are [$z.(($which==2)?'equal':'not equal')], so we [$z.(($which==2)?'can':'cannot')] form a translational surface.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-3-FormTranslationalSurface.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-3-FormTranslationalSurface.pg
@@ -1,0 +1,144 @@
+##DESCRIPTION
+## Given two sets of control points that can form a translational Bezier surface, give the control net
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Concepts for multivariable functions')
+## DBsection('Parameterized surfaces')
+## Date('04/19/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('14')
+## Problem1('3')
+##KEYWORDS('Bezier surfaces','parameterized surfaces','translational surfaces')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$C11x = random( -9, 9 );
+$C12x = random( -9, 9 );
+$C13x = random( -9, 9 );
+$C14x = random( -9, 9 );
+$C11y = random( -9, 9 );
+$C12y = random( -9, 9 );
+$C13y = random( -9, 9 );
+$C14y = random( -9, 9 );
+$C11z = random( -9, 9 );
+$C12z = random( -9, 9 );
+$C13z = random( -9, 9 );
+$C14z = random( -9, 9 );
+
+$C21x = random( -9, 9 );
+$C31x = random( -9, 9 );
+$C41x = random( -9, 9 );
+$C21y = random( -9, 9 );
+$C31y = random( -9, 9 );
+$C41y = random( -9, 9 );
+$C21z = random( -9, 9 );
+$C31z = random( -9, 9 );
+$C41z = random( -9, 9 );
+
+$C22x = $C21x + $C12x - $C11x;
+$C22y = $C21y + $C12y - $C11y;
+$C22z = $C21z + $C12z - $C11z;
+$C32x = $C31x + $C12x - $C11x;
+$C32y = $C31y + $C12y - $C11y;
+$C32z = $C31z + $C12z - $C11z;
+$C42x = $C41x + $C12x - $C11x;
+$C42y = $C41y + $C12y - $C11y;
+$C42z = $C41z + $C12z - $C11z;
+$C23x = $C22x + $C13x - $C12x;
+$C23y = $C22y + $C13y - $C12y;
+$C23z = $C22z + $C13z - $C12z;
+$C33x = $C32x + $C13x - $C12x;
+$C33y = $C32y + $C13y - $C12y;
+$C33z = $C32z + $C13z - $C12z;
+$C43x = $C42x + $C13x - $C12x;
+$C43y = $C42y + $C13y - $C12y;
+$C43z = $C42z + $C13z - $C12z;
+$C24x = $C23x + $C14x - $C13x;
+$C24y = $C23y + $C14y - $C13y;
+$C24z = $C23z + $C14z - $C13z;
+$C34x = $C33x + $C14x - $C13x;
+$C34y = $C33y + $C14y - $C13y;
+$C34z = $C33z + $C14z - $C13z;
+$C44x = $C43x + $C14x - $C13x;
+$C44y = $C43y + $C14y - $C13y;
+$C44z = $C43z + $C14z - $C13z;
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider two B[$e]*zier curves, one defined by the control points
+
+>> [`([$C11x],[$C11y],[$C11z]),
+     ([$C12x],[$C12y],[$C12z]),
+     ([$C13x],[$C13y],[$C13z]),
+     ([$C14x],[$C14y],[$C14z])`] <<
+
+and one defined by the control points
+
+>> [`([$C11x],[$C11y],[$C11z]),
+     ([$C21x],[$C21y],[$C21z]),
+     ([$C31x],[$C31y],[$C31z]),
+     ([$C41x],[$C41y],[$C41z]).`] <<
+
+These two curves are ready to be used to form a translational surface.  Give the rest of the control net for that surface.
+
+[`C_{1,1}=([$C11x],[$C11y],[$C11z])`],
+[`C_{1,2}=([$C12x],[$C12y],[$C12z])`],
+[`C_{1,3}=([$C13x],[$C13y],[$C13z])`],
+[`C_{1,4}=([$C14x],[$C14y],[$C14z])`],
+
+[`C_{2,1}=([$C21x],[$C21y],[$C21z])`],
+[`C_{2,2}=`]([___]{$C22x},[___]{$C22y},[___]{$C22z}),
+[`C_{2,3}=`]([___]{$C23x},[___]{$C23y},[___]{$C23z}),
+[`C_{2,4}=`]([___]{$C24x},[___]{$C24y},[___]{$C24z}),
+
+[`C_{3,1}=([$C31x],[$C31y],[$C31z])`],
+[`C_{3,2}=`]([___]{$C32x},[___]{$C32y},[___]{$C32z}),
+[`C_{3,3}=`]([___]{$C33x},[___]{$C33y},[___]{$C33z}),
+[`C_{3,4}=`]([___]{$C34x},[___]{$C34y},[___]{$C34z}),
+
+[`C_{4,1}=([$C41x],[$C41y],[$C41z])`],
+[`C_{4,2}=`]([___]{$C42x},[___]{$C42y},[___]{$C42z}),
+[`C_{4,3}=`]([___]{$C43x},[___]{$C43y},[___]{$C43z}),
+[`C_{4,4}=`]([___]{$C44x},[___]{$C44y},[___]{$C44z})
+
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`C_{2,2}=C_{2,1}+C_{1,2}-C_{1,1}=([$C22x],[$C22y],[$C22z])`]
+
+[`C_{3,2}=C_{3,1}+C_{1,2}-C_{1,1}=([$C32x],[$C32y],[$C32z])`]
+
+[`C_{4,2}=C_{4,1}+C_{1,2}-C_{1,1}=([$C42x],[$C42y],[$C42z])`]
+
+[`C_{2,3}=C_{2,2}+C_{1,3}-C_{1,2}=([$C23x],[$C23y],[$C23z])`]
+
+[`C_{3,3}=C_{3,2}+C_{1,3}-C_{1,2}=([$C33x],[$C33y],[$C33z])`]
+
+[`C_{4,3}=C_{4,2}+C_{1,3}-C_{1,2}=([$C43x],[$C43y],[$C43z])`]
+
+[`C_{2,4}=C_{2,3}+C_{1,4}-C_{1,3}=([$C24x],[$C24y],[$C24z])`]
+
+[`C_{3,4}=C_{3,3}+C_{1,4}-C_{1,3}=([$C34x],[$C34y],[$C34z])`]
+
+[`C_{4,4}=C_{4,3}+C_{1,4}-C_{1,3}=([$C44x],[$C44y],[$C44z])`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-4-CoonsControlNet.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-4-CoonsControlNet.pg
@@ -1,0 +1,203 @@
+##DESCRIPTION
+## Given the boundary of a cubic Bezier control net, compute the interior using Coons's formula
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Concepts for multivariable functions')
+## DBsection('Parameterized surfaces')
+## Date('04/19/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('14')
+## Problem1('4')
+##KEYWORDS('Bezier surfaces','parameterized surfaces','Coons patch')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$C11x = random( -2, 2 ) * 9;
+$C12x = random( -4, 3 ) * 3;
+$C13x = random( -4, 3 ) * 3;
+$C14x = random( -2, 2 ) * 9;
+$C11y = random( -2, 2 ) * 9;
+$C12y = random( -4, 3 ) * 3;
+$C13y = random( -4, 3 ) * 3;
+$C14y = random( -2, 2 ) * 9;
+$C11z = random( -2, 2 ) * 9;
+$C12z = random( -4, 3 ) * 3;
+$C13z = random( -4, 3 ) * 3;
+$C14z = random( -2, 2 ) * 9;
+
+$C21x = random( -3, 4 ) * 3;
+$C24x = random( -3, 4 ) * 3;
+$C21y = random( -3, 4 ) * 3;
+$C24y = random( -3, 4 ) * 3;
+$C21z = random( -3, 4 ) * 3;
+$C24z = random( -3, 4 ) * 3;
+
+$C31x = random( -4, 3 ) * 3;
+$C34x = random( -4, 3 ) * 3;
+$C31y = random( -4, 3 ) * 3;
+$C34y = random( -4, 3 ) * 3;
+$C31z = random( -4, 3 ) * 3;
+$C34z = random( -4, 3 ) * 3;
+
+$C41x = random( -2, 2 ) * 9;
+$C42x = random( -3, 4 ) * 3;
+$C43x = random( -3, 4 ) * 3;
+$C44x = random( -2, 2 ) * 9;
+$C41y = random( -2, 2 ) * 9;
+$C42y = random( -3, 4 ) * 3;
+$C43y = random( -3, 4 ) * 3;
+$C44y = random( -2, 2 ) * 9;
+$C41z = random( -2, 2 ) * 9;
+$C42z = random( -3, 4 ) * 3;
+$C43z = random( -3, 4 ) * 3;
+$C44z = random( -2, 2 ) * 9;
+
+sub li { # linear interpolation
+    my $a = shift( @_ );
+    my $b = shift( @_ );
+    my $t = shift( @_ );
+    return (1-$t)*$a + $t*$b;
+}
+sub bi { # bilinear interpolation
+    my $w = shift( @_ );
+    my $x = shift( @_ );
+    my $y = shift( @_ );
+    my $z = shift( @_ );
+    my $u = shift( @_ );
+    my $v = shift( @_ );
+    return li(li($w,$x,$v),li($y,$z,$v),$u);
+}
+
+$BI = bi($C11x,$C14x,$C41x,$C44x,1/3,1/3);
+$C22x = $BI + (li($C21x,$C24x,1/3)-$BI) + (li($C12x,$C42x,1/3)-$BI);
+$BI = bi($C11x,$C14x,$C41x,$C44x,2/3,1/3);
+$C23x = $BI + (li($C21x,$C24x,2/3)-$BI) + (li($C13x,$C43x,1/3)-$BI);
+$BI = bi($C11x,$C14x,$C41x,$C44x,1/3,2/3);
+$C32x = $BI + (li($C31x,$C34x,1/3)-$BI) + (li($C12x,$C42x,2/3)-$BI);
+$BI = bi($C11x,$C14x,$C41x,$C44x,2/3,2/3);
+$C33x = $BI + (li($C31x,$C34x,2/3)-$BI) + (li($C13x,$C43x,2/3)-$BI);
+$BI = bi($C11y,$C14y,$C41y,$C44y,1/3,1/3);
+$C22y = $BI + (li($C21y,$C24y,1/3)-$BI) + (li($C12y,$C42y,1/3)-$BI);
+$BI = bi($C11y,$C14y,$C41y,$C44y,2/3,1/3);
+$C23y = $BI + (li($C21y,$C24y,2/3)-$BI) + (li($C13y,$C43y,1/3)-$BI);
+$BI = bi($C11y,$C14y,$C41y,$C44y,1/3,2/3);
+$C32y = $BI + (li($C31y,$C34y,1/3)-$BI) + (li($C12y,$C42y,2/3)-$BI);
+$BI = bi($C11y,$C14y,$C41y,$C44y,2/3,2/3);
+$C33y = $BI + (li($C31y,$C34y,2/3)-$BI) + (li($C13y,$C43y,2/3)-$BI);
+$BI = bi($C11z,$C14z,$C41z,$C44z,1/3,1/3);
+$C22z = $BI + (li($C21z,$C24z,1/3)-$BI) + (li($C12z,$C42z,1/3)-$BI);
+$BI = bi($C11z,$C14z,$C41z,$C44z,2/3,1/3);
+$C23z = $BI + (li($C21z,$C24z,2/3)-$BI) + (li($C13z,$C43z,1/3)-$BI);
+$BI = bi($C11z,$C14z,$C41z,$C44z,1/3,2/3);
+$C32z = $BI + (li($C31z,$C34z,1/3)-$BI) + (li($C12z,$C42z,2/3)-$BI);
+$BI = bi($C11z,$C14z,$C41z,$C44z,2/3,2/3);
+$C33z = $BI + (li($C31z,$C34z,2/3)-$BI) + (li($C13z,$C43z,2/3)-$BI);
+
+$e = '&eacute;';
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a control net for a cubic B[$e]*zier surface whose outer edges are defined, but whose interior is not.
+
+[`C_{1,1}=([$C11x],[$C11y],[$C11z])`],
+[`C_{1,2}=([$C12x],[$C12y],[$C12z])`],
+[`C_{1,3}=([$C13x],[$C13y],[$C13z])`],
+[`C_{1,4}=([$C14x],[$C14y],[$C14z])`],
+
+[`C_{2,1}=([$C21x],[$C21y],[$C21z])`],
+[`C_{2,2}=(?,?,?)`],
+[`C_{2,3}=(?,?,?)`],
+[`C_{2,4}=([$C24x],[$C24y],[$C24z])`],
+
+[`C_{3,1}=([$C31x],[$C31y],[$C31z])`],
+[`C_{3,2}=(?,?,?)`],
+[`C_{3,3}=(?,?,?)`],
+[`C_{3,4}=([$C34x],[$C34y],[$C34z])`],
+
+[`C_{4,1}=([$C41x],[$C41y],[$C41z])`],
+[`C_{4,2}=([$C42x],[$C42y],[$C42z])`],
+[`C_{4,3}=([$C43x],[$C43y],[$C43z])`],
+[`C_{4,4}=([$C44x],[$C44y],[$C44z])`]
+
+Use Coons's formula (equation 14.8 in the text) to compute the interior of the control net.
+
+[`C_{2,2}=`]([_____]{$C22x},[_____]{$C22y},[_____]{$C22z}),
+[`C_{2,3}=`]([_____]{$C23x},[_____]{$C23y},[_____]{$C23z}),
+
+[`C_{3,2}=`]([_____]{$C32x},[_____]{$C32y},[_____]{$C32z}),
+[`C_{3,3}=`]([_____]{$C33x},[_____]{$C33y},[_____]{$C33z})
+END_PGML
+
+$z = 0;
+
+BEGIN_PGML_SOLUTION
+For [`C_{2,2}`], we need first to find [`B_{1/3,1/3}`], which is a bilinear interpolation among the four corner points:
+
+>> [`\frac23\left(
+    \frac23([$C11x],[$C11y],[$C11z])+\frac13([$C14x],[$C14y],[$C14z])
+  \right)+\frac13\left(
+    \frac23([$C41x],[$C41y],[$C41z])+\frac13([$C44x],[$C44y],[$C44z])
+  \right)=
+  ([$z+bi($C11x,$C14x,$C41x,$C44x,1/3,1/3)],
+   [$z+bi($C11y,$C14y,$C41y,$C44y,1/3,1/3)],
+   [$z+bi($C11z,$C14z,$C41z,$C44z,1/3,1/3)])`] <<
+
+We also need to compute [`\vec\Delta_1`], which in this case involves a linear interpolation between [`C_{2,1}`] and [`C_{2,4}`] at [`\frac13`].
+
+>> [`(\frac23C_{2,1}+\frac13C_{2,4})-B_{1/3,1/3}=(
+    [$z+li($C21x,$C24x,1/3)],
+    [$z+li($C21y,$C24y,1/3)],
+    [$z+li($C21z,$C24z,1/3)])-B_{1/3,1/3}=(
+    [$z+li($C21x,$C24x,1/3)-bi($C11x,$C14x,$C41x,$C44x,1/3,1/3)],
+    [$z+li($C21y,$C24y,1/3)-bi($C11y,$C14y,$C41y,$C44y,1/3,1/3)],
+    [$z+li($C21z,$C24z,1/3)-bi($C11z,$C14z,$C41z,$C44z,1/3,1/3)])`] <<
+
+We also need to compute [`\vec\Delta'_1`], which in this case involves a linear interpolation between [`C_{1,2}`] and [`C_{4,2}`] at [`\frac13`].
+
+>> [`(\frac23C_{1,2}+\frac13C_{4,2})-B_{1/3,1/3}=(
+    [$z+li($C12x,$C42x,1/3)],
+    [$z+li($C12y,$C42y,1/3)],
+    [$z+li($C12z,$C42z,1/3)])-B_{1/3,1/3}=(
+    [$z+li($C12x,$C42x,1/3)-bi($C11x,$C14x,$C41x,$C44x,1/3,1/3)],
+    [$z+li($C12y,$C42y,1/3)-bi($C11y,$C14y,$C41y,$C44y,1/3,1/3)],
+    [$z+li($C12z,$C42z,1/3)-bi($C11z,$C14z,$C41z,$C44z,1/3,1/3)])`] <<
+
+The sum of these is [`C_{2,2}`].
+
+>> [`C_{2,2}=([$z+bi($C11x,$C14x,$C41x,$C44x,1/3,1/3)],
+   [$z+bi($C11y,$C14y,$C41y,$C44y,1/3,1/3)],
+   [$z+bi($C11z,$C14z,$C41z,$C44z,1/3,1/3)]) +
+   ([$z+li($C21x,$C24x,1/3)-bi($C11x,$C14x,$C41x,$C44x,1/3,1/3)],
+    [$z+li($C21y,$C24y,1/3)-bi($C11y,$C14y,$C41y,$C44y,1/3,1/3)],
+    [$z+li($C21z,$C24z,1/3)-bi($C11z,$C14z,$C41z,$C44z,1/3,1/3)]) +
+   ([$z+li($C12x,$C42x,1/3)-bi($C11x,$C14x,$C41x,$C44x,1/3,1/3)],
+    [$z+li($C12y,$C42y,1/3)-bi($C11y,$C14y,$C41y,$C44y,1/3,1/3)],
+    [$z+li($C12z,$C42z,1/3)-bi($C11z,$C14z,$C41z,$C44z,1/3,1/3)])
+   =([$C22x],[$C22y],[$C22z])`] <<
+
+A similar procedure contructs the other control points, with these results.
+
+>> [`C_{2,3}=([$C23x],[$C23y],[$C23z])`] <<
+
+>> [`C_{3,2}=([$C32x],[$C32y],[$C32z])`] <<
+
+>> [`C_{3,3}=([$C33x],[$C33y],[$C33z])`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-6-TranslationalSurface.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/14-6-TranslationalSurface.pg
@@ -1,0 +1,65 @@
+##DESCRIPTION
+## Given two curves, write the translational surface formula
+##ENDDESCRIPTION
+
+## DBsubject('Calculus - multivariable')
+## DBchapter('Concepts for multivariable functions')
+## DBsection('Parameterized surfaces')
+## Date('04/19/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('14')
+## Problem1('6')
+##KEYWORDS('parameterized surfaces','translational surfaces')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t=>'Real');
+Context()->variables->add(u=>'Real');
+Context()->variables->add(v=>'Real');
+$showPartialCorrectAnswers = 1;
+
+# f(t) = ( At, 1/(B+t), Ce^t )
+# g(t) = ( Dt^2, E-t^2, F )
+
+$A = non_zero_random( -9, 9 );
+$B = non_zero_random( -9, 9 );
+$C = non_zero_random( -9, 9 );
+$D = non_zero_random( -9, 9 );
+$E = non_zero_random( -9, 9 );
+$F = non_zero_random( -9, 9 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the following two curves in space.
+
+>> [`\vec f_1(t)=\left([$A]t,\frac{1}{[$B]+t},[$C]e^t\right)`] <<
+
+>> [`\vec f_2(t)=\left([$D]t^2,[$E]-t^2,[$F]\right)`] <<
+
+We wish to form a translational surface [`\vec g(u,v)`] from them, aligning [`\vec f_1`] with the parameter [`u`] and [`\vec f_2`] with the parameter [`v`].  Write the formula for that surface here.
+
+[`\vec g(u,v)=`]([________________]{"$A*u+$D*v^2"},[________________]{"1/($B+u)-v^2"},[________________]{"$C*e^u"})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec g(u,v)=\vec f_1(u)+\vec f_2(v)-\vec f_2(0)
+    =\left([$A]u,\frac{1}{[$B]+u},[$C]e^u\right)
+    +\left([$D]v^2,[$E]-v^2,[$F]\right)
+    -\left(0,[$E],[$F]\right)
+    =\left([$A]u+[$D]v^2,\frac{1}{[$B]+u}-v^2,[$C]e^u\right)`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch14/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-1-PlanarMeshData.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-1-PlanarMeshData.pg
@@ -1,0 +1,262 @@
+##DESCRIPTION
+## Given planar meshes, give the # of vertices, faces, edges, and Euler characteristic
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/22/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('1')
+##KEYWORDS('planar mesh','vertex','edge','face','Euler characteristic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$ngon = random( 3, 6 );
+$graph1 = init_graph(-1.1,-1.1,1.1,1.1,size=>[200,200]);
+$graph1->new_color( 'light', 230, 230, 230 );
+$pi = 3.1415926539793;
+for ( my $i = 0 ; $i <= $ngon ; $i++ ) {
+    my $angle = $i/$ngon*2*$pi;
+    if ( $i == 0 ) {
+        $graph1->moveTo( cos( $angle ), sin( $angle ) );
+    } else {
+        $graph1->lineTo( cos( $angle ), sin( $angle ), 'black' );
+        $graph1->stamps( closed_circle( cos( $angle ), sin( $angle ),
+                         'black' ) );
+    }
+}
+$graph1->fillRegion( [ 0, 0, 'light' ] );
+$graph2 = init_graph(-1.1,-1.1,1.1,1.1,size=>[200,200]);
+$graph2->new_color( 'light', 230, 230, 230 );
+for ( my $i = 0 ; $i <= $ngon+1 ; $i++ ) {
+    my $angle = $i/($ngon+1)*2*$pi;
+    if ( $i == 0 ) {
+        $graph2->moveTo( cos( $angle ), sin( $angle ) );
+    } else {
+        $graph2->lineTo( cos( $angle ), sin( $angle ), 'black' );
+        $graph2->stamps( closed_circle( cos( $angle ), sin( $angle ),
+                         'black' ) );
+    }
+}
+$graph2->fillRegion( [ 0, 0, 'light' ] );
+
+$nboxes1 = random( 2, 4 );
+$graph3 = init_graph(-1.1,-1.1,1.1,1.1,size=>[200,200]);
+$graph3->new_color( 'light', 230, 230, 230 );
+$graph3->moveTo( -1, 0.5 );
+$graph3->lineTo( 1, 0.5 );
+$graph3->moveTo( -1, -0.5 );
+$graph3->lineTo( 1, -0.5 );
+my $x = 0;
+for ( my $i = 0 ; $i <= $nboxes1 + 1 ; $i++ ) {
+    $x = $i/($nboxes1+1)*2-1;
+    $graph3->moveTo( $x, -0.5 );
+    $graph3->lineTo( $x, 0.5 );
+    $graph3->fillRegion( [ $x-0.1, 0, 'light' ] );
+    $graph3->stamps( closed_circle( $x, -0.5, 'black' ) );
+    $graph3->stamps( closed_circle( $x, 0.5, 'black' ) );
+}
+$x = $nboxes1/($nboxes1+1)*2-1;
+$graph3->moveTo( $x, 0.5 );
+$graph3->lineTo( 1, 0 );
+$graph3->lineTo( $x, -0.5 );
+$graph3->fillRegion( [ $x + 0.1, 0.49, 'light' ] );
+$graph3->fillRegion( [ $x + 0.1, -0.49, 'light' ] );
+$graph3->stamps( closed_circle( 1, 0, 'black' ) );
+
+$nboxes2 = random( 6, 9 );
+$graph4 = init_graph(-1.1,-1.1,1.1,1.1,size=>[200,200]);
+$graph4->new_color( 'light', 230, 230, 230 );
+$graph4->moveTo( -1, 0.5 );
+$graph4->lineTo( 1, 0.5 );
+$graph4->moveTo( -1, -0.5 );
+$graph4->lineTo( 1, -0.5 );
+my $x = 0;
+for ( my $i = 0 ; $i <= $nboxes2 ; $i++ ) {
+    $x = $i/$nboxes2*2-1;
+    $graph4->moveTo( $x, -0.5 );
+    $graph4->lineTo( $x, 0.5 );
+    if ( $i > 0 ) { $graph4->fillRegion( [ $x-0.1, 0, 'light' ] ); }
+    $graph4->stamps( closed_circle( $x, -0.5, 'black' ) );
+    $graph4->stamps( closed_circle( $x, 0.5, 'black' ) );
+}
+
+$ncells = random( 8, 10 );
+$graph5 = init_graph(-1.1,-1.1,1.1,1.1,size=>[200,200]);
+$graph5->new_color( 'light', 230, 230, 230 );
+for ( my $i = 0 ; $i < $ncells ; $i++ ) {
+    my $angle = $i/$ncells*2*$pi;
+    my $c = cos( $angle );
+    my $s = sin( $angle );
+    my $next = ($i+1)/$ncells*2*$pi;
+    my $nc = cos( $next );
+    my $ns = sin( $next );
+    $graph5->moveTo( $nc, $ns );
+    $graph5->lineTo( $c, $s );
+    $graph5->lineTo( $c/2, $s/2 );
+    $graph5->lineTo( $nc/2, $ns/2 );
+    $graph5->fillRegion( [ ($c/2+$nc)/2, ($s/2+$ns)/2, 'light' ] );
+    $graph5->stamps( closed_circle( $c, $s, 'black' ) );
+    $graph5->stamps( closed_circle( $c/2, $s/2, 'black' ) );
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the following planar mesh.
+
+[@ image(insertGraph($graph1), width=>200, height=>200) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$ngon}
+
+[`E=`][_____]{$ngon}
+
+[`F=`][_____]{1}
+
+[`\chi=`][_____]{1}
+
+-----
+
+Consider the following planar mesh.
+
+[@ image(insertGraph($graph2), width=>200, height=>200) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$ngon+1}
+
+[`E=`][_____]{$ngon+1}
+
+[`F=`][_____]{1}
+
+[`\chi=`][_____]{1}
+
+-----
+
+Consider the following planar mesh.
+
+[@ image(insertGraph($graph3), width=>200, height=>200) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$nboxes1*2+5}
+
+[`E=`][_____]{$nboxes1*3+7}
+
+[`F=`][_____]{$nboxes1+3}
+
+[`\chi=`][_____]{1}
+
+-----
+
+Consider the following planar mesh.
+
+[@ image(insertGraph($graph4), width=>200, height=>200) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$nboxes2*2+2}
+
+[`E=`][_____]{$nboxes2*3+1}
+
+[`F=`][_____]{$nboxes2}
+
+[`\chi=`][_____]{1}
+
+-----
+
+Consider the same planar mesh shown immediately above, but imagine it contains [`n`] boxes rather than [$nboxes2].
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{"2n+2"}
+
+[`E=`][_____]{"3n+1"}
+
+[`F=`][_____]{"n"}
+
+[`\chi=`][_____]{1}
+
+-----
+
+Consider the following planar mesh.
+
+[@ image(insertGraph($graph5), width=>200, height=>200) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$ncells*2}
+
+[`E=`][_____]{$ncells*3}
+
+[`F=`][_____]{$ncells}
+
+[`\chi=`][_____]{0}
+
+-----
+
+Consider the same planar mesh shown immediately above, but imagine it contains [`n`] regions arranged in a circle rather than [$ncells].
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{"2n"}
+
+[`E=`][_____]{"3n"}
+
+[`F=`][_____]{"n"}
+
+[`\chi=`][_____]{0}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+You can count the number of vertices, edges, and faces in the first graph, giving [`V=E=[$ngon]`] and [`F=1`].  Then, as always,
+
+>> [`\chi=V-E+F=[$ngon]-[$ngon]+1=1.`] <<
+
+You can count the number of vertices, edges, and faces in the second graph, giving [`V=E=[$ngon+1]`] and [`F=1`].  Then, as always,
+
+>> [`\chi=V-E+F=[$ngon+1]-[$ngon+1]+1=1.`] <<
+
+In the third graph, there are [$nboxes1+2] vertices on top and the same number on bottom, plus one on the right, for a total of [`V=[$nboxes1*2+5]`].  Counting the edges gives [`E=[$nboxes1*3+7]`].  Counting the faces gives [`F=[$nboxes1+3]`].  Thus
+
+>> [`\chi=V-E+F=[$nboxes1*2+5]-[$nboxes1*3+7]+[$nboxes1+3]=1.`] <<
+
+In the fourth graph, there are [$nboxes2+1] vertices on top and bottom, for a total of [`V=[$nboxes2*2+2]`].  There are [$nboxes2+1] vertical edges and [$nboxes2] horizontal edges on top, and the same number on bottom, for a total of [`E=[$nboxes2*3+1]`].  Straightforward counting gives [`F=[$nboxes2]`].  Thus
+
+>> [`\chi=V-E+F=[$nboxes2*2+2]-[$nboxes2*3+1]+[$nboxes2]=1`] <<
+
+If that graph had had [`n`] boxes, then there would be [`n+1`] vertices on top and bottom, so that [`V=2n+2`].  And there would have been [`n+1`] vertical edges, plus [`n`] edges on each of top and bottom, giving [`E=3n+1`].  Obviously we would have [`F=n`].  Thus
+
+>> [`\chi=V-E+F=2n+2-(3n+1)+n=1.`] <<
+
+In the fifth graph, there are [$ncells] vertices on the inside and [$ncells] vertices on the outside, so that [`V=[$ncells*2]`].  There are [$ncells] edges on the inside, [$ncells] edges on the outside, and [$ncells] edges that run like spokes on a wheel, from inside to outside.  Thus [`E=[$ncells*3]`].  Straightforward counting gives [`F=[$ncells]`].  Thus
+
+>> [`\chi=V-E+F=[$ncells*2]-[$ncells*3]+[$ncells]=0`] <<
+
+If that graph had had [`n`] regions, then there would be [`n`] vertices on the outside and inside, so that [`V=2n`].  And there would have been [`n`] edges on the outside, [`n`] on the inside, and [`n`] like spokes on a wheel, making [`E=3n`].  Obviously we would have [`F=n`].  Thus
+
+>> [`\chi=V-E+F=2n-3n+n=0.`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-14a-SimplifyMidedge.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-14a-SimplifyMidedge.pg
@@ -1,0 +1,103 @@
+##DESCRIPTION
+## Derive simplified formulas for midedge subdivisiona algorithm counts
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/24/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('14a')
+##KEYWORDS('mesh','vertex','edge','face')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+Context()->variables->add(F=>'Real');
+Context()->variables->add(E=>'Real');
+Context()->variables->add(V=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$V = random( 5, 10 );
+$E = random( 5, 10 );
+$F = random( 5, 10 );
+
+$n = random( 3, 6 );
+$V2 = random( 5, 10 );
+$E2 = random( 5, 10 );
+$F2 = random( 5, 10 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Examine the equations on page 411 of the text for the sizes of a mesh produced by the midedge subdivision algorithm.  Now assume that the mesh has no boundary (for example, it might be a sphere or a cube).  How would the formulas simplify?  Use [`V,E,F`] for the number of vertices/edges/faces in the original mesh.
+
+[`V'=`][__________]{"E"}
+
+[`E'=`][__________]{"2E"}
+
+[`F'=`][__________]{"F+V"}
+
+If the original mesh had [`V=[$V],E=[$E],F=[$F]`], what would those values be for the new mesh?
+
+[`V'=`][__________]{$E}
+
+[`E'=`][__________]{2*$E}
+
+[`F'=`][__________]{$F+$V}
+
+What if the algorithm were applied again to that new mesh, producing yet a third mesh, for which we write [`V'',E'',F''`]; what would those values be?
+
+[`V''=`][__________]{2*$E}
+
+[`E''=`][__________]{4*$E}
+
+[`F''=`][__________]{$F+$V+$E}
+
+What if the algorithm were applied [`n`] times to the original mesh, and we write [`V^n,E^n,F^n`] for the counts of vertices/edges/faces in the resulting mesh.  What would those values be (in terms of [`n`])?
+
+[`V^n=`][__________]{"$E*2^(n-1)"}
+
+[`E^n=`][__________]{"$E*2^n"}
+
+[`F^n=`][__________]{"$F+$V+(2^(n-1)-1)*$E"}
+
+In a mesh with no boundary, if [`V=[$V2],E=[$E2],F=[$F2],V^n=[$E2*2**($n-1)],E^n=[$E2*2**$n],F^n=[$F2+$V2+(2**($n-1)-1)*$E2]`], how many iterations of the midedge subdivision algorithm were applied?
+
+[`n=`][__________]{$n}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+On page 411, the text says [`V'=E+V_b`], but there is no boundary, so [`V_b=0`].  Thus we can write [`V'=E`].
+
+The text also says [`E'=2E_i+3E_b`], but we know [`E_b=0`], so we can write [`E'=2E_i`], except the problem told us to use [`E`] for the number of edges in the original mesh, so we write [`E'=2E`].
+
+The text also says [`F'=F+V`], which needs no change, beacuse it had nothing to do with the boundary.
+
+If we apply those formulas when [`V=[$V],E=[$E],F=[$F]`], we end up with [`V'=[$E],E'=[$E*2],F'=[$F+$V]`].
+
+If we apply them again to those results, we get [`V''=[$E*2],E''=[$E*4],F''=[$F+$V+$E]`].
+
+You can apply them several more times to find a pattern, and the result is as follows.
+
+- [`V^n=[$E](2^{n-1})`]
+- [`E^n=[$E](2^n)`]
+- [`F^n=[$V+$F]+[$E](2^{n-1}-1)`]
+
+We could iterate the equations a few times in the final part to find that [`n=[$n]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-16a-SimplifyCatmullClark.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-16a-SimplifyCatmullClark.pg
@@ -1,0 +1,103 @@
+##DESCRIPTION
+## Derive simplified formulas for Catmull-Clark subdivision algorithm counts
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/24/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('16a')
+##KEYWORDS('mesh','vertex','edge','face')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+Context()->variables->add(F=>'Real');
+Context()->variables->add(E=>'Real');
+Context()->variables->add(V=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$V = random( 5, 10 );
+$E = random( 5, 10 );
+$F = random( 5, 10 );
+
+$n = random( 4, 6 );
+$V2 = random( 5, 10 );
+$E2 = random( 5, 10 );
+$F2 = random( 5, 10 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Examine the equations on page 418 of the text for the sizes of a mesh produced by the Catmull-Clark subdivision algorithm.  Now assume that the mesh has no boundary (for example, it might be a sphere or a cube).  How would the formulas simplify?  Use [`V,E,F`] for the number of vertices/edges/faces in the original mesh.
+
+[`V'=`][__________]{"V+E+F"}
+
+[`E'=`][__________]{"4E"}
+
+[`F'=`][__________]{"2E"}
+
+If the original mesh had [`V=[$V],E=[$E],F=[$F]`], what would those values be for the new mesh?
+
+[`V'=`][__________]{$V+$E+$F}
+
+[`E'=`][__________]{4*$E}
+
+[`F'=`][__________]{2*$E}
+
+What if the algorithm were applied again to that new mesh, producing yet a third mesh, for which we write [`V'',E'',F''`]; what would those values be?
+
+[`V''=`][__________]{$V+7*$E+$F}
+
+[`E''=`][__________]{16*$E}
+
+[`F''=`][__________]{8*$E}
+
+What if the algorithm were applied [`n`] times to the original mesh, and we write [`V^n,E^n,F^n`] for the counts of vertices/edges/faces in the resulting mesh.  What would those values be (in terms of [`n`])?
+
+[`V^n=`][__________]{"$V+$F+$E*(2^(2n-1)-1)"}
+
+[`E^n=`][__________]{"$E*(4^n)"}
+
+[`F^n=`][__________]{"2*$E*(4^(n-1))"}
+
+In a mesh with no boundary, if [`V=[$V2],E=[$E2],F=[$F2],V^n=[$V2+$F2+$E2*(2**(2*$n-1)-1)],E^n=[$E2*(4**$n)],F^n=[$E2*2*(4**($n-1))]`], how many iterations of the midedge subdivision algorithm were applied?
+
+[`n=`][__________]{$n}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+On page 418, the text says [`V'=V+E+F`], which needs no change, because it had nothing to do with the boundary.
+
+The text also says [`E'=4E_i+3E_b`], but we know [`E_b=0`], so we can write [`E'=4E_i`], except the problem told us to use [`E`] for the number of edges in the original mesh, so we write [`E'=4E`].
+
+The text also says [`F'=2E_i+E_b`], but we know [`E_b=0`], so we can write [`E'=2E_i`], except the problem told us to use [`E`] for the number of edges in the original mesh, so we write [`E'=2E`].
+
+If we apply those formulas when [`V=[$V],E=[$E],F=[$F]`], we end up with [`V'=[$E],E'=[$E*2],F'=[$F+$V]`].
+
+If we apply them again to those results, we get [`V''=[$E*2],E''=[$E*4],F''=[$F+$V+$E]`].
+
+You can apply them several more times to find a pattern, and the result is as follows.
+
+- [`V^n=[$E](2^{n-1})`]
+- [`E^n=[$E](2^n)`]
+- [`F^n=[$V+$F]+[$E](2^{n-1}-1)`]
+
+We could iterate the equations a few times in the final part to find that [`n=[$n]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-2-NonPlanarMeshData.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-2-NonPlanarMeshData.pg
@@ -1,0 +1,263 @@
+##DESCRIPTION
+## Given nonplanar meshes, give the # of vertices, faces, edges, and Euler characteristic
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/24/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('2')
+##KEYWORDS('nonplanar mesh','vertex','edge','face','Euler characteristic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+$showPartialCorrectAnswers = 1;
+
+$pi = 3.1415926539793;
+sub angle {
+    my $index = shift( @_ );
+    my $outof = shift( @_ );
+    return 2 * $pi * $index / $outof;
+}
+sub X { return cos( angle( @_ ) ); }
+sub Y { return sin( angle( @_ ) ); }
+sub line {
+    my $graph = shift( @_ );
+    my $x1 = shift( @_ );
+    my $y1 = shift( @_ );
+    my $x2 = shift( @_ );
+    my $y2 = shift( @_ );
+    my $type = shift( @_ );
+    my $dashed = shift( @_ );
+    $graph->moveTo( $x1, $y1 );
+    if ( $dashed ) {
+        $graph->lineTo( $x2, $y2, $type, 1, 'dashed' );
+    } else {
+        $graph->lineTo( $x2, $y2, $type );
+    }
+}
+# when drawing a ring of points connected by edges, is point $i out of $n
+# in the back, occluded by faces in front of it, or no?
+# to find this out, provide:
+#   $i = the index of the point in question
+#   $n = the number of points in the ring (so 0<=$i<$n)
+#   (we assume the points are then arranged in the unit circle w/$i=0@angle0)
+#   $offset = by how much to shift $i before drawing
+#   $v1,$v2 = unit vector pointing towards the frontmost point in the ring
+# we determine it by finding out if for any $j in 0<=$j<$n, face $j
+# would occlude vertex $i.
+# to do so, we check whether the vector from $i to <v1,v2> aims through
+# the line segment from point $j to point $j+1.
+# we compute two vectors: <w1,w2>=pointj-pointi and <w3,w4>=same but j+1
+# then it occludes if the angle between <w1,w2>&<w3,w4> is the largest
+# of the three angles among the vectors <v1,v2>,<w1,w2>,<w3,w4>
+sub ptinback {
+    my $i = shift( @_ );
+    my $n = shift( @_ );
+    my $offset = shift( @_ );
+    my $v1 = shift( @_ );
+    my $v2 = shift( @_ );
+    my $angle = acos( $v1 / ( $v1**2 + $v2**2 ) ** 0.5 );
+    if ( $v2 < 0 ) { $angle = -$angle; }
+    my $adj = - $angle / ( 2 * $pi ) * $n;
+    $x = X($i+$adj+$offset,$n);
+    $y = Y($i+$adj+$offset,$n);
+    for ( my $j = 0 ; $j < $n ; $j++ ) {
+        my $x1 = X($j+$adj+$offset,$n);
+        my $y1 = Y($j+$adj+$offset,$n);
+        my $x2 = X($j+$adj+1+$offset,$n);
+        my $y2 = Y($j+$adj+1+$offset,$n);
+        if ( ( $x1 > $x ) && ( $x2 > $x )
+          && ( ( ( $y1 < $y ) && ( $y < $y2 ) )
+            || ( ( $y1 > $y ) && ( $y > $y2 ) ) ) ) {
+            return 1;
+        }
+    }
+    return 0;
+}
+# same as previous, but for segment from $i to $i+1
+sub seginback {
+    my $i = shift( @_ );
+    my $n = shift( @_ );
+    my $offset = shift( @_ );
+    my $v1 = shift( @_ );
+    my $v2 = shift( @_ );
+    my $result = ptinback($i+0.01,$n,$offset,$v1,$v2)
+              || ptinback($i+0.99,$n,$offset,$v1,$v2);
+    return $result;
+}
+
+$n1 = random( 3, 6 );
+$g1 = init_graph(-3.1,-2.1,3.1,2.1,size=>[300,200]);
+$offset = 0.2;
+for ( my $i = 0 ; $i < $n1 ; $i++ ) {
+    my $j = $i+$offset;
+    line( $g1, -2+X($j,$n1), -1+Y($j,$n1),
+               -2+X($j+1,$n1), -1+Y($j+1,$n1), 'black' );
+    line( $g1, -2+X($j,$n1), -1+Y($j,$n1),
+               2+X($j,$n1), 1+Y($j,$n1), 'black',
+               ptinback($i,$n1,$offset,2,1) );
+    line( $g1, 2+X($j,$n1), 1+Y($j,$n1),
+               2+X($j+1,$n1), 1+Y($j+1,$n1), 'black',
+               seginback($i,$n1,$offset,2,1) );
+}
+
+$n2 = random( 5, 8 );
+$g2 = init_graph(-3.1,-2.1,3.1,3.1,size=>[300,250]);
+$offset = 0.06;
+for ( my $i = 0 ; $i < $n2 ; $i++ ) {
+    my $j = $i+$offset;
+    line( $g2, 3*X($j,$n2), -1+Y($j,$n2),
+               3*X($j+1,$n2), -1+Y($j+1,$n2), 'black',
+               seginback($i,$n2,$offset,0,-1));
+    line( $g2, 3*X($j,$n2), -1+Y($j,$n2), 0, 3, 'black',
+               ptinback($i,$n2,$offset,0,-1) );
+}
+
+$n3 = random( 4, 6 );
+$g3 = init_graph(-3.1,-4.1,3.1,4.1,size=>[300,450]);
+$offset = -0.25;
+for ( my $i = 0 ; $i < $n3 ; $i++ ) {
+    my $j = $i+$offset;
+    line( $g3, 3*X($j,$n3), Y($j,$n3),
+               3*X($j+1,$n3), Y($j+1,$n3), 'black',
+               seginback($i,$n3,$offset,0,-1));
+    line( $g3, 3*X($j,$n3), Y($j,$n3), 0, 4, 'black',
+               ptinback($i,$n3,$offset,0,-1) );
+    line( $g3, 3*X($j,$n3), Y($j,$n3), 0, -4, 'black',
+               ptinback($i,$n3,$offset,0,-1) );
+}
+
+$n4 = random( 5, 8 );
+$g4 = init_graph(-3.1,-4.1,3.1,4.1,size=>[300,450]);
+$offset = 0.06;
+for ( my $i = 0 ; $i < $n4 ; $i++ ) {
+    my $j = $i+$offset;
+    line( $g4, 3*X($j,$n4), Y($j,$n4),
+               3*X($j+1,$n4), Y($j+1,$n4), 'black',
+               seginback($i,$n4,$offset,0,-1));
+    line( $g4, 3*X($j,$n4), -3+Y($j,$n4),
+               3*X($j+1,$n4), -3+Y($j+1,$n4), 'black',
+               seginback($i,$n4,$offset,0,-1));
+    line( $g4, 3*X($j,$n4), Y($j,$n4), 0, 4, 'black',
+               ptinback($i,$n4,$offset,0,-1) );
+    line( $g4, 3*X($j,$n4), Y($j,$n4),
+               3*X($j,$n4), -3+Y($j,$n4), 'black',
+               ptinback($i,$n4,$offset,0,-1) );
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the following solid object formed from a mesh.
+
+[@ image(insertGraph($g1), width=>300, height=>200) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{2*$n1}
+
+[`E=`][_____]{3*$n1}
+
+[`F=`][_____]{$n1+2}
+
+[`\chi=`][_____]{2}
+
+-----
+
+Consider the following solid object formed from a mesh.
+
+[@ image(insertGraph($g2), width=>300, height=>250) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$n2+1}
+
+[`E=`][_____]{2*$n2}
+
+[`F=`][_____]{$n2+1}
+
+[`\chi=`][_____]{2}
+
+-----
+
+Consider the following solid object formed from a mesh.
+
+[@ image(insertGraph($g3), width=>300, height=>450) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{$n3+2}
+
+[`E=`][_____]{3*$n3}
+
+[`F=`][_____]{2*$n3}
+
+[`\chi=`][_____]{2}
+
+-----
+
+Consider the following solid object formed from a mesh.
+
+[@ image(insertGraph($g4), width=>300, height=>450) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{2*$n4+1}
+
+[`E=`][_____]{4*$n4}
+
+[`F=`][_____]{2*$n4+1}
+
+[`\chi=`][_____]{2}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The first object:
+
+- [$n1] vertices in front and in back, for a total of [`V=[$n1*2]`]
+- [$n1] edges in the front cycle, the same in the back cycle, and [$n1] again connecting front to back, for a total of [`E=[$n1*3]`]
+- one face in front, one in back, and [$n1] around the center, for a total of [`F=[$n1+2]`]
+- [`\chi=V-E+F=2`]
+
+The second object:
+
+* [$n2] vertices around the base and one on top, for a total of [`V=[$n2+1]`]
+* [$n2] edges around the base and the same number connecting the base to the top, for a total of [`E=[$n2*2]`]
+* one face on bottom and [$n2] around the sides, for a total of [`F=[$n2+1]`]
+* [`\chi=V-E+F=2`]
+
+The third object:
+
+* [$n3] vertices around the center plus one on top and one on bottom, for a total of [`V=[$n3+2]`]
+* [$n3] edges around the center, the same connecting the center to the top, and the same again connecting the center to the bottom, for a total of [`E=[$n3*3]`]
+* [$n3] faces around the top half and the same number around the bottom half, for a total of [`F=[$n3*2]`]
+* [`\chi=V-E+F=2`]
+
+The fourth object:
+
+* [$n4] vertices around the top ring, the same number around the bottom ring, and one on top, for a total of [`V=[$n4*2+1]`]
+* From top to bottom: [$n4] edges around the conical cap, [$n4] edges around the base of the cap, [$n4] edges around the cylindrical bottom, and [$n4] edges around the base of the whole shape, for a total of [`E=[$n4*4]`]
+* From top to bottom: [$n4] faces around the conical cap, [$n4] faces around the cylinder, and one on bottom, for a total of [`F=[$n4*2+1]`]
+* [`\chi=V-E+F=2`]
+
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-3-NumFacesInSmallMeshes.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-3-NumFacesInSmallMeshes.pg
@@ -1,0 +1,51 @@
+##DESCRIPTION
+## Given a number of vertices, give the max # of faces in the mesh
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/24/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('3')
+##KEYWORDS('mesh','vertex','face')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+If a mesh has three vertices, what is its maximum number of faces?
+
+Answer: [_____]{1}
+
+If a mesh has four vertices, what is its maxiumum number of faces?
+
+Answer: [_____]{4}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Answer #1: 1 (it can be only a triangle)
+
+Answer #2: 4 (See the tetrahedron in Figure 15.35 in the textbook.)
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-4-NumEdgesInSmallMeshes.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-4-NumEdgesInSmallMeshes.pg
@@ -1,0 +1,53 @@
+##DESCRIPTION
+## Given a number of vertices, give the max # of edges in the mesh
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/24/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('4')
+##KEYWORDS('mesh','vertex','edge')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+If a mesh has three vertices, what is its maximum number of edges?
+
+Answer: [_____]{3}
+
+If a mesh has four vertices, what is its maxiumum number of edges?
+
+Answer: [_____]{6}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Answer #1: 1 (it can be only a triangle)
+
+Answer #2: 6
+
+If the vertices are A, B, C, and D then we can have edges A-B, A-C, A-D, B-C, B-D, and C-D, which is 6.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-6-MoreNonplanarMeshes.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/15-6-MoreNonplanarMeshes.pg
@@ -1,0 +1,229 @@
+##DESCRIPTION
+## Given nonplanar meshes, give the # of vertices, faces, edges, and Euler characteristic
+##ENDDESCRIPTION
+
+## DBsubject('Graph theory')
+## DBchapter('Terminology')
+## DBsection('Misc.')
+## Date('04/24/2018')
+## Author('Nathan Carter')
+## Institution('Bentley University')
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## EditionText1('1')
+## AuthorText1('Nathan Carter')
+## Section1('15')
+## Problem1('6')
+##KEYWORDS('nonplanar mesh','vertex','edge','face','Euler characteristic')
+
+########################################################################
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+  "PGgraphmacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(n=>'Real');
+Context()->variables->add(m=>'Real');
+$showPartialCorrectAnswers = 1;
+
+sub line {
+    my $graph = shift( @_ );
+    my $x1 = shift( @_ );
+    my $y1 = shift( @_ );
+    my $x2 = shift( @_ );
+    my $y2 = shift( @_ );
+    my $dashed = shift( @_ );
+    $graph->moveTo( $x1, $y1 );
+    if ( $dashed ) {
+        $graph->lineTo( $x2, $y2, 'black', 1, 'dashed' );
+    } else {
+        $graph->lineTo( $x2, $y2, 'black' );
+    }
+}
+
+$n1 = random( 3, 5 );
+$d = 0.5;
+$g1 = init_graph(-0.1,-0.1,$n1+$d+0.1,1+$d+0.1,size=>[($n1+$d)*100,(1+$d)*100]);
+for ( my $i = 0 ; $i <= $n1 ; $i++ ) {
+    if ( $i > 0 ) {
+        line( $g1, $i-1, 0, $i, 0 );
+        line( $g1, $i-1, 1, $i, 1 );
+        line( $g1, $i-1+$d, 1+$d, $i+$d, 1+$d );
+        line( $g1, $i-1+$d, $d, $i+$d, $d, 1 );
+    }
+    line( $g1, $i, 0, $i, 1 );
+    line( $g1, $i, 1, $i+$d, 1+$d );
+    line( $g1, $i+$d, 1+$d, $i+$d, $d, $i < $n1 );
+    line( $g1, $i+$d, $d, $i, 0, $i < $n1 );
+}
+
+$n2 = random( 3, 6 );
+$m2 = $n2 - 1;
+$g2 = init_graph(-0.5,-0.5,$n2+0.5,$m2+0.5,size=>[100*$n2+100,100*$m2+100]);
+$g2->new_color( 'light', 220, 220, 220 );
+for ( my $i = 0 ; $i <= $m2 ; $i++ ) {
+    line( $g2, 0, $i, $n2, $i );
+}
+for ( my $i = 0 ; $i <= $n2 ; $i++ ) {
+    line( $g2, $i, 0, $i, $m2 );
+}
+for ( my $i = 0 ; $i < $n2 ; $i++ ) {
+    for ( my $j = 0 ; $j < $m2 ; $j++ ) {
+        $g2->fillRegion( [ $i+0.5, $j+0.5, 'light' ] );
+    }
+}
+
+$n3 = random( 3, 5 );
+$g3 = init_graph(-0.5,-0.5,2*$n3+1.5,3.5,size=>[200*$n3+200,400]);
+$g3->new_color( 'light', 220, 220, 220 );
+line( $g3, 0, 0, 2*$n3+1, 0 );
+line( $g3, 0, 1, 2*$n3+1, 1 );
+line( $g3, 0, 2, 2*$n3+1, 2 );
+line( $g3, 0, 3, 2*$n3+1, 3 );
+for ( my $i = 0 ; $i <= 2*$n3+3 ; $i++ ) {
+    line( $g3, $i, 0, $i, 3 );
+    if ( $i < 2*$n3+1 ) {
+        $g3->fillRegion( [ $i+0.5, 0.5, 'light' ] );
+        if ( $i % 2 == 0 ) {
+            $g3->fillRegion( [ $i+0.5, 1.5, 'light' ] );
+        }
+        $g3->fillRegion( [ $i+0.5, 2.5, 'light' ] );
+    }
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the following solid object formed from a mesh.
+
+[@ image(insertGraph($g1), width=>($n1+$d)*100, height=>(1+$d)*100) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{4*$n1+4}
+
+[`E=`][_____]{8*$n1+4}
+
+[`F=`][_____]{4*$n1+2}
+
+[`\chi=`][_____]{2}
+
+-----
+
+What if the same shape as the previous were formed from [`n`] boxes in a row, instead of just [$n1]?
+
+[`V=`][__________]{"4n+4"}
+
+[`E=`][__________]{"8n+4"}
+
+[`F=`][__________]{"4n+2"}
+
+[`\chi=`][__________]{2}
+
+-----
+
+Consider the following flat (planar) object formed from a mesh.
+
+[@ image(insertGraph($g2), width=>100*$n2+100, height=>100*$m2+100) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{($n2+1)*($m2+1)}
+
+[`E=`][_____]{$n2*($m2+1)+$m2*($n2+1)}
+
+[`F=`][_____]{$n2*$m2}
+
+[`\chi=`][_____]{1}
+
+-----
+
+What if the same shape as the previous were [`n`] squares high and [`m`] squares wide, instead of [`[$m2]\times[$n2]`]?
+
+[`V=`][__________]{"(n+1)*(m+1)"}
+
+[`E=`][__________]{"n*(m+1)+m*(n+1)"}
+
+[`F=`][__________]{"n*m"}
+
+[`\chi=`][__________]{1}
+
+-----
+
+Consider the following solid object formed from a mesh.
+
+[@ image(insertGraph($g3), width=>200*$n3+200, height=>400) @]*
+
+Give the values of [`V`], [`E`], [`F`], and [`\chi`].
+
+[`V=`][_____]{8*$n3+8}
+
+[`E=`][_____]{14*$n3+10}
+
+[`F=`][_____]{5*$n3+3}
+
+[`\chi=`][_____]{1-$n3}
+
+-----
+
+What if the same shape as the previous had [`n`] holes (and thus [`2n+1`] columns), instead of [$n3]?
+
+[`V=`][__________]{"8n+8"}
+
+[`E=`][__________]{"14n+10"}
+
+[`F=`][__________]{"5n+3"}
+
+[`\chi=`][__________]{"1-n"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+For shape 1:
+
+- There are 4 vertices on the leftmost face of the structure, then another 4 to the right of those, and so on, [$n1+1] times, for a total of [`V=[$n1+4+4]`].
+- There are 4 edges forming a ring around the leftmost face of the structure, then another ring of 4 to the right of those, and so on, [$n1+1] rings across the whole structure, for a total of [$n1*4+4] edges in rings.  Then each of the [$n1] cubes has 4 edges that are parallel to the length of the structure, which gives us another [$n1*4] edges.  The total is thus [`E=[$n1*4+4]+[$n1*4]=[$n1*8+4]`].
+- There is a face on the left and a face on the right, which makes two faces.  Then each of the [$n1] cubes also has 4 faces forming a ring around it, which makes [$n1*4].  Thus the total is [`V=[$n1*4+2]`].
+- [`\chi=V-E+F=2`]
+
+If it had [`n`] cubes, the answers would be these:
+
+- [`V=4n+4`] (each ring of vertices contains 4, and there are [`n+1`] rings)
+- [`E=8n+4`] (each ring of edges contains 4, and there are [`n+1`] rings, plus 4 edges per cube parallel to the length of the structre, for another [`4n`])
+- [`F=4n+2`] (2 for the ends, plus 4 for each of the [`n`] cubes)
+- [`\chi=V-E+F=2`]
+
+For shape 2:
+
+- There are [$n2+1] rows of vertices, each of which contains [$m2+1] vertices, so [`V=[$n2+1]\times[$m2+1]=[$n2*$m2+$n2+$m2+1]`].
+- There are [$n2+1] rows of edges, each of which contains [$m2] edges, making [$n2*$m2+$m2] horizontal edges.  There are [$m2+1] columns of edges, each of which contains [$n2] edges, making [$m2*$n2+$n2] vertical edges.  The total is thus [`E=[$n2*$m2*2+$n2+$m2]`].
+- There are [$n2] rows of faces, each of which contains [$m2] faces, for a total of [`F=[$n2*$m2]`].
+- [`\chi=V-E+F=1`]
+
+If it had [`n`] squares vertically and [`m`] horizontally, the answers would be these:
+
+- [`V=(n+1)(m+1)`] (because if the squares form an [`n\times m`] grid, then the vertices form an [`(n+1)\times(m+1)`] grid)
+- [`E=n(m+1)+m(n+1)`] (because there are [`n`] vertical edges per column in [`m+1`] columns, and the opposite for rows)
+- [`F=nm`] (because it's [`n`] squares high and [`m`] wide)
+- [`\chi=V-E+F=1`]
+
+For shape 3:
+
+- There are [$n3*2+1] columns of vertices, each of which contains 4 vertices, making [`V=[$n3*8+4]`].
+- There are [$n3*2+1] columns of edges, each of which contains 3 edges, making [$n3*6+3] vertical edges.  There are 4 rows of edges, each of which contains [$n3*2+1] edges, making [$n3*8+4] horizontal edges.  Thus [`E=[$n3*6+3]+[$n3*2+1]=[$n3*8+4]`].
+- There top and bottom rows each have [$n3*2+1] faces, and the middle row has [$n3+1].  Thus [`F=[$n3*5+3]`].
+- [`\chi=V-E+F=[$n3*-1+1]`]
+
+If it had [`n`] holes, the answers would be these:
+
+- [`V=8n+8`] (two columns of 4 vertices around each hole is [`8n`] plus the two columns of 4 vertices on each end of the structure)
+- [`E=14+10`] (there are [`2n+1`] columns of squares, each having 4 horizontal edges, which gives [`8n+4`]; there are [`2n+2`] columns of 3 vertical edges, which gives [`6n+6`]; add those expressions)
+- [`F=5n+3`] (each hole has a C-shape of 5 faces surrounding it left, above, below, plus 3 in the rightmost column)
+- [`\chi=V-E+F=1-n`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch15/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-1-PointVsVectorEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-1-PointVsVectorEssay.pg
@@ -1,0 +1,43 @@
+## DESCRIPTION
+## Essay: What's the difference between a point and a vector?
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('1')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+State in your own words the difference between a point and a vector.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A point is a location in space.  It describes no motion, only a location, and only one location.
+
+A vector is a motion in space.  It describes no location, only motion, but it can be placed to start at any location in space.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-11-VectorAnimationIn2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-11-VectorAnimationIn2D.pg
@@ -1,0 +1,72 @@
+## DESCRIPTION
+## Question about a simple linear animation along a vector in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('11')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-20,20);
+$b=random(-20,20);
+$c=random(-20,20);
+$d=random(-20,20);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume we wish to make an animation that moves an object from the point [`A=([$a],[$b])`] to the point [`B=([$c],[$d])`].
+
+What sum [`P+\vec v`] is involved in this animation?
+
+Answer: [`(`][__________]{$a},[__________]{$b}[`)~+~\langle`][__________]{$c-$a},[__________]{$d-$b}[`\rangle`]
+
+Compute [`P+\frac12\vec v`] to find where the object would be half way along its path.
+
+Answer: [`(`][__________]{$a+1/2*($c-$a)},[__________]{$b+1/2*($d-$b)}[`)`]
+
+Where is it when it is [`90\%`] of the way along?
+
+Answer: [`(`][__________]{$a+0.9*($c-$a)},[__________]{$b+0.9*($d-$b)}[`)`]
+
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The vector for the object's motion goes from [`A`] to [`B`], and is thus
+
+  [``B-A=([$c],[$d])-([$a],[$b])=\langle [$c]-[$a],[$d]-[$b] \rangle=\langle [$c-$a],[$d-$b] \rangle.``]
+
+So the answer to the first question is [`A`] plus that motion vector:
+
+  [``P+\vec v=([$a],[$b])+\langle [$c-$a],[$d-$b] \rangle``]
+
+To find where the object is half way along, we compute [`P+\frac12\vec v`]:
+
+  [``P+\frac12\vec v=([$a],[$b])+\frac12\langle [$c-$a],[$d-$b] \rangle
+  =([$a]+[$c/2-$a/2],[$b]+[$d/2-$b/2])=([$a/2+$c/2],[$b/2+$d/2])``]
+
+To find where the object is when it is [`90\%`] of the way along, we compute [`P+0.9\vec v`]:
+
+  [``P+0.9\vec v=([$a],[$b])+0.9\langle [$c-$a],[$d-$b] \rangle
+  =([$a]+[$c*0.9-$a*0.9],[$b]+[$d*0.9-$b*0.9])=([$a*0.1+$c*0.9],[$b*0.1+$d*0.9])``]
+
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-12-NoUnitVector2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-12-NoUnitVector2D.pg
@@ -1,0 +1,40 @@
+## DESCRIPTION
+## Which 2D vector has no corresponding unit vector?  (No randomization.)
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('12')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Which vector in two-dimensional space has no corresponding unit vector?
+
+Answer: [`\langle`][__________]{0},[__________]{0}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Computing a unit vector requires dividing by the magnitude of the original vector.  If a vector has magnitude zero, the computation cannot be done.  There is only one vector with magnitude zero, and it is [`\langle 0,0 \rangle`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-14-PythagoreanDistanceEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-14-PythagoreanDistanceEssay.pg
@@ -1,0 +1,45 @@
+## DESCRIPTION
+## Essay: Use the Pythagorean theorem to justify the vector magnitude formula
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('14')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Use the Pythagorean Theorem to explain why the formula [`||\langle x,y \rangle||=\sqrt{x^2+y^2}`] makes sense.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The vectors [`\langle x,0 \rangle`] and [`\langle 0,y \rangle`] can be arranged to form two sides of a right triangle whose hypotenuse is the vector [`\langle x,y \rangle`].  The lengths of those two vectors are obviously [`x`] and [`y`], respectively.
+
+If we use [`m`] for the magnitude of [`\langle x,y \rangle`], then it is the length of the triangle's hypotenuse, and so the Pythagorean Theorem tells us that [`x^2+y^2=m^2`].
+
+If we solve for [`m`], we get [`m=\sqrt{x^2+y^2}`].  Since [`m`] is the magnitude (normally written [`||\langle x,y \rangle||`]) we have given justification for the original formula, [`||\langle x,y \rangle||=\sqrt{x^2+y^2}`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-15-ProveScalarRespectsMagnitude.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-15-ProveScalarRespectsMagnitude.pg
@@ -1,0 +1,44 @@
+## DESCRIPTION
+## Essay: Prove that scalar product commutes with magnitude
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('15')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Prove that for any scalar [`s>0`] and any vector [`\vec v`], [`||s\vec v||=s||\vec v||`].
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Assume [`\vec v=\langle x,y \rangle`].
+
+[``||s\vec v||=||s\langle x,y \rangle||=||\langle sx,sy \rangle||
+=\sqrt{(sx)^2+(sy)^2}=\sqrt{s^2(x^2+y^2)}=s\sqrt{x^2+y^2}=s||\langle x,y \rangle||=s||\vec v||``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-16-MagnitudeDirectionFreedomEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-16-MagnitudeDirectionFreedomEssay.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Essay: Explain the degrees of freedom in magnitude and direction
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('16')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+A two-dimensional vector [`\langle x,y \rangle`] has two variables, [`x`] and [`y`], and thus two degrees of freedom.
+
+If we convert it into its magnitude [`m=||\langle x,y \rangle||`] and direction [`\hat u=\widehat{\langle x,y \rangle}`], it seems that we have [`m`] with one degree of freedom (since it is a scalar) and [`\hat u`] with two degrees of freedom (since it is a vector).
+
+Is that correct?  Explain whether there is a difference in degrees of freedom, and why or why not.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The vector [`\hat u`] does not have two degrees of freedom.  If you know only the single scalar value [`\theta`] that is the angle that [`\hat u`] forms with the positive [`x`] axis, you know both components of [`\hat u`].  Furthermore, if you know one component of [`\hat u`], you know the other one completely except for its sign; it is not "free."
+
+So while it may at first seem that magnitude and direction of a two-dimensional vector have three degrees of freedom, upon closer inspection we see that they do not.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-17-SameUnitVectorButNotParallel2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-17-SameUnitVectorButNotParallel2D.pg
@@ -1,0 +1,43 @@
+## DESCRIPTION
+## Given a unit vector, find a different one parallel to it in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('17')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$theta = random(0.1,2*3.14,0.01);
+$x = round(cos($theta)*100)/100;
+$y = round(sin($theta)*100)/100;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the (approximate) unit vector [`\langle [$x],[$y] \rangle`].  Give another unit vector different from it, but still parallel to it.
+
+Answer: [`\langle`][_______]{-$x},[_______]{-$y}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are parallel if they are scalar multiples of one another.  If we multiply [`\langle [$x],[$y] \rangle`] by any scalar, it will change its length, making it no longer a unit vector, unless the scalar we choose is [`1`] or [`-1`].  Multiplying by [`1`] gives us the same vector again, but we were asked for a different one.  Thus we must choose [`-1\cdot\langle [$x],[$y] \rangle`], which is [`\langle [$x*-1],[$y*-1] \rangle`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-2-PointVectorRelationshipEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-2-PointVectorRelationshipEssay.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Essay: What's the relationship between (a,b) and <a,b>?
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('2')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(1,20);
+$b=random(1,20);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Describe the relationship between [`([$a],[$b])`] and [`\langle [$a],[$b] \rangle`].
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The expression [`([$a],[$b])`] refers to a point in two dimensional space, [$a] units to the right of the origin and [$b] units above it.
+
+The expression [`\langle [$a],[$b] \rangle`] refers to a two-dimensional vector, which expresses a motion of [$a] steps to the right and [$b] steps upward.  It does not contain any notion of starting or ending location.
+
+If [`\langle [$a],[$b] \rangle`] were placed so that it started at the origin, it would end at the point [`([$a],[$b])`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-4-DefinitionOfParallelEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-4-DefinitionOfParallelEssay.pg
@@ -1,0 +1,41 @@
+## DESCRIPTION
+## Essay: What does it mean for two vectors to be parallel?
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+What does it mean for two vectors to be parallel?
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+They are scalar multiples of one another.  In other words, if the two vectors are [`\vec v`] and [`\vec w`], then there is some real number value [`s`] (a "scalar") such that [`s\vec v=\vec w`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-5-AddConstantPointAndVector2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-5-AddConstantPointAndVector2D.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Adding in 2D a point and vector containing constants
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('5')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b])`] and [`\vec v=\langle [$c],[$d] \rangle`], then what is [`A+\vec v`]?
+
+Answer: [`(`][_____]{$a+$c},[_____]{$b+$d}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are added componentwise.  That is, the left components are added, and the right components are added, to produce the left and right components (respectively) of the new vector.
+[``([$a],[$b]) + \langle [$c],[$d] \rangle
+= ([$a]+[$c],[$b]+[$d])
+= ([$a+$c],[$b+$d])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-5-AddConstantVectorAndPoint2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-5-AddConstantVectorAndPoint2D.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Adding in 2D a vector and point containing constants
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('5')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b])`] and [`\vec v=\langle [$c],[$d] \rangle`], then what is [`\vec v+A`]?
+
+Answer: [`(`][_____]{$a+$c},[_____]{$b+$d}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are added componentwise.  That is, the left components are added, and the right components are added, to produce the left and right components (respectively) of the new vector.
+[``\langle [$c],[$d] \rangle + ([$a],[$b])
+= ([$c]+[$a],[$d]+[$b])
+= ([$c+$a],[$d+$b])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-5-AddConstantVectors2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-5-AddConstantVectors2D.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Adding two 2D vectors containing constants
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('5')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`\vec v=\langle [$a],[$b] \rangle`] and [`\vec w=\langle [$c],[$d] \rangle`], then what is [`\vec v+\vec w`]?
+
+Answer: [`\langle`][_____]{$a+$c},[_____]{$b+$d}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are added componentwise.  That is, the left components are added, and the right components are added, to produce the left and right components (respectively) of the new vector.
+[``\langle [$a],[$b] \rangle + \langle [$c],[$d] \rangle
+= \langle [$a]+[$c],[$b]+[$d] \rangle
+= \langle [$a+$c],[$b+$d] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorBetweenDecimalPoints2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorBetweenDecimalPoints2D.pg
@@ -1,0 +1,46 @@
+## DESCRIPTION
+## Finding the vector between two constant points in 2D, with decimals
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('6')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10,0.1);
+$b=random(-10,10,0.1);
+$c=random(-10,10,0.1);
+$d=random(-10,10,0.1);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b])`] and [`B=([$c],[$d])`], then what is the vector from [`A`] to [`B`]?
+
+Answer: [`\langle`][_____]{$c-$a},[_____]{$d-$b}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``B-A=([$c],[$d])-([$a],[$b])=([$c]-[$a],[$d]-[$b])=([$c-$a],[$d-$b])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorBetweenFormulaPoints2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorBetweenFormulaPoints2D.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Finding the vector between two non-constant points in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('6')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+$a=non_zero_random(-10,10);
+$b=non_zero_random(-10,10);
+$c=non_zero_random(-10,10);
+$d=non_zero_random(-10,10);
+$lhs1=($a*Formula("a"))->reduce;
+$rhs1=($b*Formula("b"))->reduce;
+$lhs2=($c*Formula("a"))->reduce;
+$rhs2=($d*Formula("b"))->reduce;
+$lhs=(($c-$a)*Formula("a"))->reduce;
+$rhs=(($d-$b)*Formula("b"))->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the vector between the point [`([$lhs1],[$rhs1])`] and the point [`([$lhs2],[$rhs2])`]?
+
+Answer: [`\langle`][_____]{$lhs},[_____]{$rhs}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``([$lhs2],[$rhs2])-([$lhs1],[$rhs1])=([$lhs2-$lhs1],[$rhs2-$rhs1])=([$lhs],[$rhs])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorBetweenPoints2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorBetweenPoints2D.pg
@@ -1,0 +1,46 @@
+## DESCRIPTION
+## Finding the vector between two constant points in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('6')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b])`] and [`B=([$c],[$d])`], then what is the vector from [`A`] to [`B`]?
+
+Answer: [`\langle`][_____]{$c-$a},[_____]{$d-$b}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``B-A=([$c],[$d])-([$a],[$b])=([$c]-[$a],[$d]-[$b])=([$c-$a],[$d-$b])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorFromOriginToPoint2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-6-VectorFromOriginToPoint2D.pg
@@ -1,0 +1,53 @@
+## DESCRIPTION
+## Finding the vector between two constant points in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('6')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b])`] then what is the vector from the origin to [`A`]?
+
+Answer: [`\langle`][_____]{$a},[_____]{$b}[`\rangle`]
+
+And what is the vector from [`A`] to the origin?
+
+Answer: [`\langle`][_____]{-$a},[_____]{-$b}[`\rangle`]
+
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``A-O=([$a],[$b])-(0,0)=([$a]-0,[$b]-0)=([$a],[$b])``]
+
+[``O-A=(0,0)-([$a],[$b])=(0-[$a],0-[$b])=([$a*-1],[$b*-1])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointPartialVector2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointPartialVector2D.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Finding the endpoint of a constant vector from a constant point in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('7')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$denom=random(2,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$a],[$b] \rangle`] and [`A`] be the point [`([$c],[$d])`].
+
+What is the endoint of [`\frac{1}{[$denom]}`] of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$a/$denom+$c},[_____]{$b/$denom+$d}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To compute [`\frac{1}{[$denom]}`] of [`\vec v`], simply multiply each component of [`\vec v`] by [`\frac{1}{[$denom]}`].
+
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$c],[$d])+\frac{1}{[$denom]}\langle [$a],[$b] \rangle
+=([$c],[$d])+\left\langle \frac{[$a]}{[$denom]},\frac{[$b]}{[$denom]} \right\rangle
+=([$c]+[$a/$denom],[$d]+[$b/$denom])
+=([$c+$a/$denom],[$d+$b/$denom])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointPartialVectorFormula2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointPartialVectorFormula2D.pg
@@ -1,0 +1,64 @@
+## DESCRIPTION
+## Finding the endpoint of a non-constant vector from a non-constant point in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('7')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+$a=non_zero_random(-10,10);
+$b=non_zero_random(-10,10);
+$c=non_zero_random(-10,10);
+$d=non_zero_random(-10,10);
+$denom=random(2,10);
+$lhs1=($a*Formula("a"))->reduce;
+$rhs1=($b*Formula("b"))->reduce;
+$lhs2=($c*Formula("a"))->reduce;
+$rhs2=($d*Formula("b"))->reduce;
+$lhs1frac=($a/$denom*Formula("a"))->reduce;
+$rhs1frac=($b/$denom*Formula("a"))->reduce;
+$lhs=(($c+$a/$denom)*Formula("a"))->reduce;
+$rhs=(($d+$b/$denom)*Formula("b"))->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$lhs1],[$rhs1] \rangle`] and [`A`] be the point [`([$lhs2],[$rhs2])`].
+
+What is the endoint of [`\frac{1}{[$denom]}`] of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$lhs},[_____]{$rhs}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To find [`\frac{1}{[$denom]}`] of a vector, multiply each component of that vector by [`\frac{1}{[$denom]}`].
+
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$lhs2],[$rhs2])+\frac{1}{[$denom]}\langle [$lhs1],[$rhs1] \rangle
+=([$lhs2],[$rhs2])+\left\langle \frac{[$lhs1]}{[$denom]},\frac{[$rhs1]}{[$denom]} \right\rangle
+=([$lhs2]+[$lhs1frac],[$rhs2]+[$rhs1frac])
+=([$lhs],[$rhs])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointVector2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointVector2D.pg
@@ -1,0 +1,50 @@
+## DESCRIPTION
+## Finding the endpoint of a constant vector from a constant point in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('7')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$a],[$b] \rangle`] and [`A`] be the point [`([$c],[$d])`].
+
+What is the endoint of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$a+$c},[_____]{$b+$d}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$c],[$d])+\langle [$a],[$b] \rangle
+=([$c]+[$a],[$d]+[$b])
+=([$c+$a],[$d+$b])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointVectorFormula2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-7-EndpointPointVectorFormula2D.pg
@@ -1,0 +1,58 @@
+## DESCRIPTION
+## Finding the endpoint of a non-constant vector from a non-constant point in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('7')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+$a=non_zero_random(-10,10);
+$b=non_zero_random(-10,10);
+$c=non_zero_random(-10,10);
+$d=non_zero_random(-10,10);
+$lhs1=($a*Formula("a"))->reduce;
+$rhs1=($b*Formula("b"))->reduce;
+$lhs2=($c*Formula("a"))->reduce;
+$rhs2=($d*Formula("b"))->reduce;
+$lhs=(($c+$a)*Formula("a"))->reduce;
+$rhs=(($d+$b)*Formula("b"))->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$lhs1],[$rhs1] \rangle`] and [`A`] be the point [`([$lhs2],[$rhs2])`].
+
+What is the endoint of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$lhs},[_____]{$rhs}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$lhs2],[$rhs2])+\langle [$lhs1],[$rhs1] \rangle
+=([$lhs2]+[$lhs1],[$rhs2]+[$rhs1])
+=([$lhs],[$rhs])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionDecimals2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionDecimals2D.pg
@@ -1,0 +1,59 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 2D point with decimal coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('8')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$sign=list_random(-1,1);
+$a=$sign*random(0.1,20,0.1);
+$b=-$sign*random(0.1,20,0.1);
+$mag=sqrt($a**2+$b**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\langle [$a],[$b] \rangle`].
+
+What is its magnitude?
+
+Answer: [__________]{sqrt($a**2+$b**2)}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$a/$mag},[__________]{$b/$mag}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The magnitude of a vector [`\langle x,y\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2}=\sqrt{[$a**2]+[$b**2]}=\sqrt{[$a**2+$b**2]}=[$smag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$a],[$b] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionFormulas2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionFormulas2D.pg
@@ -1,0 +1,71 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 2D point with variable coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('8')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+$showPartialCorrectAnswers = 1;
+$aindex = random(0,2);
+do { $bindex = random(0,2); } until ($aindex+$bindex > 0);
+$a = ("0","-a","a")[$aindex];
+$b = ("0","-a","a")[$bindex];
+$signa = (0,-1,1)[$aindex];
+$signb = (0,-1,1)[$bindex];
+if ($aindex*$bindex > 0) {
+  $num=2;
+  $coeff=sprintf("%.5f",1/sqrt(2));
+  $mag=Formula("sqrt(2) * a");
+} else {
+  $num=1;
+  $coeff=1;
+  $mag=Formula("a");
+}
+@dir = ($coeff*$signa,$coeff*$signb);
+$intermediate = Formula("$num a^2")->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\langle [$a],[$b] \rangle`], with [`a>0`].
+
+What is its magnitude?
+
+Answer: [__________]{$mag}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The magnitude of a vector [`\langle x,y\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2}`].  In this case, that computation yields the following, because [`a>0`]:
+
+[``\sqrt{([$a])^2+([$b])^2}=\sqrt{[$intermediate]}=[$mag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$a],[$b] \rangle}{[$mag]}=\langle [$dir[0]],[$dir[1]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionFractions2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionFractions2D.pg
@@ -1,0 +1,66 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 2D point with negative fractional coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('8')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$adenom=random(2,10);
+$bdenom=random(2,10);
+$a=-1/$adenom;
+$b=-1/$bdenom;
+$sa=sprintf("%.5f",$a);
+$sb=sprintf("%.5f",$b);
+$sa2=sprintf("%.5f",$a**2);
+$sb2=sprintf("%.5f",$b**2);
+$mag=sqrt($a**2+$b**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\left\langle -\frac{1}{[$adenom]},-\frac{1}{[$bdenom]} \right\rangle`].
+
+What is its magnitude?
+
+Answer: [__________]{sqrt($a**2+$b**2)}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$a/$mag},[__________]{$b/$mag}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We rewrite [`\left\langle -\frac{1}{[$adenom]},-\frac{1}{[$bdenom]} \right\rangle`] as [`\langle [$sa],[$sb] \rangle`].
+
+The magnitude of a vector [`\langle x,y\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$sa]^2+[$sb]^2}=\sqrt{[$sa2]+[$sb2]}=[$smag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$sa],[$sb] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionIntegers2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-8-MagnitudeAndDirectionIntegers2D.pg
@@ -1,0 +1,58 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 2D point with positive integer coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('8')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(1,20);
+$b=random(1,20);
+$mag=sqrt($a**2+$b**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\langle [$a],[$b] \rangle`].
+
+What is its magnitude?
+
+Answer: [__________]{sqrt($a**2+$b**2)}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$a/$mag},[__________]{$b/$mag}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The magnitude of a vector [`\langle x,y\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2}=\sqrt{[$a**2]+[$b**2]}=\sqrt{[$a**2+$b**2]}=[$smag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$a],[$b] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-9-UnitVectorOfDecimals2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-9-UnitVectorOfDecimals2D.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Finding the unit vector of a 2D vector with decimal coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('9')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=non_zero_random(-20,20,0.01);
+$b=non_zero_random(-20,20,0.01);
+$mag=sqrt($a**2+$b**2);
+$smag=sprintf("%.6f",$mag);
+@dir=($a/$mag,$b/$mag);
+@sdir=(sprintf("%.6f",$dir[0]),sprintf("%.6f",$dir[1]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the unit vector for the vector [`\langle [$a],[$b] \rangle`]?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A unit vector is computed by dividing the original vector by its magnitude.
+
+The magnitude of a vector [`\langle x,y\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2}=\sqrt{[$a**2]+[$b**2]}=\sqrt{[$a**2+$b**2]}=[$smag]``]
+
+So we can now finish the unit vector computation, as follows.
+
+[``\frac{\langle [$a],[$b] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-9-UnitVectorOfIntegers2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch2/2-9-UnitVectorOfIntegers2D.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Finding the unit vector of a 2D vector with integer coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('2')
+## Problem1('9')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=non_zero_random(-20,20);
+$b=non_zero_random(-20,20);
+$mag=sqrt($a**2+$b**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the unit vector for the vector [`\langle [$a],[$b] \rangle`]?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A unit vector is computed by dividing the original vector by its magnitude.
+
+The magnitude of a vector [`\langle x,y\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2}=\sqrt{[$a**2]+[$b**2]}=\sqrt{[$a**2+$b**2]}=[$smag]``]
+
+So we can now finish the unit vector computation, as follows.
+
+[``\frac{\langle [$a],[$b] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-1-WriteTransformationAsFunction2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-1-WriteTransformationAsFunction2D.pg
@@ -1,0 +1,70 @@
+## DESCRIPTION
+## Writing 2D affine transformations as functions
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('1')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+$showPartialCorrectAnswers = 1;
+$tx1=0;
+$ty1=random(2,20);
+$sx=random(2,5);
+$sydenom=random(2,5);
+@thetas=(30,45,60,90,180,270);
+@sines=("1/2","sqrt(2)/2","sqrt(3)/2","1","0","-1");
+@cosines=("sqrt(3)/2","sqrt(2)/2","1/2","0","-1","0");
+$thetaindex1=random(0,5);
+$thetaindex2=($thetaindex1+random(1,5))%6;
+$tx2=-random(1,5);
+$ty2=-random(1,5);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Fill in the blanks to write each of the affine transformations as a function.
+
+[`T_{[$tx1],[$ty1]}(x,y)=(`][_____]{"x+$tx1"},[_____]{"y+$ty1"}[`)`]
+
+[`S_{[$sx],1/[$sydenom]}(x,y)=(`][_____]{"x*$sx"},[_____]{"y/$sydenom"}[`)`]
+
+[`F(x,y)=(`][_____]{"-x"},[_____]{"y"}[`)`]
+
+[`R_{[$thetas[$thetaindex1]]}(x,y)=(`][_____]{"x*$cosines[$thetaindex1]-y*$sines[$thetaindex1]"},[_____]{"x*$sines[$thetaindex1]+y*$cosines[$thetaindex1]"}[`)`]
+
+[`R_{[$thetas[$thetaindex2]]}(x,y)=(`][_____]{"x*$cosines[$thetaindex2]-y*$sines[$thetaindex2]"},[_____]{"x*$sines[$thetaindex2]+y*$cosines[$thetaindex2]"}[`)`]
+
+[`T_{[$tx2],[$ty2]}(x,y)=(`][_____]{"x+$tx2"},[_____]{"y+$ty2"}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``T_{a,b}(x,y)=(a+x,b+y)``]
+
+[``S_{a,b}(x,y)=(ax,by)``]
+
+[``F(x,y)=(-x,y)``]
+
+[``R_{\theta}(x,y)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta)``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-10-WriteTransformationConjugacy2.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-10-WriteTransformationConjugacy2.pg
@@ -1,0 +1,46 @@
+## DESCRIPTION
+## Combining 2D affine transformations with conjugacy, no.2
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('10')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+How would you reflect a figure vertically instead of horizontally?  Write a formula for a transformation that interchanges the two ends of the [`y`] axis instead of the two ends of the [`x`] axis (as [`F`] does).
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+Now do the same thing, but without using a scaling transformation [`S_{a,b}`].
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Using a scaling transformation, this is easy: [`F=S_{-1,1}`], so a vertical flip is [`S_{1,-1}`] instead.
+
+Without using [`S_{a,b}`], we can take a combined approach.  First, swap the [`x`] and [`y`] axes with [`R_{90^\circ}`], then apply [`F`], then put things back with [`R_{-90^\circ}`].  The final result is then [`R_{-90\circ}\circ F\circ R_{90^\circ}`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-11-WriteTransformationConjugacy3.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-11-WriteTransformationConjugacy3.pg
@@ -1,0 +1,46 @@
+## DESCRIPTION
+## Combining 2D affine transformations with conjugacy, no.3
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('11')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write a transformation that reflects the affine plane across the line [`y=mx`].
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+Write a transformation that reflects the affine plane across the line [`y=mx+b`].
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The angle between the [`x`] axis and the line [`y=mx`] is [`\tan^{-1}m`].  Thus we should first rotate [`y=mx`] down to the [`x`] axis, then flip vertically, then undo the rotation.  The sequence of transformations is therefore [`R_{\tan^{-1}m}S_{1,-1}R_{-\tan^{-1}m}`].
+
+The same solution works for the second part, except that we must first move the line [`y=mx+b`] down to be the line [`y=mx`] with a translation, and then put it back up in its original position.  Thus we wrap the previous solution in two translations, yielding [`T_{0,b}R_{\tan^{-1}m}S_{1,-1}R_{-\tan^{-1}m}T_{0,-b}`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-16-BuildACheckerboard.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-16-BuildACheckerboard.pg
@@ -1,0 +1,48 @@
+## DESCRIPTION
+## Building a checkerboard by applying affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('16')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a standard checkerboard (or chessboard), constructed of alternating light and dark tiles, eight tiles per side. Assume that you have two images, one of the light tile and one of the dark tile, and that each is a 1-unit-by-1-unit square with its lower left corner on the origin. Describe the set of transformations you would use to create the checkerboard from copies of them. You do not need to write all 64 transformations if you can describe the set more succinctly.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Assume the light tile is called [`L`] and the dark tile is called [`D`].
+Then for the even numbers [`n = 0, 2, 4, 6`], we would create rows that begin with light tiles and end with dark tiles,
+
+[`T_{0,n}L, ~T_{1,n}D, ~T_{2,n}L, ~T_{3,n}D, ~T_{4,n}L, ~T_{5,n}D, ~T_{6,n}L, ~T_{7,n}D.`]
+
+For the odd numbers [`n = 1, 3, 5, 7`], we would create rows that begin with light tiles and end with dark tiles, by taking
+the transformations above and interchanging the [`L`]s and [`D`]s.
+
+[`T_{0,n}D, ~T_{1,n}L, ~T_{2,n}D, ~T_{3,n}L, ~T_{4,n}D, ~T_{5,n}L, ~T_{6,n}D, ~T_{7,n}L.`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-17-UnderstandingCombiningTransformations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-17-UnderstandingCombiningTransformations.pg
@@ -1,0 +1,95 @@
+## DESCRIPTION
+## Understanding combining 2D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('17')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$a = non_zero_random(-10,10);
+$b = non_zero_random(-10,10);
+$c = non_zero_random(-10,10);
+$d = non_zero_random(-10,10);
+$theta = non_zero_random(-89,89);
+$n = random(5,13,2);
+$expanded = "";
+for (my $i=0; $i < $n; $i++) { $expanded .= "F"; }
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+For what values of [`a`] and [`b`] is [`T_{[$a],[$b]}T_{[$c],[$d]}=T_{a,b}`]?
+
+[`a=`][_____]{$a+$c}
+
+[`b=`][_____]{$b+$d}
+
+For what value of [`\theta`] is [`FR_{[$theta]^\circ}=R_{\theta}F`]?
+
+[`\theta=`][_____]{-$theta}
+
+Fill in the following blanks.
+
+[`R_{\theta}R_{-\theta}=`][___]{PopUp( [ (
+  '(make a choice)',
+  'rotation by 2 times theta',
+  'rotation by -2 times theta',
+  'I (the identity transformation)',
+  'rotation by theta squared',
+  'rotation by negative theta squared',
+  'none of the above'
+) ], 'I (the identity transformation)' )}
+
+[`F^{[$n]}=[$expanded]=`][___]{PopUp( [ (
+  '(make a choice)',
+  'F to the ' . $n . 'th power (cannot be simplified)',
+  'F to the ' . ($n-1) . 'th power',
+  'F',
+  'I (the identity transformation)',
+  'none of the above'
+) ], 'F' )}
+
+If [`n`] is an even number, then [`F^n=`][___]{PopUp( [ (
+  '(make a choice)',
+  'F to the nth power (cannot be simplified)',
+  'F to the (n-1)th power',
+  'F',
+  'I (the identity transformation)',
+  'none of the above'
+) ], 'I (the identity transformation)' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`T_{[$a],[$b]}T_{[$c],[$d]}=T_{[$a]+[$c],[$b]+[$d]}=T_{[$a+$c],[$b+$d]}`]
+
+[`FR_{[$theta]^\circ}=R_{-[$theta]^\circ}F`]
+
+[`R_{\theta}R_{-\theta}=R_0=I`]
+
+[`F^{[$n]}=F`] because of the answer to the next question.
+
+If [`n`] is even, then [`F^n=I`].  Recall that [`F^2=I`], and thus any even number of [`F`]'s is just repeated applications of [`I`], which make no change to the figure.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-18-SimplifyingCombinedTransformations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-18-SimplifyingCombinedTransformations.pg
@@ -1,0 +1,48 @@
+## DESCRIPTION
+## Simplifying combinations of 2D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('18')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Simplify the expressions.
+
+[`T_{a,b}T_{c,d}T_{e,f}=`][@ ANS(essay_cmp); essay_box(1,20) @]*
+
+[`S_{a,b}S_{c,d}S_{e,f}=`][@ ANS(essay_cmp); essay_box(1,20) @]*
+
+[`R_{\theta}R_{\phi}R_{\rho}=`][@ ANS(essay_cmp); essay_box(1,20) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`T_{a+c+e,b+d+f}`]
+
+[`S_{ace,bdf}`]
+
+[`R_{\theta+\phi+\rho}`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-2-ApplyAffineTransformations2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-2-ApplyAffineTransformations2D.pg
@@ -1,0 +1,86 @@
+## DESCRIPTION
+## Applying 2D affine transformations as functions
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('2')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+$showPartialCorrectAnswers = 1;
+$tx1=0;
+$ty1=random(2,20);
+$sx=random(2,5);
+$sydenom=random(2,5);
+@thetas=(30,45,60,90,180,270);
+@sines=(1/2,sqrt(2)/2,sqrt(3)/2,1,0,-1);
+@cosines=(sqrt(3)/2,sqrt(2)/2,1/2,0,-1,0);
+$thetaindex1=random(0,5);
+$thetaindex2=($thetaindex1+random(1,5))%6;
+$tx2=-random(1,5);
+$ty2=-random(1,5);
+$P1x=0;
+$P1y=0;
+$P2x=non_zero_random(-10,10,0.5);
+$P2y=non_zero_random(-10,10,0.5);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Apply the affine transformations below to the points as requested.
+
+[`T_{[$tx1],[$ty1]}([$P1x],[$P1y])=(`][_____]{$P1x+$tx1},[_____]{$P1y+$ty1}[`)`]
+
+[`T_{[$tx1],[$ty1]}([$P2x],[$P2y])=(`][_____]{$P2x+$tx1},[_____]{$P2y+$ty1}[`)`]
+
+[`S_{[$sx],1/[$sydenom]}([$P1x],[$P1y])=(`][_____]{$P1x*$sx},[_____]{$P1y/$sydenom}[`)`]
+
+[`S_{[$sx],1/[$sydenom]}([$P2x],[$P2y])=(`][_____]{$P2x*$sx},[_____]{$P2y/$sydenom}[`)`]
+
+[`F([$P1x],[$P1y])=(`][_____]{-$P1x},[_____]{$P1y}[`)`]
+
+[`F([$P2x],[$P2y])=(`][_____]{-$P2x},[_____]{$P2y}[`)`]
+
+[`R_{[$thetas[$thetaindex1]]}([$P1x],[$P1y])=(`][_____]{$P1x*$cosines[$thetaindex1]-$P1y*$sines[$thetaindex1]},[_____]{$P1x*$sines[$thetaindex1]+$P1y*$cosines[$thetaindex1]}[`)`]
+
+[`R_{[$thetas[$thetaindex1]]}([$P2x],[$P2y])=(`][_____]{$P2x*$cosines[$thetaindex1]-$P2y*$sines[$thetaindex1]},[_____]{$P2x*$sines[$thetaindex1]+$P2y*$cosines[$thetaindex1]}[`)`]
+
+[`R_{[$thetas[$thetaindex2]]}([$P1x],[$P1y])=(`][_____]{$P1x*$cosines[$thetaindex2]-$P1y*$sines[$thetaindex2]},[_____]{$P1x*$sines[$thetaindex2]+$P1y*$cosines[$thetaindex2]}[`)`]
+
+[`R_{[$thetas[$thetaindex2]]}([$P2x],[$P2y])=(`][_____]{$P2x*$cosines[$thetaindex2]-$P2y*$sines[$thetaindex2]},[_____]{$P2x*$sines[$thetaindex2]+$P2y*$cosines[$thetaindex2]}[`)`]
+
+[`T_{[$tx2],[$ty2]}([$P1x],[$P1y])=(`][_____]{$P1x+$tx2},[_____]{$P1y+$ty2}[`)`]
+
+[`T_{[$tx2],[$ty2]}([$P2x],[$P2y])=(`][_____]{$P2x+$tx2},[_____]{$P2y+$ty2}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``T_{a,b}(x,y)=(a+x,b+y)``]
+
+[``S_{a,b}(x,y)=(ax,by)``]
+
+[``F(x,y)=(-x,y)``]
+
+[``R_{\theta}(x,y)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta)``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-20-InvertingCombinedTransformations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-20-InvertingCombinedTransformations.pg
@@ -1,0 +1,115 @@
+## DESCRIPTION
+## Inverting combinations of 2D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('20')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$a = non_zero_random(-10,10);
+$b = non_zero_random(-10,10);
+$c = non_zero_random(-10,10);
+$d = non_zero_random(-10,10);
+$theta = non_zero_random(-89,89);
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+Assume that we want to write formulas that simplify the following expressions involving inverses. The answers may not include any inverse applied to a parenthetical expression.
+
+-----
+
+First consider [`(T_{[$a],[$b]}R_{[$theta]^\circ})^{-1}`].  What form will the inverse take?
+
+1. [`T_{a,b}R_\theta`] for some values of [`a,b,\theta`]
+2. [`T_{a,b}`] for some values of [`a,b`]
+3. [`R_\theta T_{a,b}`] for some values of [`a,b,\theta`]
+4. [`R_\theta`] for some value of [`\theta`]
+
+Choose an answer: [___]{PopUp( [ (
+  '(make a choice)',
+  'option 1',
+  'option 2',
+  'option 3',
+  'option 4'
+) ], 'option 3' )}
+
+What are the corresponding values of the relevant variables?
+
+[`a=`][_____]{-$a} [`b=`][_____]{-$b} [`\theta=`][_____]{-$theta}[`{}^\circ`]
+
+(Leave any irrelevant variables blank, if there are any.)
+
+-----
+
+Next consider the expression [`(T_{[$a],[$b]}R_{[$theta]^\circ}S_{[$c],[$d]})^{-1}`].  What form will the inverse take?
+
+1. [`T_{a,b}R_\theta S_{c,d}`] for some values of [`a,b,\theta,c,d`]
+2. [`S_{c,d}R_\theta T_{a,b}`] for some values of [`a,b,\theta,c,d`]
+3. [`T_{a,b}S_{c,d}`] for some values of [`a,b,c,d`]
+4. [`T_{a,b}R_\theta`] for some values of [`a,b,\theta`]
+5. [`R_\theta S_{c,d}`] for some values of [`\theta,c,d`]
+
+Choose an answer: [___]{PopUp( [ (
+  '(make a choice)',
+  'option 1',
+  'option 2',
+  'option 3',
+  'option 4',
+  'option 5'
+) ], 'option 2' )}
+
+What are the corresponding values of the relevant variables?
+
+[`a=`][_____]{-$a} [`b=`][_____]{-$b} [`\theta=`][_____]{-$theta}[`{}^\circ`] [`c=`][_____]{1/$c} [`d=`][_____]{1/$d}
+
+(Leave any irrelevant variables blank, if there are any.)
+
+-----
+
+For any transformations [`A_1,A_2,\ldots,A_n`], the inverse of the combined transformation [`(A_1A_2\cdots A_n)^{-1}`] is which of these?
+
+1. [`A_1^{-1}A_2^{-1}\cdots A_n^{-1}`]
+2. [`A_1A_2\cdots A_{n-1}A_n^{-1}`]
+3. [`A_nA_{n-1}\cdots A_2A_1^{-1}`]
+4. [`A_n^{-1}A_{n-1}^{-1}\cdots A_1^{-1}`]
+
+Choose an answer: [___]{PopUp( [ (
+  '(make a choice)',
+  'option 1',
+  'option 2',
+  'option 3',
+  'option 4'
+) ], 'option 4' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The answer to the final question helps answer all of them.  To invert a combined transformation, invert each one and reverse their order.
+
+[`(A_1A_2\cdots A_n)^{-1}=A_n^{-1}A_{n-1}^{-1}\cdots A_1^{-1}`]
+
+Recall also that [`T_{a,b}^{-1}=T_{-a,-b}`], [`R_\theta^{-1}=R_{-\theta}`], and [`S_{a,b}^{-1}=S_{1/a,1/b}`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-21-ProvingCombinedTranslations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-21-ProvingCombinedTranslations.pg
@@ -1,0 +1,46 @@
+## DESCRIPTION
+## Proving the formula for the combination of 2D translations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('21')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write a sequence of equations or simplifications in the box below that shows uses the fact [`T_{a,b}(x,y)=(x+a,y+b)`] to prove the fact [`T_{a,b}T_{c,d}=T_{a+c,b+d}`].
+
+[@ ANS(essay_cmp); essay_box(10,60) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+
+Each step here is true by the fact given in the problem:
+[`T_{a,b}T_{c,d}(x,y)=T_{a,b}(x+c,y+d)=(x+c+a,y+d+b)`]
+
+The final expression above is equal to [`(x+a+c,y+b+d)`] just because of commutativity of ordinary addition.
+
+And that expression is equal to [`T_{a+c,b+d}(x,y)`] by the fact given in the problem.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-22-ProvingCombinedScalings.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-22-ProvingCombinedScalings.pg
@@ -1,0 +1,42 @@
+## DESCRIPTION
+## Proving the formula for the combination of 2D scalings
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('22')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write a sequence of equations or simplifications in the box below that shows uses the fact [`S_{a,b}(x,y)=(ax,by)`] to prove the fact [`S_{a,b}S_{c,d}=S_{ac,bd}`].
+
+[@ ANS(essay_cmp); essay_box(10,60) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+
+Each step here is true by the fact given in the problem:
+[`S_{a,b}S_{c,d}(x,y)=S_{a,b}(cx,dy)=(acx,bdy)=S_{ac,bd}(x,y)`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-26-ProvingRotationFormula.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-26-ProvingRotationFormula.pg
@@ -1,0 +1,56 @@
+## DESCRIPTION
+## Proving the formula for rotation in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('26')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Recall the following formula from the text.
+
+[`R_\theta(x,y)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta)`]
+
+Prove that formula is correct by combining the following hints.
+
+1. Consider the point [`(x,y)`] in polar coordinates [`(r,\alpha)`], so that [`x=r\cos\alpha`] and [`y=r\sin\alpha`].
+2. Recall the trigonometric identity [`\sin(\alpha+\beta)=\sin\alpha\cos\beta+\sin\beta\cos\alpha`].
+3. Recall the trigonometric identity [`\cos(\alpha+\beta)=\cos\alpha\cos\beta-\sin\alpha\sin\beta`].
+
+[@ ANS(essay_cmp); essay_box(10,60) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Using Hint 1, we consider [`(x,y)`] as the point [`(r\cos\alpha, r\sin\alpha)`], which is the point [`(r, 0)`] rotated counterclockwise by the angle [`\alpha`].
+
+We could then obtain the point [`R_\theta(x,y)`] by rotating [`(r,0)`] by another [`\theta`] degrees after the first rotation of [`\alpha`] degrees. That would yield the point [`(r\cos(\alpha+\theta), r\sin(\alpha+\theta))`].
+
+Using Hints 2 and 3, we can expand the summed angles, yielding 
+[`(r\cos\alpha\sin\theta − r\sin\alpha\sin\theta, r\cos\alpha\sin\theta + r\sin\alpha\cos\theta)`].
+
+If we use Hint 1 again, we can replace each [`r\cos\alpha`] with [`x`] and [`r\sin\alpha`] with [`y`], obtaining the formula we have been seeking to justify,
+[`R_\theta(x, y) = (x\cos\theta − y\sin\theta, x\sin\theta + y\cos\theta)`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-30-ProvingRotationCombination.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-30-ProvingRotationCombination.pg
@@ -1,0 +1,56 @@
+## DESCRIPTION
+## Proving the formula for rotation in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('26')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Recall the following formula from the text.
+
+[`R_\theta(x,y)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta)`]
+
+Prove that formula is correct by combining the following hints.
+
+1. Consider the point [`(x,y)`] in polar coordinates [`(r,\alpha)`], so that [`x=r\cos\alpha`] and [`y=r\sin\alpha`].
+2. Recall the trigonometric identity [`\sin(\alpha+\beta)=\sin\alpha\cos\beta+\sin\beta\cos\alpha`].
+3. Recall the trigonometric identity [`\cos(\alpha+\beta)=\cos\alpha\cos\beta-\sin\alpha\sin\beta`].
+
+[@ ANS(essay_cmp); essay_box(10,60) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Using Hint 1, we consider [`(x,y)`] as the point [`(r\cos\alpha, r\sin\alpha)`], which is the point [`(r, 0)`] rotated counterclockwise by the angle [`\alpha`].
+
+We could then obtain the point [`R_\theta(x,y)`] by rotating [`(r,0)`] by another [`\theta`] degrees after the first rotation of [`\alpha`] degrees. That would yield the point [`(r\cos(\alpha+\theta), r\sin(\alpha+\theta))`].
+
+Using Hints 2 and 3, we can expand the summed angles, yielding 
+[`(r\cos\alpha\sin\theta − r\sin\alpha\sin\theta, r\cos\alpha\sin\theta + r\sin\alpha\cos\theta)`].
+
+If we use Hint 1 again, we can replace each [`r\cos\alpha`] with [`x`] and [`r\sin\alpha`] with [`y`], obtaining the formula we have been seeking to justify,
+[`R_\theta(x, y) = (x\cos\theta − y\sin\theta, x\sin\theta + y\cos\theta)`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-32-CombiningRotationsAndTranslations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-32-CombiningRotationsAndTranslations.pg
@@ -1,0 +1,73 @@
+## DESCRIPTION
+## Creating formulas to combine rotation and translation formulas
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('32')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+Context()->variables->add(c => 'Real');
+Context()->variables->add(d => 'Real');
+Context()->variables->add(theta => 'Real');
+
+TEXT(beginproblem());
+BEGIN_PGML
+If we rewrite the transformation [`R_\theta T_{a,b}`] so that the rotation comes first, as in [`T_{c,d}R_\theta`], what are the values of [`c`] and [`d`] (in terms of [`a`], [`b`], and [`\theta`])?
+
+(If you need to type [`\theta`], use the word theta.)
+
+[`c=`][_______________]{"a*cos(theta)+b*sin(theta)"}
+
+[`d=`][_______________]{"b*cos(theta)-a*sin(theta)"}
+
+-----
+
+If we reverse the process, converting [`T_{c,d}R_\theta`] into the form [`R_\theta T_{a,b}`], what are the values of [`a`] and [`b`] (in terms of [`c`], [`d`], and [`theta`])?
+
+(If you need to type [`\theta`], use the word theta.)
+
+[`a=`][_______________]{"c*cos(theta)-d*sin(theta)"}
+
+[`b=`][_______________]{"c*sin(theta)+d*cos(theta)"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`T_{a,b}(R_\theta(x,y))=(x\cos\theta-y\sin\theta+a,x\sin\theta+y\cos\theta+b)`]
+
+[`R_\theta(T_{c,d}(x,y))=((x+c)\cos\theta-(y+d)\sin\theta,(x+c)\sin\theta+(y+d)\cos\theta)`]
+
+Setting the components equal and multiplying out the right hand sides, then canceling yields two equations.
+
+[`a=c\cos\theta-d\sin\theta`]
+
+[`b=c\sin\theta+d\cos\theta`]
+
+To reverse the process and solve for [`c`] and [`d`] in terms of [`a`] and [`b`], we simply treat the trig parts as coefficients and [`c`] and [`d`] as variables.  Then it is a two-variable, two-equation problem, yielding these solutions.
+
+[`c=a\cos\theta+b\sin\theta`]
+
+[`d=b\cos\theta-a\sin\theta`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-34-OrientationPreservingScalings.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-34-OrientationPreservingScalings.pg
@@ -1,0 +1,45 @@
+## DESCRIPTION
+## Orientation preserving and reversing scalings in 2D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('34')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+A scaling transformation with both [`x`] and [`y`] coordinates negative is not orientation-reversing. Consider the transformation [`S_{-1,-1}`] and verify that it does not interchange left and right. To what non-scaling transformation is [`S_{-1,-1}`] equivalent?
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+It is equivalent to [`R_{180^\circ}`].
+
+Notice:
+
+[`R_{180^\circ}(x,y)=(x\cos180^\circ-y\sin180^\circ,x\sin180^\circ+y\cos180^\circ)`]
+
+[`=(x(-1)-y(0),x(0)+y(-1))=(-x,-y)=S_{-1,-1}(x,y)`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-35-RotationPlusScalingIsntTranslation.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-35-RotationPlusScalingIsntTranslation.pg
@@ -1,0 +1,40 @@
+## DESCRIPTION
+## Explain why rotations and scalings can't create translations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/17/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('35')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+Explain briefly why no combination of rotation and scaling transformations will ever equal a translation transformation.
+
+[@ ANS(essay_cmp); essay_box(2,60) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Neither scaling nor rotation transformations move the origin. Translations move the origin, and thus include many transformations not achievable by combining rotations and scalings.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-5-AffineTransformationsOfUnitCircle.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-5-AffineTransformationsOfUnitCircle.pg
@@ -1,0 +1,77 @@
+## DESCRIPTION
+## Questions about affine transformations of the unit circle
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('2')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$r1=random(10,20);
+$c1x=non_zero_random(-10,10);
+$c1y=non_zero_random(-10,10);
+$r2=random(10,20);
+$c2x=non_zero_random(-10,10);
+$c2y=non_zero_random(-10,10);
+$theta=random(10,350,10);
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the unit circle, which is centered at the origin and has radius 1.
+
+What transformation should be applied to it to yield a circle with radius [`[$r1]`] and the same center?
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+What transformation should be applied to it to yield a circle with the same radius but center [`([$c1x],[$c1y])`]?
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+What transformation should be applied to it to yield a circle with radius [`[$r2]`] and center [`([$c2x],[$c2y])`]?
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+What effect does [`F`] have on the unit circle?
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+What effect does [`R_{[$theta]^\circ}`] have on the unit circle?
+
+[@ ANS(essay_cmp); essay_box(1,30) @]*
+
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``S_{[$r1],[$r1]}``]
+
+[``T_{[$c1x],[$c1y]}``]
+
+[``T_{[$c2x],[$c2y]}S_{[$r2],[$r2]}``]
+
+[`F`] has no effect on the unit circle.
+
+[`R_{[$theta]^\circ}`] has no effect on the unit circle.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-6-LocalVsGlobalCoordSystem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-6-LocalVsGlobalCoordSystem.pg
@@ -1,0 +1,44 @@
+## DESCRIPTION
+## Local vs. global when combining transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Composition of transformations)
+## Date(01/15/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('6')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "parserPopUp.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+@options = ( '(make a choice)', 'global', 'local', 'neither', 'both' );
+$pop = PopUp( [ @options ], 'global' );
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is multiple choice, you are permitted ONLY ONE ATTEMPT.  Use it wisely.*
+
+When performing two affine transformations in sequence to place an object into a scene, does the second transformation happen in the global coordinate system or in the local coordinate system?
+
+Choose your answer from this list: [__]{$pop}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+These terms and their relationship are covered in Section 3.3 of the text.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-7-WriteCombinationAsFunction2D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-7-WriteCombinationAsFunction2D.pg
@@ -1,0 +1,81 @@
+## DESCRIPTION
+## Combining 2D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('7')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+@angles = (30,45,60,90,180,270);
+@cosines = (sqrt(3)/2,sqrt(2)/2,1/2,0,-1,0);
+@texcos = ("\frac{\sqrt3}2","\frac{\sqrt2}2","\frac12","0","-1","0");
+@sines = (1/2,sqrt(2)/2,sqrt(3)/2,1,0,-1);
+@texsin = ("\frac12","\frac{\sqrt2}2","\frac{\sqrt3}2","1","0","-1");
+$a = non_zero_random(-9,9);
+$b = non_zero_random(-9,9);
+$th_i = random(0,5);
+$th = $angles[$th_i] . "^\circ";
+$cth = $cosines[$th_i];
+$sth = $sines[$th_i];
+$a2 = non_zero_random(-9,9);
+$b2 = non_zero_random(-9,9);
+$phi_i = random(0,5);
+$phi = $angles[$phi_i] . "^\circ";
+$sphi = $sines[$phi_i];
+$cphi = $cosines[$phi_i];
+$al_i = random(0,5);
+$al = $angles[$al_i] . "^\circ";
+$sal = $sines[$al_i];
+$cal = $cosines[$al_i];
+$s2al = $sal*$sal;
+$c2al = $cal*$cal;
+$c = non_zero_random(-9,9);
+$d = non_zero_random(-9,9);
+$e = non_zero_random(-9,9);
+$f = non_zero_random(-9,9);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Fill in the blanks to write each of the combined affine transofrmations as a function.
+
+[`F(T_{[$a],[$b]}(x,y))=(`][_____]{"-x-$a"}[`,`][_____]{"y+$b"}[`)`]
+
+[`R_{[$th]}(T_{[$a2],[$b2]}(x,y))=(`][_______________]{"$cth*x-$sth*y+$a2*$cth-$b2*$sth"}[`,`][_______________]{"$sth*x+$cth*y+$a2*$sth+$b2*$cth"}[`)`]
+
+[`R_{[$phi]}(S_{[$c],[$d]}(x,y))=(`][_______________]{"$c*$cphi*x-$d*$sphi*y"}[`,`][_______________]{"$c*$sphi*x+$d*$cphi*y"}[`)`]
+
+[`R_{-[$al]}(S_{[$e],[$f]}(R_{[$al]}(x,y)))=(`][____________________]{"($e*$c2al+$f*$s2al)*x+($f-$e)*$sal*$cal*y"}[`,`][____________________]{"($f-$e)*$sal*$cal*x+($e*$s2al+$f*$c2al)*y"}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``T_{a,b}(x,y)=(a+x,b+y)``]
+
+[``S_{a,b}(x,y)=(ax,by)``]
+
+[``F(x,y)=(-x,y)``]
+
+[``R_{\theta}(x,y)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta)``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-8-TransformationConjugacy.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-8-TransformationConjugacy.pg
@@ -1,0 +1,49 @@
+## DESCRIPTION
+## Conjugating 2D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('8')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$x = non_zero_random(-9,9);
+$y = non_zero_random(-9,9);
+$deg = list_random(-90,-60,-45,-30,30,45,60,90,150,180,270);
+
+TEXT(beginproblem());
+BEGIN_PGML
+To rotate a figure around some point other than the origin we can combine a sequence of affine transformations.  For instance, to rotate [`[$deg]^\circ`] around the point [`([$x],[$y])`], the sequence [`T_{[$x],[$y]}R_{[$deg]^\circ}T_{[$x*-1],[$y*-1]}`] could be employed.
+
+Explain why the transformation accomplishes a rotation about the point [`([$x],[$y])`].
+
+[@ ANS(essay_cmp); essay_box(4,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The first step [`T_{[$x*-1],[$y*-1]}`] moves the point about which we want to rotate to the origin.
+
+The second step [`R_{[$deg]^\circ}`] rotates about the origin, which now contains the part of our figure about which we want to rotate.
+
+The third step [`T_{[$x],[$y]}`] puts the figure back to its original location, now rotated.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-9-WriteTransformationConjugacy.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch3/3-9-WriteTransformationConjugacy.pg
@@ -1,0 +1,60 @@
+## DESCRIPTION
+## Combining 2D affine transformations with conjugacy
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/16/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('3')
+## Problem1('9')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$scaleFactor = random(2,9);
+$x = non_zero_random(-9,9);
+$y = random(-9,9);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Determine what formula you would use to scale a figure by a factor of [$scaleFactor] about the point [`([$x],[$y])`].  That is, how would you create a scaling transformation that leaves the point [`([$x],[$y])`] unmoved, and scales the rest of the plane around it, to [$scaleFactor] times its original size?
+
+The answer is of the form [`T_{a,b}S_{c,d}T_{e,f}`].  What are the values of the variables?
+
+[`a=`][_____]{$x}
+
+[`b=`][_____]{$y}
+
+[`c=`][_____]{$scaleFactor}
+
+[`d=`][_____]{$scaleFactor}
+
+[`e=`][_____]{-$x}
+
+[`f=`][_____]{-$y}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Rationale for the above answers:
+
+[`T_{-[$x],-[$y]}`] moves [`([$x],[$y])`] to the origin.
+
+[`S_{[$scaleFactor],[$scaleFactor]}`] scales about the origin, which now contains the center about which we want to scale.
+
+[`T_{[$x],[$y]}`] moves [`([$x],[$y])`] back to its original location.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-1-AddConstantPointAndVector3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-1-AddConstantPointAndVector3D.pg
@@ -1,0 +1,49 @@
+## DESCRIPTION
+## Adding in 3D a point and vector containing constants
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('1')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$e=random(-10,10);
+$f=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b],[$c])`] and [`\vec v=\langle [$d],[$e],[$f] \rangle`], then what is [`A+\vec v`]?
+
+Answer: [`(`][_____]{$a+$d},[_____]{$b+$e},[_____]{$c+$f}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are added componentwise.  That is, the left components are added, and the right components are added, to produce the left and right components (respectively) of the new vector.
+[``([$a],[$b],[$c]) + \langle [$d],[$e],[$f] \rangle
+= ([$a]+[$d],[$b]+[$e],[$c]+[$f])
+= ([$a+$d],[$b+$e],[$c+$f])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-1-AddConstantVectorAndPoint3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-1-AddConstantVectorAndPoint3D.pg
@@ -1,0 +1,49 @@
+## DESCRIPTION
+## Adding in 3D a vector and point containing constants
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('1')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$e=random(-10,10);
+$f=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b],[$c])`] and [`\vec v=\langle [$d],[$e],[$f] \rangle`], then what is [`\vec v+A`]?
+
+Answer: [`(`][_____]{$a+$d},[_____]{$b+$e},[_____]{$c+$f}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are added componentwise.  That is, the left components are added, and the right components are added, to produce the left and right components (respectively) of the new vector.
+[``\langle [$d],[$e],[$f] \rangle + ([$a],[$b],[$c])
+= ([$d]+[$a],[$e]+[$b],[$f]+[$c])
+= ([$d+$a],[$e+$b],[$f+$c])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-1-AddConstantVectors3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-1-AddConstantVectors3D.pg
@@ -1,0 +1,49 @@
+## DESCRIPTION
+## Adding two 3D vectors containing constants
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('1')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$e=random(-10,10);
+$f=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`\vec v=\langle [$a],[$b],[$c] \rangle`] and [`\vec w=\langle [$d],[$e],[$f] \rangle`], then what is [`\vec v+\vec w`]?
+
+Answer: [`\langle`][_____]{$a+$d},[_____]{$b+$e},[_____]{$c+$f}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors are added componentwise.  That is, the left components are added, and the right components are added, to produce the left and right components (respectively) of the new vector.
+[``\langle [$a],[$b],[$c] \rangle + \langle [$d],[$e],[$f] \rangle
+= \langle [$a]+[$d],[$b]+[$e],[$c]+[$f] \rangle
+= \langle [$a+$d],[$b+$e],[$c+$f] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-11-WriteTransformationConjugacy.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-11-WriteTransformationConjugacy.pg
@@ -1,0 +1,67 @@
+## DESCRIPTION
+## Combining 3D affine transformations with conjugacy
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('11')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$scaleFactor = random(2,9);
+$x = non_zero_random(-9,9);
+$y = random(-9,9);
+$z = non_zero_random(-9,9);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Determine what formula you would use to scale a figure by a factor of [$scaleFactor] about the point [`([$x],[$y],[$z])`].  That is, how would you create a scaling transformation that leaves the point [`([$x],[$y],[$z])`] unmoved, and scales the rest of the plane around it, to [$scaleFactor] times its original size?
+
+The answer is of the form [`T_{a,b,c}S_{d,e,f}T_{g,h,i}`].  What are the values of the variables?
+
+[`a=`][_____]{$x}
+
+[`b=`][_____]{$y}
+
+[`c=`][_____]{$z}
+
+[`d=`][_____]{$scaleFactor}
+
+[`e=`][_____]{$scaleFactor}
+
+[`f=`][_____]{$scaleFactor}
+
+[`g=`][_____]{-$x}
+
+[`h=`][_____]{-$y}
+
+[`i=`][_____]{-$z}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Rationale for the above answers:
+
+[`T_{-[$x],-[$y],-[$z]}`] moves [`([$x],[$y],[$z])`] to the origin.
+
+[`S_{[$scaleFactor],[$scaleFactor],[$scaleFactor]}`] scales about the origin, which now contains the center about which we want to scale.
+
+[`T_{[$x],[$y],[$z]}`] moves [`([$x],[$y],[$z])`] back to its original location.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-12-WriteTransformationConjugacy.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-12-WriteTransformationConjugacy.pg
@@ -1,0 +1,73 @@
+## DESCRIPTION
+## Combining 3D affine transformations with conjugacy
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('12')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$angle = list_random(-60,-45,-30,30,45,60);
+@axisnames = ("x","y","z");
+$axisindex = random(0,2);
+@subscripts = (0,0,0);
+$subscripts[$axisindex] = $angle;
+$x = non_zero_random(-9,9);
+$y = non_zero_random(-9,9);
+$z = non_zero_random(-9,9);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Determine what formula you would use to rotate a figure by an angle of [`[$angle]^\circ`] about the line parallel to the [$axisnames[$axisindex]] axis and passing through the point [`([$x],[$y],[$z])`].  That is, how would you create a rotation transformation that leaves the line through [`([$x],[$y],[$z])`] (and parallel to the [$axisnames[$axisindex]] axis) unmoved, and rotates the rest of space around it, by an angle of [`[$angle]^\circ`]?
+
+You may assume that the rotation is counterclockwise when viewed from the positive end of the [$axisnames[$axisindex]] axis.
+
+The answer is of the form [`T_{a,b,c}R_{d,e,f}T_{g,h,i}`].  What are the values of the variables?
+
+Any real number is acceptable for [`a`], so we do not ask for that value.
+
+[`b=`][_____]{$y}
+
+[`c=`][_____]{$z}
+
+[`d=`][_____]{$subscripts[0]}
+
+[`e=`][_____]{$subscripts[1]}
+
+[`f=`][_____]{$subscripts[2]}
+
+Any real number is acceptable for [`g`], so we do not ask for that value.
+
+[`h=`][_____]{-$y}
+
+[`i=`][_____]{-$z}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Rationale for the above answers:
+
+[`T_{-[$x],-[$y],-[$z]}`] moves [`([$x],[$y],[$z])`] to the origin.
+
+[`R_{[$suscripts[0]],[$subscripts[1]],[$subscripts[2]]}`] rotates about the origin, which now contains the point about which we want to rotate.
+
+[`T_{[$x],[$y],[$z]}`] moves [`([$x],[$y],[$z])`] back to its original location.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-13-WriteTransformationConjugacy.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-13-WriteTransformationConjugacy.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Combining 3D affine transformations with conjugacy
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('12')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+
+TEXT(beginproblem());
+BEGIN_PGML
+How could you create a transformation or combination of transformations that flips not about the yz plane, like [`F`] does, but about the xy plane instead?
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+
+What about a transformation or combination of transformations that flips about the xz plane?
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+About the xy plane:
+
+A single transformation: [`S_{1,1,-1}`]
+
+A combination of transformations: [`R_{0,90^\circ,0}FR_{0,-90^\circ,0}`]
+
+About the xz plane:
+
+A single transformation: [`S_{1,-1,1}`]
+
+A combination of transformations: [`R_{0,0,90^\circ}FR_{0,0,-90^\circ}`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-14-SpheresInSpace.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-14-SpheresInSpace.pg
@@ -1,0 +1,78 @@
+## DESCRIPTION
+## Placing spheres in a 3D scene subject to certain constraints
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Coordinate systems)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('14')
+## KEYWORDS('spheres')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(2,4);
+$b=random(5,7);
+$c=random(8,10);
+$d=random(11,13);
+$x=random(-10,10);
+$y=random(-10,10);
+$z=random(-10,10);
+
+$m=max($a,$b);
+
+TEXT(beginproblem());
+BEGIN_PGML
+What center should a sphere of radius [$a] have so that it sits on the xy plane with its bottom (lowest point in the z direction) just touching the origin?
+
+Answer: ([_____]{0},[_____]{0},[_____]{$a})
+
+What center should a sphere of radius [$b] have so that it sits on top of the previous sphere (that is, higher in the z direction, touching the previous sphere at just one point)?
+
+Answer: ([_____]{0},[_____]{0},[_____]{2*$a+$b})
+
+What are the two opposite corners of a box that tightly contains the previous two spheres (and whose edges are parallel to the axes)?
+
+First give the corner with all positive coordinates:
+([_____]{$m},[_____]{$m},[_____]{2*($a+$b)})
+
+Then give the corner opposite that one:
+([_____]{-$m},[_____]{-$m},[_____]{0})
+
+What center should a sphere of radius [$c] have so that it sits on top of the point [`([$x],[$y],[$z])`]?
+
+Answer: ([_____]{$x},[_____]{$y},[_____]{$z+$c})
+
+What center should a sphere of radius [$d] have so that it hangs just below the previous sphere, touching it at just one point?
+
+Answer: ([_____]{$x},[_____]{$y},[_____]{$z-$d})
+
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A sphere centered at [`(0,0,[$a])`] will have its lowest point at the origin (and its highest point at [`(0,0,[$a*2])`]).
+
+A sphere centered at [`(0,0,[$a*2]+[$b])`], which is [`(0,0,[$a*2+$b])`], will have its lowest point at [`(0,0,[$a*2])`], which therefore just touches the previous sphere.
+
+The larger of the two radii is [$m], and thus in the x and y directions, the sphere reach out as far as [`\pm [$m]`].  We know that their lowest point in z is at [`z=0`] and their highest point will be the top of the second sphere, or [`z=[$a*2+b]+[$b]=[$a*2+$b*2]`].  Thus the corners of the box go as high as [`([$m],[$m],[$a*2+$b*2])`] and as low as [`(-[$m],-[$m],0)`].
+
+A sphere centered at [`([$x],[$y],[$z+$c])`] will have its lowest point at [`([$x],[$y],[$z])`].
+
+A sphere centerd at [`([$x],[$y],[$z-$d])`] will have its highest point at [`([$x],[$y],[$z])`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-15-BirdwatcherExample.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-15-BirdwatcherExample.pg
@@ -1,0 +1,81 @@
+## DESCRIPTION
+## Using vectors in a 3D scene containing objects/shapes
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('15')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$x1=random(1,10);
+$y1=random(1,10);
+$z1=random(2,10);
+$x2=random(-10,$x1-1);
+$y2=random(-10,$y1-1);
+$z2=random(0.5,1,0.1);
+$l=random(0.2,0.5,0.01);
+$mag=sqrt(($x1-$x2)**2 + ($y1-$y2)**2 + ($z1-$z2)**2);
+$ux=($x1-$x2)/$mag;
+$uy=($y1-$y2)/$mag;
+$uz=($z1-$z2)/$mag;
+$sux=sprintf("%.5f",$ux);
+$suy=sprintf("%.5f",$uy);
+$suz=sprintf("%.5f",$uz);
+$sfinx=sprintf("%.5f",$x2+$l*$ux);
+$sfiny=sprintf("%.5f",$y2+$l*$uy);
+$sfinz=sprintf("%.5f",$z2+$l*$uz);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Imagine a scene in which a birdwatcher, whose eye is located at [`([$x2],[$y2],[$z2])`], is watching a bird located at [`([$x1],[$y1],[$z1])`].
+
+What is the vector from the birdwatcher's eye to the bird?
+[`\langle`][_____]{$x1-$x2},[_____]{$y1-$y2},[_____]{$z1-$z2}[`\rangle`]
+
+Express that vector as a direction (without magnitude).
+[`\langle`][__________]{$ux},[__________]{$uy},[__________]{$uz}[`\rangle`]
+
+Suppose the birdwatcher is using a telescope, which we wish to represent in a 3D scene as a cylinder extending from the birdwatcher's eye to the bird.  We know the center of one end of the cylinder (the eye point), but need to compute the other.  If the telescope is [$l] units long, what is the center of the other end of the telescope?
+
+Answer: ([__________]{$x2+$l*$ux},[__________]{$y2+$l*$uy},[__________]{$z2+$l*$uz})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Vectors between points are computed by subtracting the starting point from the ending point.  Thus in this case we have
+[`( [$x1],[$y1],[$z1] ) - ( [$x2],[$y2],[$z2] )
+= \langle [$x1-$x2],[$y1-$y2],[$z1-$z2] \rangle `]
+
+Without its magnitude, this vector becomes a unit vector.  We compute that by dividing by the magnitude, so we must first compute that magnitude using the usual formula.
+
+[`` ||\langle [$x1-$x2],[$y1-$y2],[$z1-$z2] \rangle||
+= \sqrt{([$x1-$x2])^2 + ([$y1-$y2])^2 + ([$z1-$z2])^2}
+\approx [$mag] ``]
+
+[`` \frac{\langle [$x1-$x2],[$y1-$y2],[$z1-$z2] \rangle}{[$mag]}
+    \approx \langle [$sux],[$suy],[$suz] \rangle ``]
+
+The other end of the telescope can be computed from these tools.  We take the eye point and add the unit vector, scaled by the telescope length.
+
+[`` ([$x2],[$y2],[$z2]) + [$l]\langle [$sux],[$suy],[$suz] \rangle
+    \approx ([$sfinx],[$sfiny],[$sfinz]) ``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-18-PythagoreanDistanceEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-18-PythagoreanDistanceEssay.pg
@@ -1,0 +1,53 @@
+## DESCRIPTION
+## Essay: Use the Pythagorean theorem to justify the vector magnitude formula
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('18')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Use the Pythagorean Theorem to explain why the formula [`||\langle x,y,z \rangle||=\sqrt{x^2+y^2+z^2}`] makes sense.
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Here is the explanation we gave in the two-dimensional case, now working just within the xy plane:
+
+The vectors [`\langle x,0,0 \rangle`] and [`\langle 0,y,0 \rangle`] can be arranged to form two sides of a right triangle whose hypotenuse is the vector [`\langle x,y,0 \rangle`].  The lengths of those two vectors are obviously [`x`] and [`y`], respectively.
+
+If we use [`m`] for the magnitude of [`\langle x,y,0 \rangle`], then it is the length of the triangle's hypotenuse, and so the Pythagorean Theorem tells us that [`x^2+y^2=m^2`].  If we solve for [`m`], we get [`m=\sqrt{x^2+y^2}`].
+
+We now extend that explanation to handle this 3D case as well:
+
+Now consider two line segments, one from [`(0, 0, 0)`] to [`(x, y, 0)`] and the other from [`(x, y, 0)`] to [`(x, y, z)`], as the two legs of another right triangle.  We just saw that the first has length [`\sqrt{x^2 + y^2}`] and clearly the second has length [`z`].  We can thus apply the Pythagorean Theorem to this right triangle also, to find the length of its hypotenuse, which is the line segment from [`(0, 0, 0)`] to [`(x, y, z)`], the one whose length we’re trying to measure in this problem.  It is:
+
+[``\sqrt{\left(\sqrt{x^2+y^2}\right)^2+z^2}=\sqrt{x^2+y^2+z^2},``]
+
+the formula specified in the statement of the problem.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-18=9-TranslationCompositionEssay.p9.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-18=9-TranslationCompositionEssay.p9.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Essay: Justify the formula for composition of two translations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('19')
+## KEYWORDS('affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Your textbook gives the following formula: [`T_{a,b,c}T_{d,e,f}=T_{a+d,b+e,c+f}`].
+
+Use equations that appear earlier in the text than that one to show why that equation is true.
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`` T_{a,b,c}T_{d,e,f}(x,y,z) = T_{a,b,c}(T_{d,e,f}(x,y,z)) ``]
+
+[`` = T_{a,b,c}(x+d,y+e,z+f) = (x+d+a,y+e+b,z+f+c) ``]
+
+[`` = (x+(a+d),y+(b+e),z+(c+f)) = T_{a+d,b+e,c+f}(x,y,z) ``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-19-TranslationCompositionEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-19-TranslationCompositionEssay.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Essay: Justify the formula for composition of two translations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('19')
+## KEYWORDS('affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Your textbook gives the following formula: [`T_{a,b,c}T_{d,e,f}=T_{a+d,b+e,c+f}`].
+
+Use equations that appear earlier in the text than that one to show why that equation is true.
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`` T_{a,b,c}T_{d,e,f}(x,y,z) = T_{a,b,c}(T_{d,e,f}(x,y,z)) ``]
+
+[`` = T_{a,b,c}(x+d,y+e,z+f) = (x+d+a,y+e+b,z+f+c) ``]
+
+[`` = (x+(a+d),y+(b+e),z+(c+f)) = T_{a+d,b+e,c+f}(x,y,z) ``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorBetweenDecimalPoints3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorBetweenDecimalPoints3D.pg
@@ -1,0 +1,48 @@
+## DESCRIPTION
+## Finding the vector between two constant points in 3D, with decimals
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('2')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10,0.1);
+$b=random(-10,10,0.1);
+$c=random(-10,10,0.1);
+$d=random(-10,10,0.1);
+$e=random(-10,10,0.1);
+$f=random(-10,10,0.1);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b],[$c])`] and [`B=([$d],[$e],[$f])`], then what is the vector from [`A`] to [`B`]?
+
+Answer: [`\langle`][_____]{$d-$a},[_____]{$e-$b},[_____]{$f-$c}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``B-A=([$d],[$e],[$f])-([$a],[$b],[$c])=([$d]-[$a],[$e]-[$b],[$f]-[$c])=([$d-$a],[$e-$b],[$f-$c])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorBetweenFormulaPoints3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorBetweenFormulaPoints3D.pg
@@ -1,0 +1,60 @@
+## DESCRIPTION
+## Finding the vector between two non-constant points in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('2')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+Context()->variables->add(c => 'Real');
+$a=non_zero_random(-10,10);
+$b=non_zero_random(-10,10);
+$c=non_zero_random(-10,10);
+$d=non_zero_random(-10,10);
+$e=non_zero_random(-10,10);
+$f=non_zero_random(-10,10);
+$A1=($a*Formula("a"))->reduce;
+$B1=($b*Formula("b"))->reduce;
+$C1=($c*Formula("c"))->reduce;
+$A2=($d*Formula("a"))->reduce;
+$B2=($e*Formula("b"))->reduce;
+$C2=($f*Formula("c"))->reduce;
+$A=(($d-$a)*Formula("a"))->reduce;
+$B=(($e-$b)*Formula("b"))->reduce;
+$C=(($f-$c)*Formula("c"))->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the vector between the point [`([$A1],[$B1],[$C1])`] and the point [`([$A2],[$B2],[$C2])`]?
+
+Answer: [`\langle`][_____]{$A},[_____]{$B},[_____]{$C}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``([$A2],[$B2],[$C2])-([$A1],[$B1],[$C1])=([$A2-$A1],[$B2-$B1],[$C2-$C1])=([$A],[$B],[$C])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorBetweenPoints3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorBetweenPoints3D.pg
@@ -1,0 +1,48 @@
+## DESCRIPTION
+## Finding the vector between two constant points in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('2')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$e=random(-10,10);
+$f=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b],[$c])`] and [`B=([$d],[$e],[$f])`], then what is the vector from [`A`] to [`B`]?
+
+Answer: [`\langle`][_____]{$d-$a},[_____]{$e-$b},[_____]{$f-$c}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``B-A=([$d],[$e],[$f])-([$a],[$b],[$c])=([$d]-[$a],[$e]-[$b],[$f]-[$c])=([$d-$a],[$e-$b],[$f-$c])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorFromOriginToPoint3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-2-VectorFromOriginToPoint3D.pg
@@ -1,0 +1,53 @@
+## DESCRIPTION
+## Finding the vector between two constant points in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('2')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+If [`A=([$a],[$b],[$c])`] then what is the vector from the origin to [`A`]?
+
+Answer: [`\langle`][_____]{$a},[_____]{$b},[_____]{$c}[`\rangle`]
+
+And what is the vector from [`A`] to the origin?
+
+Answer: [`\langle`][_____]{-$a},[_____]{-$b},[_____]{-$c}[`\rangle`]
+
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The formula for the vector from one point to another is the end point minus the start point, with points being subtracted componentwise, as shown below.
+
+[``A-O=([$a],[$b],[$c])-(0,0)=([$a]-0,[$b]-0,[$c]-0)=([$a],[$b],[$c])``]
+
+[``O-A=(0,0)-([$a],[$b])=(0-[$a],0-[$b])=([$a*-1],[$b*-1],[$c*-1])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-20-ScalingCompositionEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-20-ScalingCompositionEssay.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Essay: Justify the formula for composition of two scalings
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('20')
+## KEYWORDS('affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Your textbook gives the following formula: [`S_{a,b,c}S_{d,e,f}=S_{ad,be,cf}`].
+
+Use equations that appear earlier in the text than that one to show why that equation is true.
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`` S_{a,b,c}S_{d,e,f}(x,y,z) = S_{a,b,c}(S_{d,e,f}(x,y,z)) ``]
+
+[`` = S_{a,b,c}(dx,ey,fz) = (adx,bey,cfz) ``]
+
+[`` = ((ad)x,(be)y,(cf)z) = S_{ad,be,cf}(x,y,z) ``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-21-ReflectionCompositionEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-21-ReflectionCompositionEssay.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Essay: Justify the formula for composition of two reflections
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('21')
+## KEYWORDS('affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Your textbook gives the following formula: [`FF=I`].
+
+Use equations that appear earlier in the text than that one to show why that equation is true.
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`` FF(x,y,z) = F(F(x,y,z)) ``]
+
+[`` = F(-x,y,z) = (-(-x),y,z) ``]
+
+[`` = (x,y,z) = I(x,y,z) ``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointPartialVector3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointPartialVector3D.pg
@@ -1,0 +1,56 @@
+## DESCRIPTION
+## Finding the endpoint of a constant vector from a constant point in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('3')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$e=random(-10,10);
+$f=random(-10,10);
+$denom=random(2,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$a],[$b],[$c] \rangle`] and [`A`] be the point [`([$d],[$e],[$f])`].
+
+What is the endoint of [`\frac{1}{[$denom]}`] of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$a/$denom+$d},[_____]{$b/$denom+$e},[_____]{$c/$denom+$f}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To compute [`\frac{1}{[$denom]}`] of [`\vec v`], simply multiply each component of [`\vec v`] by [`\frac{1}{[$denom]}`].
+
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$d],[$e],[$f])+\frac{1}{[$denom]}\langle [$a],[$b],[$c] \rangle
+=([$d],[$e],[$f])+\left\langle \frac{[$a]}{[$denom]},\frac{[$b]}{[$denom]},\frac{[$c]}{[$denom]} \right\rangle
+=([$d]+[$a/$denom],[$e]+[$b/$denom],[$f]+[$c/$denom])
+=([$d+$a/$denom],[$e+$b/$denom],[$f+$c/$denom])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointPartialVectorFormula3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointPartialVectorFormula3D.pg
@@ -1,0 +1,71 @@
+## DESCRIPTION
+## Finding the endpoint of a non-constant vector from a non-constant point in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('3')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+Context()->variables->add(c => 'Real');
+$a=non_zero_random(-10,10);
+$b=non_zero_random(-10,10);
+$c=non_zero_random(-10,10);
+$d=non_zero_random(-10,10);
+$e=non_zero_random(-10,10);
+$f=non_zero_random(-10,10);
+$denom=random(2,10);
+$A1=($a*Formula("a"))->reduce;
+$B1=($b*Formula("b"))->reduce;
+$C1=($c*Formula("c"))->reduce;
+$A2=($d*Formula("a"))->reduce;
+$B2=($e*Formula("b"))->reduce;
+$C2=($f*Formula("c"))->reduce;
+$A1frac=($a/$denom*Formula("a"))->reduce;
+$B1frac=($b/$denom*Formula("b"))->reduce;
+$C1frac=($c/$denom*Formula("c"))->reduce;
+$A=(($d+$a/$denom)*Formula("a"))->reduce;
+$B=(($e+$b/$denom)*Formula("b"))->reduce;
+$C=(($f+$c/$denom)*Formula("c"))->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$A1],[$B1],[$C1] \rangle`] and [`A`] be the point [`([$A2],[$B2],[$C2])`].
+
+What is the endoint of [`\frac{1}{[$denom]}`] of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][__________]{$A},[__________]{$B},[__________]{$C}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To find [`\frac{1}{[$denom]}`] of a vector, multiply each component of that vector by [`\frac{1}{[$denom]}`].
+
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$A1],[$B2],[$C2])+\frac{1}{[$denom]}\langle [$A1],[$B1],[$C1] \rangle
+=([$A2],[$B2],[$C2])+\left\langle \frac{[$A1]}{[$denom]},\frac{[$B1]}{[$denom]},\frac{[$C1]}{[$denom]} \right\rangle
+=([$A2]+[$A1frac],[$B2]+[$B1frac],[$C2]+[$C2frac])
+=([$A],[$B],[$C])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointVector3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointVector3D.pg
@@ -1,0 +1,52 @@
+## DESCRIPTION
+## Finding the endpoint of a constant vector from a constant point in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('3')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(-10,10);
+$b=random(-10,10);
+$c=random(-10,10);
+$d=random(-10,10);
+$e=random(-10,10);
+$f=random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$a],[$b],[$c] \rangle`] and [`A`] be the point [`([$d],[$e],[$f])`].
+
+What is the endoint of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$a+$d},[_____]{$b+$e},[_____]{$c+$f}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$d],[$e],[$f])+\langle [$a],[$b],[$c] \rangle
+=([$d]+[$a],[$e]+[$b],[$f]+[$c])
+=([$d+$a],[$e+$b],[$f+$c])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointVectorFormula3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-3-EndpointPointVectorFormula3D.pg
@@ -1,0 +1,64 @@
+## DESCRIPTION
+## Finding the endpoint of a non-constant vector from a non-constant point in 3D
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('3')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+Context()->variables->add(c => 'Real');
+$a=non_zero_random(-10,10);
+$b=non_zero_random(-10,10);
+$c=non_zero_random(-10,10);
+$d=non_zero_random(-10,10);
+$e=non_zero_random(-10,10);
+$f=non_zero_random(-10,10);
+$A1=($a*Formula("a"))->reduce;
+$B1=($b*Formula("b"))->reduce;
+$C1=($c*Formula("c"))->reduce;
+$A2=($d*Formula("a"))->reduce;
+$B2=($e*Formula("b"))->reduce;
+$C2=($f*Formula("c"))->reduce;
+$A=(($d+$a)*Formula("a"))->reduce;
+$B=(($e+$b)*Formula("b"))->reduce;
+$C=(($f+$c)*Formula("c"))->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`\vec v`] be the vector [`\langle [$A1],[$B1],[$C1] \rangle`] and [`A`] be the point [`([$A2],[$B2],[$C2])`].
+
+What is the endoint of [`\vec v`] if it starts at [`A`]?
+
+Answer: [`\langle`][_____]{$A},[_____]{$B},[_____]{$C}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To find the endpoint of a vector, add the vector's components to those of the starting point.
+
+[``([$A2],[$B2],[$C2])+\langle [$A1],[$B1],[$C1] \rangle
+=([$A2]+[$A1],[$B2]+[$B1],[$C2]+[$C1])
+=([$A],[$B],[$C])``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-33-OrientationPreservingOrReversing.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-33-OrientationPreservingOrReversing.pg
@@ -1,0 +1,167 @@
+## DESCRIPTION
+## Identify orientation preserving/reversing scaling transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/01/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('33')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: BECAUSE THIS PROBLEM CONTAINS MULTIPLE CHOICE PORTIONS, YOU HAVE ONLY A SMALL NUMBER OF ATTEMPTS.  USE THEM WISELY.*
+
+Which of the following transformations are orientation-preserving and which are orientation-reversing?
+
+The transformation [`S_{1,1,1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation preserving and equivalent to a rotation by 0,0,0' )}
+
+The transformation [`S_{1,1,-1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation reversing and not equivalent to any rotation' )}
+
+The transformation [`S_{1,-1,1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation reversing and not equivalent to any rotation' )}
+
+The transformation [`S_{1,-1,-1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation preserving and equivalent to a rotation by 180,0,0' )}
+
+The transformation [`S_{-1,1,1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation reversing and not equivalent to any rotation' )}
+
+The transformation [`S_{-1,1,-1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation preserving and equivalent to a rotation by 0,180,0' )}
+
+The transformation [`S_{-1,-1,1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation preserving and equivalent to a rotation by 0,0,180' )}
+
+The transformation [`S_{-1,-1,-1}`] is: [___]{PopUp( [ (
+  '(make a choice)',
+  'orientation preserving and equivalent to a rotation by 0,0,0',
+  'orientation preserving and equivalent to a rotation by 180,0,0',
+  'orientation preserving and equivalent to a rotation by 0,180,0',
+  'orientation preserving and equivalent to a rotation by 0,0,180',
+  'orientation preserving and not equivalent to any rotation',
+  'orientation reversing and equivalent to a rotation by 0,0,0',
+  'orientation reversing and equivalent to a rotation by 180,0,0',
+  'orientation reversing and equivalent to a rotation by 0,180,0',
+  'orientation reversing and equivalent to a rotation by 0,0,180',
+  'orientation reversing and not equivalent to any rotation',
+) ], 'orientation reversing and not equivalent to any rotation' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`S_{1,1,1}=I=R_{0,0,0}`]
+
+[`S_{1,1,-1}`] has an odd number of flips, and is thus orientation reversing.  Based on the definition of that term in the text, it cannot be equivalent to any rotation.
+
+[`S_{1,-1,1}`] is the same as the previous.
+
+[`S_{1,-1,-1}`] negates y and z, which is the same as doing [`R_{180^\circ,0,0}`].  You can tell this by computing [`R_{180^\circ,0,0}(x,y,z)`].
+
+[`S_{-1,1,1}`] is the same as the other orientation-reversing ones.
+
+[`S_{-1,1,-1}`] negates x and z, and is thus [`R_{0,180^\circ,0}`].
+
+[`S_{-1,-1,1}`] negates x and y, and is thus [`R_{0,0,180^\circ}`].
+
+[`S_{-1,-1,-1}`] is also an odd number of flips, and thus orientation reversing, and thus equivalent to none of the rotations.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionDecimals3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionDecimals3D.pg
@@ -1,0 +1,60 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 3D point with decimal coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$sign=list_random(-1,1);
+$a=$sign*random(0.1,20,0.1);
+$b=-$sign*random(0.1,20,0.1);
+$c=$sign*random(0.1,20,0.1);
+$mag=sqrt($a**2+$b**2+$c**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag,$c/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]),sprintf("%.5f",$dir[2]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\langle [$a],[$b],[$c] \rangle`].
+
+What is its magnitude?
+
+Answer: [__________]{sqrt($a**2+$b**2+$c**2)}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$a/$mag},[__________]{$b/$mag},[__________]{$c/$mag}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The magnitude of a vector [`\langle x,y,z\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2+z^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2+[$c]^2}=\sqrt{[$a**2]+[$b**2]+[$c**2]}=\sqrt{[$a**2+$b**2+$c**2]}=[$smag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$a],[$b],[$c] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]],[$dir[2]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionFormulas3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionFormulas3D.pg
@@ -1,0 +1,76 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 3D point with variable coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(a => 'Real');
+Context()->variables->add(b => 'Real');
+Context()->variables->add(c => 'Real');
+$showPartialCorrectAnswers = 1;
+$aindex = random(0,2);
+do { $bindex = random(0,2); } until ($aindex+$bindex > 0);
+$a = ("0","-a","a")[$aindex];
+$b = ("0","-a","a")[$bindex];
+$signa = (0,-1,1)[$aindex];
+$signb = (0,-1,1)[$bindex];
+if ($aindex*$bindex > 0) {
+  $num=3;
+  $coeff=sprintf("%.5f",1/sqrt(3));
+  $mag=Formula("sqrt(3) * a");
+} elsif ($aindex > 0) {
+  $num=2;
+  $coeff=sprintf("%.5f",1/sqrt(2));
+  $mag=Formula("sqrt(2) * a");
+} else {
+  $num=1;
+  $coeff=1;
+  $mag=Formula("a");
+}
+@dir = ($coeff*$signa,$coeff*$signb,$coeff*$signa);
+$intermediate = Formula("$num a^2")->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\langle [$a],[$b],[$a] \rangle`], with [`a>0`].
+
+What is its magnitude?
+
+Answer: [__________]{$mag}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]},[__________]{$dir[2]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The magnitude of a vector [`\langle x,y,z\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2+z^2}`].  In this case, that computation yields the following, because [`a>0`]:
+
+[``\sqrt{([$a])^2+([$b])^2+([$a])^2}=\sqrt{[$intermediate]}=[$mag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$a],[$b],[$a] \rangle}{[$mag]}=\langle [$dir[0]],[$dir[1]],[$dir[2]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionFractions3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionFractions3D.pg
@@ -1,0 +1,70 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 3D point with negative fractional coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$adenom=random(2,10);
+$bdenom=random(2,10);
+$cdenom=random(2,10);
+$a=-1/$adenom;
+$b=-1/$bdenom;
+$c=-1/$cdenom;
+$sa=sprintf("%.5f",$a);
+$sb=sprintf("%.5f",$b);
+$sc=sprintf("%.5f",$c);
+$sa2=sprintf("%.5f",$a**2);
+$sb2=sprintf("%.5f",$b**2);
+$sc2=sprintf("%.5f",$c**2);
+$mag=sqrt($a**2+$b**2+$c**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag,$c/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]),sprintf("%.5f",$dir[2]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\left\langle -\frac{1}{[$adenom]},-\frac{1}{[$bdenom]},-\frac{1}{[$cdenom]} \right\rangle`].
+
+What is its magnitude?
+
+Answer: [__________]{$mag}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$a/$mag},[__________]{$b/$mag},[__________]{$c/$mag}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We rewrite [`\left\langle -\frac{1}{[$adenom]},-\frac{1}{[$bdenom]},-\frac{1}{[$cdenom]} \right\rangle`] as [`\langle [$sa],[$sb],[$sc] \rangle`].
+
+The magnitude of a vector [`\langle x,y,z\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2+z^2}`].  In this case, that computation yields:
+
+[``\sqrt{([$sa])^2+([$sb])^2+([$sc])^2}=\sqrt{[$sa2]+[$sb2]+[$sc2]}=[$smag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$sa],[$sb],[$sc] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]],[$sdir[2]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionIntegers3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-MagnitudeAndDirectionIntegers3D.pg
@@ -1,0 +1,59 @@
+## DESCRIPTION
+## Finding the magnitude and direction of a 3D point with positive integer coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=random(1,20);
+$b=random(1,20);
+$c=random(1,20);
+$mag=sqrt($a**2+$b**2+$c**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag,$c/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]),sprintf("%.5f",$dir[2]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the vector [`\vec v=\langle [$a],[$b],[$c] \rangle`].
+
+What is its magnitude?
+
+Answer: [__________]{$mag}
+
+What is its direction?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]},[__________]{$dir[2]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The magnitude of a vector [`\langle x,y,z\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2+z^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2+[$c]^2}=\sqrt{[$a**2]+[$b**2]+[$c**2]}=\sqrt{[$a**2+$b**2+$c**2]}=[$smag]``]
+
+The direction of a vector is its unit vector, computed by dividing the original vector by its magnitude.  In this case, we have:
+
+[``\frac{\langle [$a],[$b],[$c] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]],[$dir[2]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-UnitVectorOfDecimals3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-UnitVectorOfDecimals3D.pg
@@ -1,0 +1,55 @@
+## DESCRIPTION
+## Finding the unit vector of a 3D vector with decimal coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=non_zero_random(-20,20,0.01);
+$b=non_zero_random(-20,20,0.01);
+$c=non_zero_random(-20,20,0.01);
+$mag=sqrt($a**2+$b**2+$c**2);
+$smag=sprintf("%.6f",$mag);
+@dir=($a/$mag,$b/$mag,$c/$mag);
+@sdir=(sprintf("%.6f",$dir[0]),sprintf("%.6f",$dir[1]),sprintf("%.6f",$dir[2]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the unit vector for the vector [`\langle [$a],[$b],[$c] \rangle`]?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]},[__________]{$dir[2]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A unit vector is computed by dividing the original vector by its magnitude.
+
+The magnitude of a vector [`\langle x,y,z\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2+z^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2+[$c]^2}=\sqrt{[$a**2]+[$b**2]+[$c**2]}=\sqrt{[$a**2+$b**2+$c**2]}=[$smag]``]
+
+So we can now finish the unit vector computation, as follows.
+
+[``\frac{\langle [$a],[$b],[$c] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]],[$sdir[2]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-UnitVectorOfIntegers3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-4-UnitVectorOfIntegers3D.pg
@@ -1,0 +1,55 @@
+## DESCRIPTION
+## Finding the unit vector of a 3D vector with integer coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('4')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a=non_zero_random(-20,20);
+$b=non_zero_random(-20,20);
+$c=non_zero_random(-20,20);
+$mag=sqrt($a**2+$b**2+$c**2);
+$smag=sprintf("%.5f",$mag);
+@dir=($a/$mag,$b/$mag,$c/$mag);
+@sdir=(sprintf("%.5f",$dir[0]),sprintf("%.5f",$dir[1]),sprintf("%.5f",$dir[2]));
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the unit vector for the vector [`\langle [$a],[$b],[$c] \rangle`]?
+
+Answer: [`\langle`][__________]{$dir[0]},[__________]{$dir[1]},[__________]{$dir[2]}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A unit vector is computed by dividing the original vector by its magnitude.
+
+The magnitude of a vector [`\langle x,y,z\rangle`] is its length, computed with the formula [`\sqrt{x^2+y^2+z^2}`].  In this case, that computation yields:
+
+[``\sqrt{[$a]^2+[$b]^2+[$c]^2}=\sqrt{[$a**2]+[$b**2]+[$c**2]}=\sqrt{[$a**2+$b**2+$c**2]}=[$smag]``]
+
+So we can now finish the unit vector computation, as follows.
+
+[``\frac{\langle [$a],[$b],[$c] \rangle}{[$smag]}=\langle [$sdir[0]],[$sdir[1]],[$sdir[2]] \rangle``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-5-WriteCombinationAsFunction3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-5-WriteCombinationAsFunction3D.pg
@@ -1,0 +1,120 @@
+## DESCRIPTION
+## Combining 3D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('5')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+@angles = (30,45,60,90,180,270);
+@cosines = (sqrt(3)/2,sqrt(2)/2,1/2,0,-1,0);
+@texcos = ("\frac{\sqrt3}2","\frac{\sqrt2}2","\frac12","0","-1","0");
+@sines = (1/2,sqrt(2)/2,sqrt(3)/2,1,0,-1);
+@texsin = ("\frac12","\frac{\sqrt2}2","\frac{\sqrt3}2","1","0","-1");
+
+$r1_i = random(0,5);
+$r1 = $angles[$r1_i] . "^\circ";
+$cr1 = $cosines[$r1_i];
+$sr1 = $sines[$r1_i];
+@r1s = ($r1,0,0);
+$r1_i2 = random(0,2);
+$r1x = $r1s[$r1_i2];
+$r1y = $r1s[($r1_i2+1)%3];
+$r1z = $r1s[($r1_i2+2)%3];
+
+$r2_i = random(0,5);
+$r2 = $angles[$r2_i] . "^\circ";
+$cr2 = $cosines[$r2_i];
+$sr2 = $sines[$r2_i];
+@r2s = ($r2,0,0);
+$r2_i2 = random(0,2);
+$r2x = $r2s[$r2_i2];
+$r2y = $r2s[($r2_i2+1)%3];
+$r2z = $r2s[($r2_i2+2)%3];
+
+$s1x = non_zero_random(-5,5);
+$s1y = non_zero_random(-5,5);
+$s1z = non_zero_random(-5,5);
+$s2x = non_zero_random(-5,5);
+$s2y = non_zero_random(-5,5);
+$s2z = non_zero_random(-5,5);
+$tx = non_zero_random(-5,5);
+$ty = non_zero_random(-5,5);
+$tz = non_zero_random(-5,5);
+
+if ( $r1x > 0 ) {
+    $ans1x = Formula("x");
+    $ans1y = Formula("y*$cr1-z*$sr1");
+    $ans1z = Formula("y*$sr1+z*$cr1");
+} elsif ( $r1y > 0 ) {
+    $ans1x = Formula("x*$cr1+z*$sr1");
+    $ans1y = Formula("y");
+    $ans1z = Formula("-x*$sr1+z*$cr1");
+} else {
+    $ans1x = Formula("x*$cr1-y*$sr1");
+    $ans1y = Formula("x*$sr1+y*$cr1");
+    $ans1z = Formula("z");
+}
+
+if ( $r2x > 0 ) {
+    $ans2x = Formula("$s1x*x");
+    $ans2y = Formula("$s1y*y*$cr2-$s1z*z*$sr2");
+    $ans2z = Formula("$s1y*y*$sr2+$s1z*z*$cr2");
+} elsif ( $r2y > 0 ) {
+    $ans2x = Formula("$s1x*x*$cr2+$s1z*z*$sr2");
+    $ans2y = Formula("$s1y*y");
+    $ans2z = Formula("-$s1x*x*$sr2+$s1z*z*$cr2");
+} else {
+    $ans2x = Formula("$s1x*x*$cr2-$s1y*y*$sr2");
+    $ans2y = Formula("$s1x*x*$sr2+$s1y*y*$cr2");
+    $ans2z = Formula("$s1z*z");
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+Fill in the blanks to write each of the combined affine transofrmations as a function.
+
+[`R_{[$r1x],[$r1y],[$r1z]}(x,y,z)=(`][__________]{"$ans1x"}[`,`][__________]{"$ans1y"}[`,`][__________]{"$ans1z"}[`)`]
+
+[`R_{[$r2x],[$r2y],[$r2z]}(S_{[$s1x],[$s1y],[$s1z]}(x,y,z))=(`][__________]{"$ans2x"}[`,`][__________]{"$ans2y"}[`,`][__________]{"$ans2z"}[`)`]
+
+[`S_{[$s2x],[$s2y],[$s2z]}(T_{[$tx],[$ty],[$tz]}(x,y,z))=(`][__________]{"$s2x*(x+$tx)"}[`,`][__________]{"$s2y*(y+$ty)"}[`,`][__________]{"$s2z*(z+$tz)"}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``T_{a,b,c}(x,y,z)=(a+x,b+y,c+z)``]
+
+[``S_{a,b,c}(x,y,z)=(ax,by,cz)``]
+
+[``F(x,y,z)=(-x,y,z)``]
+
+[``R_{\theta,0,0}(x,y,z)=(x,y\cos\theta-z\sin\theta,y\sin\theta+z\cos\theta)``]
+
+[``R_{0,\theta,0}(x,y,z)=(x\cos\theta+z\sin\theta,y,-x\sin\theta+z\cos\theta)``]
+
+[``R_{0,0,\theta}(x,y,z)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta,z)``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-5-WriteTransformationAsFunction3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-5-WriteTransformationAsFunction3D.pg
@@ -1,0 +1,78 @@
+## DESCRIPTION
+## Writing 3D affine transformations as functions
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('5')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+$showPartialCorrectAnswers = 1;
+$tx1=0;
+$ty1=random(2,20);
+$tz1=random(-20,-2);
+$sx=random(2,5);
+$sydenom=random(2,5);
+$sz=1;
+@thetas=(30,45,60,90,180,270);
+@sines=(1/2,sqrt(2)/2,sqrt(3)/2,1,0,-1);
+@cosines=(sqrt(3)/2,sqrt(2)/2,1/2,0,-1,0);
+$thetaindex1=random(0,5);
+$thetaindex2=($thetaindex1+random(1,5))%6;
+$tx2=-random(1,5);
+$ty2=-random(1,5);
+$tz2=-random(1,5);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Fill in the blanks to write each of the affine transformations as a function.
+
+[`T_{[$tx1],[$ty1],[$tz1]}(x,y,z)=(`][_____]{"x+$tx1"},[_____]{"y+$ty1"},[_____]{"z+$tz1"}[`)`]
+
+[`S_{[$sx],1/[$sydenom],[$sz]}(x,y,z)=(`][_____]{"x*$sx"},[_____]{"y/$sydenom"},[_____]{"z*$sz"}[`)`]
+
+[`F(x,y,z)=(`][_____]{"-x"},[_____]{"y"},[_____]{"z"}[`)`]
+
+[`R_{[$thetas[$thetaindex1]]^\circ,0,0}(x,y,z)=(`][__________]{"x"},[__________]{"y*$cosines[$thetaindex1]-z*$sines[$thetaindex1]"},[__________]{"y*$sines[$thetaindex1]+z*$cosines[$thetaindex1]"}[`)`]
+
+[`R_{0,[$thetas[$thetaindex2]]^\circ,0}(x,y,z)=(`][__________]{"x*$cosines[$thetaindex2]+z*$sines[$thetaindex2]"},[__________]{"y"},[__________]{"-x*$sines[$thetaindex2]+z*$cosines[$thetaindex2]"}[`)`]
+
+[`T_{[$tx2],[$ty2],[$tz2]}(x,y,z)=(`][_____]{"x+$tx2"},[_____]{"y+$ty2"},[_____]{"z+$tz2"}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``T_{a,b,c}(x,y,z)=(a+x,b+y,c+z)``]
+
+[``S_{a,b,c}(x,y,z)=(ax,by,cz)``]
+
+[``F(x,y,z)=(-x,y,z)``]
+
+[``R_{\theta,0,0}(x,y,z)=(x,y\cos\theta-z\sin\theta,y\sin\theta+z\cos\theta)``]
+
+[``R_{0,\theta,0}(x,y,z)=(x\cos\theta+z\sin\theta,y,-x\sin\theta+z\cos\theta)``]
+
+[``R_{0,0,\theta}(x,y,z)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta,z)``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-6-ApplyAffineTransformations3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-6-ApplyAffineTransformations3D.pg
@@ -1,0 +1,96 @@
+## DESCRIPTION
+## Applying 3D affine transformations as functions
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('6')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+$showPartialCorrectAnswers = 1;
+$tx1=0;
+$ty1=random(2,20);
+$tz1=random(-20,-2);
+$sx=random(2,5);
+$sydenom=random(2,5);
+$sz=1;
+@thetas=(30,45,60,90,180,270);
+@sines=(1/2,sqrt(2)/2,sqrt(3)/2,1,0,-1);
+@cosines=(sqrt(3)/2,sqrt(2)/2,1/2,0,-1,0);
+$thetaindex1=random(0,5);
+$thetaindex2=($thetaindex1+random(1,5))%6;
+$tx2=-random(1,5);
+$ty2=-random(1,5);
+$tz2=-random(1,5);
+$P1x=0;
+$P1y=0;
+$P1z=0;
+$P2x=non_zero_random(-10,10,0.5);
+$P2y=non_zero_random(-10,10,0.5);
+$P2z=non_zero_random(-10,10,0.5);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Fill in the blanks to write each of the affine transformations as a function.
+
+[`T_{[$tx1],[$ty1],[$tz1]}([$P1x],[$P1y],[$P1z])=(`][_____]{$P1x+$tx1},[_____]{$P1y+$ty1},[_____]{$P1z+$tz1}[`)`]
+
+[`T_{[$tx1],[$ty1],[$tz1]}([$P2x],[$P2y],[$P2z])=(`][_____]{$P2x+$tx1},[_____]{$P2y+$ty1},[_____]{$P2z+$tz1}[`)`]
+
+[`S_{[$sx],1/[$sydenom],[$sz]}([$P1x],[$P1y],[$P1z])=(`][_____]{$P1x*$sx},[_____]{$P1y/$sydenom},[_____]{$P1z*$sz}[`)`]
+
+[`S_{[$sx],1/[$sydenom],[$sz]}([$P2x],[$P2y],[$P2z])=(`][_____]{$P2x*$sx},[_____]{$P2y/$sydenom},[_____]{$P2z*$sz}[`)`]
+
+[`F([$P1x],[$P1y],[$P1z])=(`][_____]{-$P1x},[_____]{$P1y},[_____]{$P1z}[`)`]
+
+[`F([$P2x],[$P2y],[$P2z])=(`][_____]{-$P2x},[_____]{$P2y},[_____]{$P2z}[`)`]
+
+[`R_{[$thetas[$thetaindex1]]^\circ,0,0}([$P1x],[$P1y],[$P1z])=(`][__________]{$P1x},[__________]{$P1y*$cosines[$thetaindex1]-$P1z*$sines[$thetaindex1]},[__________]{$P1y*$sines[$thetaindex1]+$P1z*$cosines[$thetaindex1]}[`)`]
+
+[`R_{[$thetas[$thetaindex1]]^\circ,0,0}([$P2x],[$P2y],[$P2z])=(`][__________]{$P2x},[__________]{$P2y*$cosines[$thetaindex1]-$P2z*$sines[$thetaindex1]},[__________]{$P2y*$sines[$thetaindex1]+$P2z*$cosines[$thetaindex1]}[`)`]
+
+[`R_{0,[$thetas[$thetaindex2]]^\circ,0}([$P1x],[$P1y],[$P1z])=(`][__________]{$P1x*$cosines[$thetaindex2]+$P1z*$sines[$thetaindex2]},[__________]{$P1y},[__________]{-$P1x*$sines[$thetaindex2]+$P1z*$cosines[$thetaindex2]}[`)`]
+
+[`R_{0,[$thetas[$thetaindex2]]^\circ,0}([$P2x],[$P2y],[$P2z])=(`][__________]{$P2x*$cosines[$thetaindex2]+$P2z*$sines[$thetaindex2]},[__________]{$P2y},[__________]{-$P2x*$sines[$thetaindex2]+$P2z*$cosines[$thetaindex2]}[`)`]
+
+[`T_{[$tx2],[$ty2],[$tz2]}([$P1x],[$P1y],[$P1z])=(`][_____]{$P1x+$tx2},[_____]{$P1y+$ty2},[_____]{$P1z+$tz2}[`)`]
+
+[`T_{[$tx2],[$ty2],[$tz2]}([$P2x],[$P2y],[$P2z])=(`][_____]{$P2x+$tx2},[_____]{$P2y+$ty2},[_____]{$P2z+$tz2}[`)`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The solutions are all created using the formulas from the text:
+
+[``T_{a,b,c}(x,y,z)=(a+x,b+y,c+z)``]
+
+[``S_{a,b,c}(x,y,z)=(ax,by,cz)``]
+
+[``F(x,y,z)=(-x,y,z)``]
+
+[``R_{\theta,0,0}(x,y,z)=(x,y\cos\theta-z\sin\theta,y\sin\theta+z\cos\theta)``]
+
+[``R_{0,\theta,0}(x,y,z)=(x\cos\theta+z\sin\theta,y,-x\sin\theta+z\cos\theta)``]
+
+[``R_{0,0,\theta}(x,y,z)=(x\cos\theta-y\sin\theta,x\sin\theta+y\cos\theta,z)``]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-7-UnderstandingCombiningTransformations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch4/4-7-UnderstandingCombiningTransformations.pg
@@ -1,0 +1,105 @@
+## DESCRIPTION
+## Understanding combining 3D affine transformations
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(01/31/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('4')
+## Problem1('7')
+## KEYWORDS('transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$a = non_zero_random(-10,10);
+$b = non_zero_random(-10,10);
+$c = non_zero_random(-10,10);
+$d = non_zero_random(-10,10);
+$e = non_zero_random(-10,10);
+$f = non_zero_random(-10,10);
+$theta = non_zero_random(-89,89);
+$n = random(5,13,2);
+$expanded = "";
+for (my $i=0; $i < $n; $i++) { $expanded .= "F"; }
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+For what values of [`a`], [`b`], and [`c`] is [`T_{[$a],[$b],[$c]}T_{[$d],[$e],[$f]}=T_{a,b,c}`]?
+
+[`a=`][_____]{$a+$d}
+
+[`b=`][_____]{$b+$e}
+
+[`c=`][_____]{$c+$f}
+
+For what value of [`\theta`] is [`FR_{[$theta]^\circ,0,0}=R_{\theta,0,0}F`]?
+
+[`\theta=`][_____]{$theta}
+
+For what value of [`\theta`] is [`FR_{0,0,[$theta]^\circ}=R_{0,0,\theta}F`]?
+
+[`\theta=`][_____]{-$theta}
+
+Fill in the following blanks.
+
+[`R_{0,\theta,0}R_{0,-\theta,0}=`][___]{PopUp( [ (
+  '(make a choice)',
+  'rotation by 2 times theta about the y axis',
+  'rotation by -2 times theta about the y axis',
+  'I (the identity transformation)',
+  'rotation by theta squared about the y axis',
+  'rotation by negative theta squared about the y axis',
+  'none of the above'
+) ], 'I (the identity transformation)' )}
+
+[`F^{[$n]}=[$expanded]=`][___]{PopUp( [ (
+  '(make a choice)',
+  'F to the ' . $n . 'th power (cannot be simplified)',
+  'F to the ' . ($n-1) . 'th power',
+  'F',
+  'I (the identity transformation)',
+  'none of the above'
+) ], 'F' )}
+
+If [`n`] is an even number, then [`F^n=`][___]{PopUp( [ (
+  '(make a choice)',
+  'F to the nth power (cannot be simplified)',
+  'F to the (n-1)th power',
+  'F',
+  'I (the identity transformation)',
+  'none of the above'
+) ], 'I (the identity transformation)' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`T_{[$a],[$b],[$c]}T_{[$d],[$e],[$f]}=T_{[$a]+[$d],[$b]+[$e],[$c]+[$f]}=T_{[$a+$d],[$b+$e],[$c+$f]}`]
+
+[`FR_{[$theta]^\circ,0,0}=R_{[$theta]^\circ,0,0}F`]
+
+[`FR_{0,0,[$theta]^\circ}=R_{0,0,-[$theta]^\circ}F`]
+
+[`R_{0,\theta,0}R_{0,-\theta,0}=R_0=I`]
+
+[`F^{[$n]}=F`] because of the answer to the next question.
+
+If [`n`] is even, then [`F^n=I`].  Recall that [`F^2=I`], and thus any even number of [`F`]'s is just repeated applications of [`I`], which make no change to the figure.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-1-ConvertToHomogeneous.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-1-ConvertToHomogeneous.pg
@@ -1,0 +1,93 @@
+## DESCRIPTION
+## Converting points and vectors to homogeneous coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Coordinate systems)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('1')
+## KEYWORDS('homogeneous coordinates')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+@r = (
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+);
+$ans1 = Matrix( [
+    [ $r[0] ], 
+    [ $r[1] ],
+    [ 1 ]
+] );
+$ans2 = Matrix( [
+    [ $r[2] ], 
+    [ $r[3] ],
+    [ 0 ]
+] );
+$ans3 = Matrix( [
+    [ $r[4] ], 
+    [ $r[5] ],
+    [ $r[6] ],
+    [ 1 ]
+] );
+$ans4 = Matrix( [
+    [ $r[7] ], 
+    [ $r[8] ],
+    [ $r[9] ],
+    [ 0 ]
+] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Express [`([$r[0]],[$r[1]])`] in homogeneous coordinates.
+
+[_____]*{$ans1} [@ AnswerFormatHelp("matrices") @]*
+
+Express [`\langle [$r[2]],[$r[3]] \rangle`] in homogeneous coordinates.
+
+[_____]*{$ans2} [@ AnswerFormatHelp("matrices") @]*
+
+Express [`([$r[4]],[$r[5]],[$r[6]])`] in homogeneous coordinates.
+
+[_____]*{$ans3} [@ AnswerFormatHelp("matrices") @]*
+
+Express [`\langle [$r[7]],[$r[8]],[$r[9]] \rangle`] in homogeneous coordinates.
+
+[_____]*{$ans4} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A point [`(x,y)`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ 1 \end{array}\right]`].
+
+A vector [`\langle x,y \rangle`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ 0 \end{array}\right]`].
+
+A point [`(x,y,z)`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ z \\ 1 \end{array}\right]`].
+
+A vector [`\langle x,y,z \rangle`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ z \\ 0 \end{array}\right]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-10-MatrixMultiplicationWithVariables.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-10-MatrixMultiplicationWithVariables.pg
@@ -1,0 +1,97 @@
+## DESCRIPTION
+## Matrix multiplication problems with variable entries
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Matrices)
+## DBsection(Matrix Algebra)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('10')
+## KEYWORDS('matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+Context()->variables->add( u => Real );
+Context()->variables->add( v => Real );
+Context()->variables->add( w => Real );
+Context()->variables->add( a => Real );
+Context()->variables->add( b => Real );
+Context()->variables->add( c => Real );
+Context()->variables->add( d => Real );
+Context()->variables->add( e => Real );
+$showPartialCorrectAnswers = 1;
+$L3 = Matrix( [
+    [ Formula( list_random( 0, 1, "a", "b", "c" ) ),
+      Formula( list_random( 0, 1, "a", "b", "c" ) ),
+      Formula( list_random( 0, 1, "a", "b", "c" ) ) ], 
+    [ Formula( list_random( "a", "b", "c" ) ),
+      Formula( list_random( "a", "b", "c" ) ),
+      Formula( list_random( 0, 1, "a", "b", "c" ) ) ], 
+    [ 0, 0, 1 ]
+] );
+$R3 = Matrix( [
+    [ Formula( list_random( 0, 1, "d", "e" ) ),
+      Formula( list_random( 0, 1, "d", "e" ) ),
+      Formula( list_random( 0, 1, "d", "e" ) ) ], 
+    [ Formula( list_random( "d", "e" ) ),
+      Formula( list_random( 0, 1 ) ),
+      Formula( list_random( 0, 1 ) ) ], 
+    [ 0, 0, 1 ]
+] );
+$L4 = Matrix( [
+    [ 1, 0, 0, Formula("u") ],
+    [ 0, 1, 0, Formula("v") ],
+    [ 0, 0, 1, Formula("w") ],
+    [ 0, 0, 0, 1 ]
+] );
+$R4 = Matrix( [
+    [ Formula("x"), 0, 0, 0 ],
+    [ 0, Formula("y"), 0, 0 ],
+    [ 0, 0, Formula("z"), 0 ],
+    [ 0, 0, 0, 1 ]
+] );
+if ( random(0,1) == 1 ) {
+    $tmp = $R4;
+    $R4 = $L4;
+    $L4 = $tmp;
+}
+$v1 = Formula( list_random( "u", "v", "w", "x", "y", "z" ) );
+$v2 = Formula( list_random( "u", "v", "w", "x", "y", "z" ) );
+$Lv = Matrix( [ [ $v1, 0, 0, $v2 ], [ 0, $v1, 0, $v2 ], [ 0, 0, $v1, $v2 ], [ 0, 0, 0, 1 ] ] );
+$Rv = Matrix( [ [ random(1,9) ], [ random(1,9) ], [ random(1,9) ], [ 1 ] ] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Compute the results of each matrix multiplication shown below.
+
+[`[$L3][$R3]=`][_____]*{$L3*$R3} [@ AnswerFormatHelp("matrices") @]*
+
+[`[$L4][$R4]=`][_____]*{$L4*$R4} [@ AnswerFormatHelp("matrices") @]*
+
+[`[$Lv][$Rv]=`][_____]*{$Lv*$Rv} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`[$L3][$R3]=[$L3*$R3]`]
+
+[`[$L4][$R4]=[$L4*$R4]`]
+
+[`[$Lv][$Rv]=[$Lv*$Rv]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-11-ApplyAffineTransformationMatrices.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-11-ApplyAffineTransformationMatrices.pg
@@ -1,0 +1,117 @@
+## DESCRIPTION
+## Applying affine transformation matrices to points in homogeneous coordinates
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Linear transformations)
+## DBsection(Associated matrices)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('11')
+## KEYWORDS('matrices','affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+
+$tx = non_zero_random(-9,9);
+$ty = non_zero_random(-9,9);
+$T = Matrix( [ [ 1, 0, $tx ], [ 0, 1, $ty ], [ 0, 0, 1 ] ] );
+$F = Matrix( [ [ -1, 0, 0 ], [ 0, 1, 0 ], [ 0, 0, 1 ] ] );
+$p1x = non_zero_random(-9,9);
+$p1y = non_zero_random(-9,9);
+$p1 = Matrix( [ [ $p1x ], [ $p1y ], [ 1 ] ] );
+
+$sx = random(0.5,2,0.5);
+$sy = random(0.5,2,0.5);
+$S = Matrix( [ [ $sx, 0, 0 ], [ 0, $sy, 0 ], [ 0, 0, 1 ] ] );
+$r = list_random( -30, -45, -60, 30, 45, 60 );
+$cos = cos($r*3.14159265358/180);
+$sin = sin($r*3.14159265358/180);
+$R = Matrix( [ [ $cos, -$sin, 0 ], [ $sin, $cos, 0 ], [ 0, 0, 1 ] ] );
+$p2x = non_zero_random(-9,9);
+$p2y = non_zero_random(-9,9);
+$p2 = Matrix( [ [ $p2x ], [ $p2y ], [ 1 ] ] );
+
+$p3x = non_zero_random(-9,9);
+$p3y = non_zero_random(-9,9);
+$p3 = Matrix( [ [ $p3x ], [ $p3y ], [ 1 ] ] );
+
+$FRF = $F * $R * $F;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Show the application of the transformation [`T_{[$tx],[$ty]}F`] to the point [`([$p1x],[$p1y])`] as a pair of matrices multiplied by a column vector. Then combine the matrices so that you have a single matrix multiplied by the column vector. Finally, perform the operation and give the answer.
+
+First, as two matrices and a column vector:
+
+[_____]*{$T}
+[_____]*{$F}
+[_____]*{$p1}
+
+Then as a single matrix times the column vector, with the final answer:
+
+[_____]*{$T*$F}
+[_____]*{$p1}
+=
+[_____]*{$T*$F*$p1} [@ AnswerFormatHelp("matrices") @]*
+
+-----
+
+Show the application of the transformation [`S_{[$sx],[$sy]}R_{[$r]^\circ}`] to the point [`([$p2x],[$p2y])`] as a pair of matrices multiplied by a column vector. Then combine the matrices so that you have a single matrix multiplied by the column vector. Finally, perform the operation and give the answer.
+
+First, as two matrices and a column vector:
+
+[_____]*{$S}
+[_____]*{$R}
+[_____]*{$p2}
+
+Then as a single matrix times the column vector, with the final answer:
+
+[_____]*{$S*$R}
+[_____]*{$p2}
+=
+[_____]*{$S*$R*$p2} [@ AnswerFormatHelp("matrices") @]*
+
+-----
+
+Show the application of the transformation [`FR_{[$r]^\circ}F`] to the point [`([$p3x],[$p3y])`] as a sequence of matrices multiplied by a column vector. Then combine the matrices so that you have a single matrix multiplied by the column vector. Finally, perform the operation and give the answer.
+
+First, as three matrices and a column vector:
+
+[_____]*{$F}
+[_____]*{$R}
+[_____]*{$F}
+[_____]*{$p3}
+
+Then as a single matrix times the column vector, with the final answer:
+
+[_____]*{$F*$R*$F}
+[_____]*{$p3}
+=
+[_____]*{$FRF*$p3} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`T_{[$tx],[$ty]}F([$p1x],[$p1y])=[$T][$F][$p1]=[$T*$F][$p1]=[$T*$F*$p1]`]
+
+[`S_{[$sx],[$sy]}R_{[$r]^\circ}([$p2x],[$p2y])=[$S][$R][$p2]=[$S*$R][$p2]=[$S*$R*$p2]`]
+
+[`FR_{[$r]\circ}F([$p3x],[$p3y])=[$F][$R][$F][$p3]=[$F*$R*$F][$p3]=[$FRF*$p3]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-12-ApplyTransformationMatrices3D.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-12-ApplyTransformationMatrices3D.pg
@@ -1,0 +1,71 @@
+## DESCRIPTION
+## Applying 3D affine transformations as matrices
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Matrices)
+## DBsection(Matrix Algebra)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('12')
+## KEYWORDS('transformations','matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$M1 = Matrix( [
+    [ non_zero_random(-5,5), 0, non_zero_random(-5,5), 0 ], 
+    [ 0, non_zero_random(-5,5), non_zero_random(-5,5), non_zero_random(-5,5) ],
+    [ 0, non_zero_random(-5,5), 0, non_zero_random(-5,5) ], 
+    [ 0, 0, 0, 1 ]
+] );
+$CV1 = Matrix( [ [ random(1,9) ], [ random(1,9) ], [ random(1,9) ], [ 1 ] ] );
+$M2 = Matrix( [
+    [ 0,
+      non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01) ], 
+    [ non_zero_random(-1,10,0.01),
+      0,
+      non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01) ], 
+    [ non_zero_random(-1,10,0.01),
+      0,
+      non_zero_random(-1,10,0.01),
+      0 ], 
+    [ 0, 0, 0, 1 ]
+] );
+$CV2 = Matrix( [ [ non_zero_random(-1,10,0.01) ],
+                 [ non_zero_random(-1,10,0.01) ],
+                 [ non_zero_random(-1,10,0.01) ],
+                 [ 1 ] ] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Perform the following applications of an affine transformation matrix to a column vector.
+
+[`[$M1][$CV1]=`][_____]*{$M1*$CV1} [@ AnswerFormatHelp("matrices") @]*
+
+[`[$M2][$CV2]=`][_____]*{$M2*$CV2} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`[$M1][$CV1]=[$M1*$CV1]`]
+
+[`[$M2][$CV2]=[$M2*$CV2]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-14-TranformationsIntoMatrices.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-14-TranformationsIntoMatrices.pg
@@ -1,0 +1,230 @@
+## DESCRIPTION
+## Combining affine transformations as functions, then into matrices
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Linear Transformations)
+## DBsection(Associated matrices)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('14')
+## KEYWORDS('transformations','matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$scale = random(2,9);
+$tx = random(-9,9);
+$ty = random(-9,9);
+$tz = random(-9,9);
+$S = Matrix( [ [ $scale, 0, 0, 0 ],
+               [ 0, $scale, 0, 0 ],
+               [ 0, 0, $scale, 0 ],
+               [ 0, 0,      0, 1 ] ] );
+$T = Matrix( [ [ 1, 0, 0, $tx ],
+               [ 0, 1, 0, $ty ],
+               [ 0, 0, 1, $tz ],
+               [ 0, 0, 0,   1 ] ] );
+$ans1 = $S*$T;
+
+$t = non_zero_random(-9,9);
+$T2 = Matrix( [ [ 1, 0, 0, $t ],
+                [ 0, 1, 0, $t ],
+                [ 0, 0, 1, $t ],
+                [ 0, 0, 0,  1 ] ] );
+$r = list_random( -30, -45, -60, 30, 45, 60 );
+$cos = cos($r*3.14159265358/180);
+$sin = sin($r*3.14159265358/180);
+$Ry = Matrix( [ [  $cos, 0, $sin, 0 ],
+                [     0, 1,    0, 0 ],
+                [ -$sin, 0, $cos, 0 ],
+                [     0, 0,    0, 1 ] ] );
+$ans2 = $T2->inverse * $Ry * $T2;
+
+$t2x = random(-9,9);
+$t2y = random(-9,9);
+$t2z = random(-9,9);
+$sx = random(-9,9);
+$sy = random(-9,9);
+$sz = random(-9,9);
+$T3 = Matrix( [ [ 1, 0, 0, $t2x ],
+                [ 0, 1, 0, $t2y ],
+                [ 0, 0, 1, $t2z ],
+                [ 0, 0, 0,    1 ] ] );
+$S2 = Matrix( [ [ $sx,   0,   0, 0 ],
+                [   0, $sy,   0, 0 ],
+                [   0,   0, $sz, 0 ],
+                [   0,   0,   0, 1 ] ] );
+$Rx = Matrix( [ [ 1,    0,     0, 0 ],
+                [ 0, $cos, -$sin, 0 ],
+                [ 0, $sin,  $cos, 0 ],
+                [ 0,    0,     0, 1 ] ] );
+$ans3 = $Rx * $S2 * $T3;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Combine the following pair of transformations into a single transformation, as a function.
+
+[`S_{[$scale],[$scale],[$scale]}T_{[$tx],[$ty],[$tz]}(x,y,z)=`]
+
+(
+[_____]{$ans1->element(1,1)}x+
+[_____]{$ans1->element(1,2)}y+
+[_____]{$ans1->element(1,3)}z+
+[_____]{$ans1->element(1,4)}
+,
+
+[_____]{$ans1->element(2,1)}x+
+[_____]{$ans1->element(2,2)}y+
+[_____]{$ans1->element(2,3)}z+
+[_____]{$ans1->element(2,4)}
+,
+
+[_____]{$ans1->element(3,1)}x+
+[_____]{$ans1->element(3,2)}y+
+[_____]{$ans1->element(3,3)}z+
+[_____]{$ans1->element(3,4)}
+)
+
+What is that transformation expressed as a matrix?
+
+[_____]*{$ans1}
+
+Combine the following series of transformations into a single transformation, as a function.
+
+[`T_{[$t*-1],[$t*-1],[$t*-1]}R_{0,[$r]^\circ,0}T_{[$t],[$t],[$t]}(x,y,z)=`]
+
+(
+[_____]{$ans2->element(1,1)}x+
+[_____]{$ans2->element(1,2)}y+
+[_____]{$ans2->element(1,3)}z+
+[_____]{$ans2->element(1,4)}
+,
+
+[_____]{$ans2->element(2,1)}x+
+[_____]{$ans2->element(2,2)}y+
+[_____]{$ans2->element(2,3)}z+
+[_____]{$ans2->element(2,4)}
+,
+
+[_____]{$ans2->element(3,1)}x+
+[_____]{$ans2->element(3,2)}y+
+[_____]{$ans2->element(3,3)}z+
+[_____]{$ans3->element(3,4)}
+)
+
+What is that transformation expressed as a matrix?
+
+[_____]*{$ans2}
+
+Combine the following series of transformations into a single transformation, as a function.
+
+[`R_{[$r]^\circ,0,0}S_{[$sx],[$sy],[$sz]}T_{[$t2x],[$t2y],[$t2z]}(x,y,z)=`]
+
+(
+[_____]{$ans3->element(1,1)}x+
+[_____]{$ans3->element(1,2)}y+
+[_____]{$ans3->element(1,3)}z+
+[_____]{$ans3->element(1,4)}
+,
+
+[_____]{$ans3->element(2,1)}x+
+[_____]{$ans3->element(2,2)}y+
+[_____]{$ans3->element(2,3)}z+
+[_____]{$ans3->element(2,4)}
+,
+
+[_____]{$ans3->element(3,1)}x+
+[_____]{$ans3->element(3,2)}y+
+[_____]{$ans3->element(3,3)}z+
+[_____]{$ans3->element(3,4)}
+)
+
+What is that transformation expressed as a matrix?
+
+[_____]*{$ans3}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`S_{[$scale],[$scale],[$scale]}T_{[$tx],[$ty],[$tz]}(x,y,z)=
+S_{[$scale],[$scale],[$scale]}(x+[$tx],y+[$ty],z+[$tz])=
+(
+[$ans1->element(1,1)]x+
+[$ans1->element(1,2)]y+
+[$ans1->element(1,3)]z+
+[$ans1->element(1,4)]
+,
+[$ans1->element(2,1)]x+
+[$ans1->element(2,2)]y+
+[$ans1->element(2,3)]z+
+[$ans1->element(2,4)]
+,
+[$ans1->element(3,1)]x+
+[$ans1->element(3,2)]y+
+[$ans1->element(3,3)]z+
+[$ans1->element(3,4)]
+)`]
+
+As a matrix, this is [`[$ans1]`].
+
+[`T_{[$t*-1],[$t*-1],[$t*-1]}R_{0,[$r]^\circ,0}T_{[$t],[$t],[$t]}(x,y,z)=
+T_{[$t*-1],[$t*-1],[$t*-1]}R_{0,[$r]^\circ,0}(x+[$t],y+[$t],z+[$t])=...`]
+
+[`=
+(
+[$ans2->element(1,1)]x+
+[$ans2->element(1,2)]y+
+[$ans2->element(1,3)]z+
+[$ans2->element(1,4)]
+,
+[$ans2->element(2,1)]x+
+[$ans2->element(2,2)]y+
+[$ans2->element(2,3)]z+
+[$ans2->element(2,4)]
+,
+[$ans2->element(3,1)]x+
+[$ans2->element(3,2)]y+
+[$ans2->element(3,3)]z+
+[$ans2->element(3,4)]
+)`]
+
+As a matrix, this is [`[$ans2]`].
+
+[`R_{[$r]^\circ,0,0}S_{[$sx],[$sy],[$sz]}T_{[$t2x],[$t2y],[$t2z]}(x,y,z)=
+R_{[$r]^\circ,0,0}S_{[$sx],[$sy],[$sz]}(x+[$t2x],y+[$t2y],z+[$t2z])=...`]
+
+[`
+(
+[$ans3->element(1,1)]x+
+[$ans3->element(1,2)]y+
+[$ans3->element(1,3)]z+
+[$ans3->element(1,4)]
+,
+[$ans3->element(2,1)]x+
+[$ans3->element(2,2)]y+
+[$ans3->element(2,3)]z+
+[$ans3->element(2,4)]
+,
+[$ans3->element(3,1)]x+
+[$ans3->element(3,2)]y+
+[$ans3->element(3,3)]z+
+[$ans3->element(3,4)]
+)`]
+
+As a matrix, this is [`[$ans3]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-17-MatrixEfficiencyInHardware.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-17-MatrixEfficiencyInHardware.pg
@@ -1,0 +1,126 @@
+## DESCRIPTION
+## On the efficiency of combinint transformation matrices in computer applications
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Linear Transformations)
+## DBsection(Associated matrices)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('17')
+## KEYWORDS('transformations','matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$nmats = random(7,10);
+$npts = random(2000,10000,1000);
+
+$ans1 = ($nmats-1)*112 + 28;
+$ans2 = $ans1 * $npts;
+$ans3 = 28*$nmats;
+$ans4 = $ans3 * $npts;
+$ans5 = ($nmats-1)*112 + 28*$npts;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Suppose a computer program needs to apply an affine transformation to a complex three-dimensional object made up of [$npts] points. The transformation is composed of [$nmats] matrices (call them [`M_1`] through [`M_{[$nmats]}`]), so for each point [`(x, y, z)`] in the object, the following operation is performed.
+
+[`
+\left[\begin{array}{c} ~ \\ ~ M_1 ~ \\ ~ \end{array}\right] ~
+\left[\begin{array}{c} ~ \\ ~ M_2 ~ \\ ~ \end{array}\right] ~
+\left[\begin{array}{c} ~ \\ ~ M_3 ~ \\ ~ \end{array}\right] ~
+\cdots
+\left[\begin{array}{c} ~ \\ ~ M_{[$nmats-1]} ~ \\ ~ \end{array}\right] ~
+\left[\begin{array}{c} ~ \\ ~ M_{[$nmats]} ~ \\ ~ \end{array}\right] ~
+\left[\begin{array}{c} x \\ y \\ z \\ 1 \end{array}\right]
+`]
+
+Each multiplication of a matrix times a column vector involves 16 multiplications (of one number by another) and 12 additions, for a total of 28 arithmetic operations. Each multiplication of a matrix times another matrix involves 64 multiplications and 48 additions, for a total of 112 arithmetic operations.  (These numbers are not made up or chosen randomly; they are facts about [`4\times 4`] matrix multiplication.)
+
+-----
+
+The most inefficient way of applying the transformation to the [$npts] points would be to begin on the left, multiplying [`M_1`] by [`M_2`], then that result by [`M_3`], and so on along the list from left to right, and doing the same [$nmats] multiplications again for each of the [$npts] points.  How many arithmetic operations would this require for transforming one point?
+
+Answer: [_____]{$ans1}
+
+How many would it require in total for transforming all [$npts] points?
+
+Answer: [_____]{$ans2}
+
+-----
+
+A more efficient method would be to start on the right, first multiplying [`M_{[$nmats]}`] by the column vector, then multiplying [`M_{[$nmats-1]}`] by that result, and so on, proceeding along the list from right to
+left.
+
+How many arithmetic operations would this require for transforming one point?
+
+Answer: [_____]{$ans3}
+
+How many would it require in total for transforming all [$npts] points?
+
+Answer: [_____]{$ans4}
+
+Using this method would therefore save what percentage of the time of the previous method?
+
+Answer: [_____]{(1-$ans4/$ans2)*100}%
+
+-----
+
+The most efficient method would be to multiply the [$nmats] matrices together and call that result [`A`] (without yet multiplying [`A`] by any column vector). After computing [`A`] (just once of course), multiply [`A`] by each of the [$npts] points, each represented as a column vector.
+
+How many arithmetic operations would it take to compute [`A`]?
+
+Answer: [_____]{$nmats*112-112}
+
+How many arithmetic operations would it require to multiply [`A`] by one point?
+
+Answer: [_____]{28}
+
+How many would this method require in total?
+
+Answer: [_____]{$ans5}
+
+Using this method would therefore save what percentage of the time of the previous method?
+
+Answer: [_____]{100*(1-$ans5/$ans4)}%
+END_PGML
+
+BEGIN_PGML_SOLUTION
+To transform one point the inefficient way requires [`[$nmats-1]\times 112=[$nmats*112-112]`] for the [$nmats-1] matrix multiplications, plus another 28 for the final matrix-by-column-vector multiplication, for a total of [$ans1].
+
+To transform [$npts] the inefficient way is that previous answer times [$npts], which is [$ans2].
+
+-----
+
+If we proceed from right to left instead, then each multiplication is a matrix-times-column-vector multiplication, and thus requires only 28 operations.  Since there are [$nmats] matrices, it takes [`[$nmats]\times 28=[$ans3]`] operations to transform one point.
+
+To transform all [$npts] points, it requires [`[$ans3]\times [$npts]=[$ans4]`] operations.
+
+To see the time percentage of this method compared to the previous, we divide [`\frac{[$ans4]}{[$ans2]}=[$ans4/$ans2]`], which is [$ans4*100/$ans2]%, for a savings of [$ans4*-100/$ans2+100]%.
+
+-----
+
+Multiplying the [$nmats] matrices together involves only [$nmats-1] multiplications, each of which takes 112 operations.  So the total number of operations to compute [`A`] is [`[$nmats-1]\times 112=[$nmats*112-112]`].
+
+To apply [`A`] to a single point takes 28 operations, as the problem states.
+
+To apply [`A`] to all [$npts] points takes [`28\times [$npts]=[$npts*28]`] operations, to which we add the [$nmats*112-112] operations we needed to compute [`A`], making the total number of operations in this method equal to [`[$npts*28]+[$nmats*112-112]=[$ans5]`].
+
+To see the time percentage of this method compared to the previous, we divide [`\frac{[$ans5]}{[$ans4]}=[$ans5/$ans4]`], which is [$ans5*100/$ans4]%, for a savings of [$ans5*-100/$ans4+100]%.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-2-ConvertFromHomogeneous.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-2-ConvertFromHomogeneous.pg
@@ -1,0 +1,101 @@
+## DESCRIPTION
+## Converting homogeneous coordinates to points and/or vectors
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Coordinate systems)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('2')
+## KEYWORDS('homogeneous coordinates')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+@r = (
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+    non_zero_random(-10,10),
+);
+$ans1 = Matrix( [ [ $r[0], $r[1], 1 ] ] );
+$ans2 = Matrix( [ [ $r[2], $r[3], 0 ] ] );
+$ans3 = Matrix( [ [ $r[4], $r[5], $r[6], 1 ] ] );
+$ans4 = Matrix( [ [ $r[7], $r[8], $r[9], 0 ] ] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is/contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+The column vector [`\left[\begin{array}{c} [$r[0]] \\ [$r[1]] \\ 1 \end{array}\right]`] is in homogeneous coordinates.  What is it in standard notation?
+
+Answer:  It is a
+[___]{PopUp( [ (
+  '(make a choice)',
+  'point',
+  'vector'
+) ], 'point' )}
+with coordinates [_____]{$r[0]} and [_____]{$r[1]}.
+
+The column vector [`\left[\begin{array}{c} [$r[2]] \\ [$r[3]] \\ 0 \end{array}\right]`] is in homogeneous coordinates.  What is it in standard notation?
+
+Answer:  It is a
+[___]{PopUp( [ (
+  '(make a choice)',
+  'point',
+  'vector'
+) ], 'vector' )}
+with coordinates [_____]{$r[2]} and [_____]{$r[3]}.
+
+The column vector [`\left[\begin{array}{c} [$r[4]] \\ [$r[5]] \\ [$r[6]] \\ 1 \end{array}\right]`] is in homogeneous coordinates.  What is it in standard notation?
+
+Answer:  It is a
+[___]{PopUp( [ (
+  '(make a choice)',
+  'point',
+  'vector'
+) ], 'point' )}
+with coordinates [_____]{$r[4]}, [_____]{$r[5]}, and [_____]{$r[6]}.
+
+The column vector [`\left[\begin{array}{c} [$r[7]] \\ [$r[8]] \\ [$r[9]] \\ 0 \end{array}\right]`] is in homogeneous coordinates.  What is it in standard notation?
+
+Answer:  It is a
+[___]{PopUp( [ (
+  '(make a choice)',
+  'point',
+  'vector'
+) ], 'vector' )}
+with coordinates [_____]{$r[7]}, [_____]{$r[8]}, and [_____]{$r[9]}.
+END_PGML
+
+BEGIN_PGML_SOLUTION
+A point [`(x,y)`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ 1 \end{array}\right]`].
+
+A vector [`\langle x,y \rangle`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ 0 \end{array}\right]`].
+
+A point [`(x,y,z)`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ z \\ 1 \end{array}\right]`].
+
+A vector [`\langle x,y,z \rangle`] in homogeneous coordinates is the column vector [`\left[\begin{array}{c} x \\ y \\ z \\ 0 \end{array}\right]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-4-WriteTransformationMatrices.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-4-WriteTransformationMatrices.pg
@@ -1,0 +1,85 @@
+## DESCRIPTION
+## Writing 2D affine transformations as matrices
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Transformations)
+## DBsection(Rotation and reflection)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('4')
+## KEYWORDS('transformations','matrices')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$tx = non_zero_random(-10,10);
+$ty = non_zero_random(-10,10);
+$tz = non_zero_random(-10,10);
+$sx = non_zero_random(-10,10);
+$sy = non_zero_random(-10,10);
+$sz = non_zero_random(-10,10);
+if ( $sx < 0 ) {
+    $strx = sprintf("1/%d",-$sx);
+    $sx = -1/$sx;
+} else {
+    $strx = sprintf("%d",$sx);
+}
+if ( $sy < 0 ) {
+    $stry = sprintf("1/%d",-$sy);
+    $sy = -1/$sy;
+} else {
+    $stry = sprintf("%d",$sy);
+}
+if ( $sz < 0 ) {
+    $strz = sprintf("1/%d",-$sz);
+    $sz = -1/$sz;
+} else {
+    $strz = sprintf("%d",$sz);
+}
+$ans1 = Matrix( [
+    [ 1, 0, 0, $tx ], 
+    [ 0, 1, 0, $ty ],
+    [ 0, 0, 1, $tz ],
+    [ 0, 0, 0,   1 ]
+] );
+$ans2 = Matrix( [
+    [ $sx, 0, 0, 0 ], 
+    [ 0, $sy, 0, 0 ],
+    [ 0, 0, $sz, 0 ],
+    [ 0, 0, 0,   1 ]
+] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Express the transformation [`T_{[$tx],[$ty],[$tz]}`] in matrix form.
+
+[_____]*{$ans1} [@ AnswerFormatHelp("matrices") @]*
+
+Express the transformation [`S_{[$strx],[$stry],[$strz]}`] in matrix form.
+
+[_____]*{$ans2} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The transformation [`T_{a,b,c}`] is expressed in the matrix
+[`\left[\begin{array}{c} 1 & 0 & 0 & a \\ 0 & 1 & 0 & b \\ 0 & 0 & 1 & c \\ 0 & 0 & 0 & 1 \end{array}\right]`].
+
+The transformation [`S_{a,b,c}`] is expressed in the matrix
+[`\left[\begin{array}{c} a & 0 & 0 & 0 \\ 0 & b & 0 & 0 \\ 0 & 0 & c & 0 \\ 0 & 0 & 0 & 1 \end{array}\right]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-6-ApplyTransformationMatrices.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-6-ApplyTransformationMatrices.pg
@@ -1,0 +1,64 @@
+## DESCRIPTION
+## Applying 2D affine transformations as matrices
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Matrices)
+## DBsection(Matrix Algebra)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('6')
+## KEYWORDS('transformations','matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$M1 = Matrix( [
+    [ non_zero_random(-5,5), 0, non_zero_random(-5,5) ], 
+    [ 0, non_zero_random(-5,5), non_zero_random(-5,5) ],
+    [ 0, 0, 1 ]
+] );
+$easy = random(1,3);
+$CV1 = Matrix( [ [ $easy ], [ $easy ], [ 1 ] ] );
+$M2 = Matrix( [
+    [ non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01) ], 
+    [ non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01),
+      non_zero_random(-1,10,0.01) ], 
+    [ 0, 0, 1 ]
+] );
+$CV2 = Matrix( [ [ non_zero_random(-1,10,0.01) ],
+                 [ non_zero_random(-1,10,0.01) ],
+                 [ 1 ] ] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Perform the following applications of an affine transformation matrix to a column vector.
+
+[`[$M1][$CV1]=`][_____]*{$M1*$CV1} [@ AnswerFormatHelp("matrices") @]*
+
+[`[$M2][$CV2]=`][_____]*{$M2*$CV2} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`[$M1][$CV1]=[$M1*$CV1]`]
+
+[`[$M2][$CV2]=[$M2*$CV2]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-7-IsMatrixMultiplicationCommutative.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-7-IsMatrixMultiplicationCommutative.pg
@@ -1,0 +1,69 @@
+## DESCRIPTION
+## Investigating whether matrix multiplication is commutative (...it's not)
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Matrices)
+## DBsection(Matrix Algebra)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('7')
+## KEYWORDS('matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+# the positive random numbers and later the +1/-1's ensure that ML != LM
+$M = Matrix( [
+    [ random(0,9), random(0,9), random(0,9) ], 
+    [ random(0,9), random(-9,9), random(-9,9) ],
+    [ random(0,9), random(-9,9), random(-9,9) ]
+] );
+$L = Matrix( [
+    [ $M->element(1,1), $M->element(1,2)+1, $M->element(1,3)+1 ], 
+    [ $M->element(2,1)-1, random(-9,9), random(-9,9) ],
+    [ $M->element(3,1)-1, random(-9,9), random(-9,9) ]
+] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`L`] and [`M`] be the matrices defined below.
+
+[`L=[$L] ~ ~ ~ ~ ~ ~ M=[$M]`]
+
+Compute [`LM`].
+
+Answer: [_____]*{$L*$M} [@ AnswerFormatHelp("matrices") @]*
+
+Compute [`ML`].
+
+Answer: [_____]*{$M*$L} [@ AnswerFormatHelp("matrices") @]*
+
+Based on your results above, is matrix multiplication commutative?  Explain how you know.
+
+[@ ANS(essay_cmp); essay_box(3,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`LM=[$L][$M]=[$L*$M]`]
+
+[`ML=[$M][$L]=[$M*$L]`]
+
+Commutativity means that no matter what two matrices [`L`] and [`M`] you choose, we should see [`LM=ML`].  But these example choices for [`L`] and [`M`] show an example when [`ML\neq LM`], so matrix multiplication is not commutative.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-8-IsMatrixMultiplicationAssociative.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-8-IsMatrixMultiplicationAssociative.pg
@@ -1,0 +1,75 @@
+## DESCRIPTION
+## Investigating whether matrix multiplication is associative (...it is)
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Matrices)
+## DBsection(Matrix Algebra)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('8')
+## KEYWORDS('matrices','matrix multiplication')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$L = Matrix( [
+    [ random(-9,9), random(-9,9), random(-9,9) ], 
+    [ 0, random(-9,9), random(-9,9) ],
+    [ random(-9,9), 0, random(-9,9) ]
+] );
+$M = Matrix( [
+    [ 0, random(-9,9), random(-9,9) ], 
+    [ random(-9,9), 0, random(-9,9) ],
+    [ random(-9,9), random(-9,9), random(-9,9) ]
+] );
+$N = Matrix( [
+    [ random(-9,9), 0, random(-9,9) ], 
+    [ random(-9,9), random(-9,9), random(-9,9) ],
+    [ 0, random(-9,9), random(-9,9) ]
+] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`L`], [`M`], and [`N`] be the matrices defined below.
+
+[`L=[$L] ~ ~ ~ ~ ~ ~ M=[$M] ~ ~ ~ ~ ~ ~ N=[$N]`]
+
+Compute [`(LM)N`].
+
+Answer: [_____]*{($L*$M)*$N} [@ AnswerFormatHelp("matrices") @]*
+
+Compute [`L(MN)`].
+
+Answer: [_____]*{$L*($M*$N)} [@ AnswerFormatHelp("matrices") @]*
+
+Based on your results above, can you conclude that matrix multiplication associative?  Explain your answer.
+
+[@ ANS(essay_cmp); essay_box(3,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`(LM)N=\left([$L][$M]\right)[$N]=[$L*$M][$N]=[$L*$M*$N]`]
+
+[`L(MN)=[$L]\left([$M][$N]\right)=[$L][$M*$N]=[$L*$M*$N]`]
+
+Associativity means that no matter what three matrices [`L`], [`M`], and [`N`] you choose, we should see [`L(MN)=(LM)N`].  With these example choices for [`L`], [`M`], and [`N`], we do see that pattern, but we should not conclude from just one example that associativity is true across all possible matrices you could choose for [`L`], [`M`], and [`N`].
+
+(Matrix multiplication *is* associative, but one example is not enough evidence to know that for certain.)
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-9-InvestigatingIdentityMatrix.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch5/5-9-InvestigatingIdentityMatrix.pg
@@ -1,0 +1,82 @@
+## DESCRIPTION
+## Investigating the identity matrix
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Matrices)
+## DBsection(Elementary matrices)
+## Date(02/02/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('5')
+## Problem1('9')
+## KEYWORDS('matrices','identity matrix')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "AnswerFormatHelp.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$I = Value::Matrix->I(3);
+$M = Matrix( [
+    [ random(-6,6), random(-6,6), random(-6,6) ], 
+    [ random(-6,6), random(-6,6), random(-6,6) ],
+    [ random(-6,6), random(-6,6), random(-6,6) ]
+] );
+$L = $M + Matrix( [
+    [ random(1,3), random(1,3), random(1,3) ], 
+    [ random(1,3), random(1,3), random(1,3) ],
+    [ random(1,3), random(1,3), random(1,3) ]
+] );
+# strangely, when I tried using the Value::Matrix->I(4),
+# it caused errors in the problem, but this works fine.
+$I4 = Matrix( [ [ 1, 0, 0, 0 ], [ 0, 1, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ] ] );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let [`I`], [`M`], and [`L`] be the matrices shown below.
+
+[`I=[$I] ~ ~ ~ ~ ~ ~ M=[$M] ~ ~ ~ ~ ~ ~ L=[$L]`]
+
+Compute [`IM`].
+
+Answer: [_____]*{$M} [@ AnswerFormatHelp("matrices") @]*
+
+Compute [`MI`].
+
+Answer: [_____]*{$M} [@ AnswerFormatHelp("matrices") @]*
+
+Without computing [`IL`] or [`LI`], what do you think they would be?
+
+Answer:
+
+[`IL=`][_____]*{$L} [@ AnswerFormatHelp("matrices") @]*
+
+[`LI=`][_____]*{$L} [@ AnswerFormatHelp("matrices") @]*
+
+What [`4\times 4`] matrix has the same special behavior as [`I`]?
+
+Answer: [_____]*{$I4} [@ AnswerFormatHelp("matrices") @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`IM=MI=M`]
+
+[`IL=LI=L`]
+
+A matrix that does not alter another when multiplied by it exists in the [`4\times 4`] case also:
+
+[`[$I4]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-1-ParametricEquationsOfALine.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-1-ParametricEquationsOfALine.pg
@@ -1,0 +1,73 @@
+## DESCRIPTION
+## Constructing the parametric equations for two different lines
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Lines)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('1')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t => 'Real');
+$showPartialCorrectAnswers = 1;
+$px=random(-10,10,0.1);
+$py=non_zero_random(-10,10,0.1);
+$pz=non_zero_random(-10,10,0.1);
+$vx=non_zero_random(-10,10,0.1);
+$vy=non_zero_random(-10,10,0.1);
+$vz=random(-10,10,0.1);
+$signindex=random(0,1);
+$sign=(1,-1)[$signindex];
+$signname=("positive","negative")[$signindex];
+$axisindex=random(0,2);
+$axisx=($sign,0,0)[$axisindex];
+$axisy=(0,$sign,0)[$axisindex];
+$axisz=(0,0,$sign)[$axisindex];
+$axisname=("x","y","z")[$axisindex];
+
+TEXT(beginproblem());
+BEGIN_PGML
+Give the parametric equations of the line through the point [`([$px],[$py],[$pz])`] in the direction of the vector [`\langle [$vx],[$vy],[$vz] \rangle`].  While there are many possible answers here, use the most natural form generated from this point and vector.
+
+Answer:
+
+[`x=`][__________]{"$px+$vx*t"}
+
+[`y=`][__________]{"$py+$vy*t"}
+
+[`z=`][__________]{"$pz+$vz*t"}
+
+Give the parametric equations of the line through the origin in the direction of the [$signname] [$axisname] axis.  While there are many possible answers here, use the most natural form generated from this point and vector.
+
+Answer:
+
+[`x=`][__________]{"$axisx*t"}
+
+[`y=`][__________]{"$axisy*t"}
+
+[`z=`][__________]{"$axisz*t"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The parametric equations of a line through [`(p_1,p_2,p_3)`] in the direction of [`\langle v_1,v_2,v_3 \rangle`] are [`x=p_1+tv_1,y=p_2+tv_2,z=p_3+tv_3`].  Thus for the values in the first half of this problem, we have [`x=[$px]+[$vx]t,y=[$py]+[$vy]t,z=[$pz]+[$vz]t`].
+
+For the second half of the problem, the point is [`(0,0,0)`] and the vector is [`([$axisx],[$axisy],[$axisz])`], so the equations are [`x=[$axisx]t,y=[$axisy]t,z=[$axisz]t`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-10-RangeOfDotProductAngles.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-10-RangeOfDotProductAngles.pg
@@ -1,0 +1,52 @@
+## DESCRIPTION
+## Angle between two vectors: what range of values might it have?
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Inner products)
+## DBsection(Computing with dot products)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('10')
+## KEYWORDS('vectors','angles')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Your textbook gives the following equation for finding the angle between vectors [`\vec v`] and [`\vec w`]:
+
+>> [`\theta=\cos^{-1}\left(\hat v\cdot\hat w\right)=\cos^{-1}\left(\frac{\vec v\cdot\vec w}{\left\|\vec v\right\|~\left\|\vec w\right\|}\right) `] <<
+
+What is the smallest value of [`\theta`] that such a formula might yield?
+
+Answer: [_____]{0} radians, which is [_____]{0} degrees
+
+What is the largest value of [`\theta`] that such a formula might yield?
+
+Answer: [_____]{3.14159265358} radians, which is [_____]{180} degrees
+
+On a related note, the dot product of two unit vectors has what maximum and minimum values?
+
+Minimum: [_____]{-1} and maximum: [_____]{1}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The [`\cos^{-1}`] function always outputs values between 0 and [`\pi`] in radians, or 0 and 180 in degrees.  Inputs to that function are always between [`-1`] and [`1`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-11-MakeTheEquationOfAPlane.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-11-MakeTheEquationOfAPlane.pg
@@ -1,0 +1,59 @@
+## DESCRIPTION
+## Write the standard form equation of a plane, from a point and normal vector
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Planes)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('11')
+## KEYWORDS('vectors','planes','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+$showPartialCorrectAnswers = 1;
+$px=random(-10,10);
+$py=random(-10,10);
+$pz=random(-10,10);
+$vx=non_zero_random(-10,10);
+$vy=random(-10,10);
+$vz=random(-10,10);
+$C=-$vx*$px-$vy*$py-$vz*$pz;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write the standard form equation of a plane containing the point [`([$px],[$py],[$pz])`], with normal vector [`\langle [$vx],[$vy],[$vz] \rangle`].  Although there are many possible answers to this question (by multiplying the correct answer by any constant), give the one in which the normal vector has not been scaled.
+
+Answer: [____________________________________]{"$vx*x+$vy*y+$vz*z+$C"}=0
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The text gives the following equation for a plane through [`(p_1,p_2,p_3)`] with normal vector [`\langle v_1,v_2,v_3 \rangle`]:
+
+>> [`v_1(x-p_1)+v_2(y-p_2)+v_3(z-p_3)=0`] <<
+
+Substituting the values from this problem gives:
+
+>> [`[$vx](x-[$px])+[$vy](y-[$py])+[$vz](z-[$pz])=0`] <<
+
+Multiplying out each group and combining like terms yields the following.
+
+>> [`[$vx]x+[$vy]y+[$vz]z+[$C]`] <<
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-12-MakeTheEquationOfACanonicalPlane.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-12-MakeTheEquationOfACanonicalPlane.pg
@@ -1,0 +1,49 @@
+## DESCRIPTION
+## Write the standard form equation of the xy, xz, or yz plane
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Planes)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('12')
+## KEYWORDS('vectors','planes','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+$showPartialCorrectAnswers = 1;
+$whichPlane = random(0,2);
+$planeName = ("xy","yz","xz")[$whichPlane];
+$equationLHS = ("z","x","y")[$whichPlane];
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write the standard form equation of the [$planeName] plane.  Although there are many possible answers to this question (by multiplying the correct answer by any constant), give the one in which the coefficient is 1.
+
+Answer: [____________________________________]{"$equationLHS"}=0
+END_PGML
+
+BEGIN_PGML_SOLUTION
+In the yz plane, points can have any value of y and z, but must have [`x=0`], which is the equation defining the plane.  (The origin is in the plane, and the normal vector is [`\langle 1,0,0 \rangle`].)
+
+In the xz plane, points can have any value of x and z, but must have [`y=0`], which is the equation defining the plane.  (The origin is in the plane, and the normal vector is [`\langle 0,1,0 \rangle`].)
+
+In the xy plane, points can have any value of x and y, but must have [`z=0`], which is the equation defining the plane.  (The origin is in the plane, and the normal vector is [`\langle 0,0,1 \rangle`].)
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-14-LineOfSightIntersectsPlane.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-14-LineOfSightIntersectsPlane.pg
@@ -1,0 +1,114 @@
+## DESCRIPTION
+## Find the intersection of a line of sight and a plane
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Planes)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('14')
+## KEYWORDS('vectors','lines','planes','intersection')
+
+# Technically, this is like 6.13a and 6.14 together in one.
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t => 'Real');
+$showPartialCorrectAnswers = 1;
+
+$A=non_zero_random(0,10);
+$B=non_zero_random(-1,10);
+$C=non_zero_random(0,10);
+$v1=random(1,5);
+$v2=random(1,5);
+$v3=random(1,5);
+
+$p1=$A+$v1;
+$p2=$B+$v2;
+$p3=$C+$v3;
+$D=-($A*$p1+$B*$p2+$C*$p3)+random(-10,10);
+
+$t=-($A*$p1+$B*$p2+$C*$p3+$D)/($A*$v1+$B*$v2+$C*$v3);
+@choices = (
+    '(make a choice)',
+    'The intersection is in front of the camera.',
+    'The intersection is behind the camera.',
+    'The intersection is exactly at the camera point.'
+);
+if ( $t > 0 ) { $ansidx = 1; $explain = "t>0"; }
+if ( $t < 0 ) { $ansidx = 2; $explain = "t<0"; }
+if ( $t == 0 ) { $ansidx = 3; $explain = "t=0"; }
+
+$i1 = $p1+$v1*$t;
+$i2 = $p2+$v2*$t;
+$i3 = $p3+$v3*$t;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume a camera at [`([$p1],[$p2],[$p3])`] is looking through a pixel at [`([$p1+$v1],[$p2+$v2],[$p3+$v3])`].
+
+What is the corresponding line of sight?
+
+[`x=`][_______________]{"$p1+$v1*t"}
+
+[`y=`][_______________]{"$p2+$v2*t"}
+
+[`z=`][_______________]{"$p3+$v3*t"}
+
+Find the [`t`] value for which that line of sight intersects the plane [`[$A]x+[$B]y+[$C]z+[$D]=0`].
+
+Answer: [`t=`][__________]{$t}
+
+What is the point in space corresponding to that [`t`] value?
+
+Answer: ([______]{$i1},[______]{$i2},[______]{$i3})
+
+Where does that point sit relative to the camera?
+
+Pick your answer from here: [___]{PopUp( [ @choices ], $choices[$ansidx] )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Lines of sight are created with the formula [`P+t\vec v`] with [`P`] the camera point and [`\vec v`] the vector from the camera to the pixel.  We were given the camera point, and compute the vector here.
+
+[`\vec v=([$p1+$v1],[$p2+$v2],[$p3+$v3])-([$p1],[$p2],[$p3])
+=\langle [$v1],[$v2],[$v3] \rangle`]
+
+Thus the line of sight is [`x=[$p1]+[$v1]t, y=[$p2]+[$v2]t, z=[$p3]+[$v3]t`].
+
+We can find where it intersects the plane by substituting it into the equation of the plane.
+
+Plane equation: [`[$A]x+[$B]y+[$C]z+[$D]=0`]
+
+After substitution: [`[$A]([$p1]+[$v1]t)+[$B]([$p2]+[$v2]t)+[$C]([$p3]+[$v3]t)+[$D]=0`]
+
+After solving, we find [`t=[$t]`].
+
+We can find the corresponding point in space by substituting back into the parametric equations for the line of sight.
+
+[`x=[$p1]+[$v1]t=[$p1]+[$v1]([$t])=[$i1]`]
+
+[`y=[$p2]+[$v2]t=[$p2]+[$v2]([$t])=[$i2]`]
+
+[`z=[$p3]+[$v3]t=[$p3]+[$v3]([$t])=[$i3]`]
+
+Thus the point is [`([$i1],[$i2],[$i3])`].
+
+Because [`[$explain]`], we know that the correct answer to the multiple choice question is "[$choices[$ansidx]]"
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-15-LinePlaneNoIntersectionEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-15-LinePlaneNoIntersectionEssay.pg
@@ -1,0 +1,58 @@
+## DESCRIPTION
+## Explain how you can tell when a line does not intersect a plane
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Planes)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('15')
+## KEYWORDS('vectors','lines','planes','intersection')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$A=non_zero_random(0,10);
+$B=non_zero_random(-1,10);
+$C=non_zero_random(0,2);
+$v1=random(1,5);
+$v2=random(1,5);
+$v3=(-$A*$v1-$B*$v2)/$C;
+$p1=random(-10,10);
+$p2=random(-10,10);
+$p3=random(-10,10);
+$D=-($A*$p1+$B*$p2+$C*$p3)+non_zero_random(-10,10);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let us assume we have the line whose parametric equations are [`x=[$p1]+[$v1]t, y=[$p2]+[$v2]t, z=[$p3]+[$v3]t`] and the plane with equation [`[$A]x+[$B]y+[$C]z+[$D]=0`].
+
+This line and this plane do not intersect, but let's pretend we did not know that, and attempted to find their point of intersection by substituting the parametric equations into the plane equation.
+
+What goes wrong?  Be sure to phrase your answer in such a way that it explains how someone could tell, in a future situation, that a line and plane don't intersect.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+After substitution we have [`[$A]([$p1]+[$v1]t)+[$B]([$p2]+[$v2]t)+[$C]([$p3]+[$v3]t)+[$D]=0`], which simplifies to [`[$A*$p1+$B*$p2+$C*$p3+$D]=0`].
+
+Since that equation is always false, regardless of what value we choose for [`t`], it has no solution, and thus there is no intersection between the line and the plane.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-2-DataFromParametricEquations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-2-DataFromParametricEquations.pg
@@ -1,0 +1,71 @@
+## DESCRIPTION
+## Deconstructing the parametric equations for two different lines
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Lines)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('2')
+## KEYWORDS('lines','parametric equations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$py=non_zero_random(-10,10,0.1);
+$pz=non_zero_random(-10,10,0.1);
+$vx=non_zero_random(-10,10,0.1);
+$vy=non_zero_random(-10,10,0.1);
+$vz=non_zero_random(-10,10,0.1);
+$nx=list_random(-1,-3,-5,-7,-9,1,3,5,7,9);
+$nz=list_random(-1,-3,-5,-7,-9,1,3,5,7,9);
+$dx=list_random(2,4,8,11);
+$dz=list_random(2,4,8,11);
+$qx=non_zero_random(5,15);
+$qy=non_zero_random(-15,-5);
+
+TEXT(beginproblem());
+BEGIN_PGML
+From what point [`P`] and direction vector [`\vec v`] were the following parametric equations constructed?
+
+[`x=[$vx]t,y=[$py]+[$vy]t,z=[$pz]+[$vz]t`]
+
+Answer:
+
+[`P=(`][_____]{0},[_____]{$py},[_____]{$pz}[`)`] and
+[`\vec v=\langle`][_____]{$vx},[_____]{$vy},[_____]{$vz}[`\rangle`]
+
+From what point [`P`] and direction vector [`\vec v`] were the following parametric equations constructed?
+
+[`x=[$qx]+\frac{[$nx]}{[$dx]}t,y=[$qy],z=\frac{[$nz]}{[$dz]}t`]
+
+Answer:
+
+[`P=(`][_____]{$qx},[_____]{$qy},[_____]{0}[`)`] and
+[`\vec v=\langle`][_____]{$nx/$dx},[_____]{0},[_____]{$nz/$dz}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The parametric equations of a line through [`(p_1,p_2,p_3)`] in the direction of [`\langle v_1,v_2,v_3 \rangle`] are [`x=p_1+tv_1,y=p_2+tv_2,z=p_3+tv_3`].  We can therefore lift the point and vector values directly from the equations.  In this case, they are as follows:
+
+For the first set of equations:
+[`P=(0,[$py],[$pz])`] and [`\vec v=\langle [$vx],[$vy],[$vz] \rangle`].
+
+For the second set of equations:
+[`P=([$qx],[$qy],0)`] and [`\vec v=\langle \frac{[$nx]}{[$dx]},0,\frac{[$nz]}{[$dz]} \rangle`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-21-ProveScalarAndDotProductsCommute.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-21-ProveScalarAndDotProductsCommute.pg
@@ -1,0 +1,51 @@
+## DESCRIPTION
+## Prove that the scalar and dot products commute
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Dot product, length, and unit vectors)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('21')
+## KEYWORDS('vectors','dot product','scalar product')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Use some algebra to demonstrate why the following equation is true, for any scalars [`s`] and [`t`] and any vectors [`\vec u`] and [`\vec v`].
+
+>> [`(s\vec v)\cdot(t\vec w)=st(\vec v\cdot\vec w)`] <<
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`(s\vec v)\cdot(t\vec w)=(s\langle v_1,v_2,v_3 \rangle)\cdot(t\langle w_1,w_2,w_3 \rangle)`]
+
+[`=\langle sv_1,sv_2,sv_3 \rangle\cdot\langle tw_1,tw_2,tw_3 \rangle`] using scalar multiplication
+
+[`=sv_1tw_1+sv_2tw_2+sv_3tw_3`] using the dot product
+
+[`=st(v_1w_1+v_2w_2+v_3w_3)`] by simple factoring
+
+[`=st(\vec v\cdot\vec w)`] using the dot product again
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-22-ProveDotProductRelatesToLength.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-22-ProveDotProductRelatesToLength.pg
@@ -1,0 +1,47 @@
+## DESCRIPTION
+## Prove that the dot product of a vector with itself is its length squared
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Dot product, length, and unit vectors)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('22')
+## KEYWORDS('vectors','dot product','magnitude')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Use some algebra to demonstrate why the following equation is true for any vector [`\vec v`].
+
+>> [`\vec v\cdot\vec v=\left\|\vec v\right\|^2`] <<
+
+[@ ANS(essay_cmp); essay_box(10,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec v\cdot\vec v=\langle v_1,v_2,v_3 \rangle\cdot\langle v_1,v_2,v_3 \rangle`]
+
+[`=v_1\cdot v_1+v_2\cdot v_2+v_3\cdot v_3=v_1^2+v_2^2+v_3^2`]
+
+[`=\left(\sqrt{v_1^2+v_2^2+v_3^2}\right)^2=\left\|\langle v_1,v_2,v_3 \rangle\right\|^2=\left\|\vec v\right\|^2`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-25a-PlaneEquationInPOVRay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-25a-PlaneEquationInPOVRay.pg
@@ -1,0 +1,61 @@
+## DESCRIPTION
+## Connect standard form plane equation to POV-Ray code for a plane
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Dot product, length, and unit vectors)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('25a')
+## KEYWORDS('vectors','planes','equations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(A => 'Real');
+Context()->variables->add(B => 'Real');
+Context()->variables->add(C => 'Real');
+Context()->variables->add(D => 'Real');
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+The POV code for a plane, in its simplest form, is as follows.
+
+[| plane { <a,b,c>, d } |]
+
+The POV documentation (Section 3.4.5.3.1) states that this code creates the plane that satisfies the equation [`ax+by+cz-d\sqrt{a^2+b^2+c^2}=0`].
+
+This tells us how to translate POV plane code into an equation of a plane in standard form.
+
+Now assume we wish to convert in the other direction. Given the equation of a plane in standard form, [`Ax + By + Cz + D = 0`], you wish to render the plane in POV.  What POV code would you write?
+
+[|plane <|][_____]{"A"},[_____]{"B"},[_____]{"C"}[|>,|] [____________________]{"-D/sqrt(A*A+B*B+C*C)"} [|}|]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We want [`ax+by+cz-d\sqrt{a^2+b^2+c^2}=0`] to match [`Ax+By+Cz+D=0`].  So set [`a=A,b=B,c=C`], and then we must choose [`d`] so that [`-d\sqrt{a^2+b^2+c^2}=D`].
+
+This is not difficult to solve for [`d`], and while we’re at it we replace [`a`], [`b`], and [`c`] with their values from the standard form plane equation, giving
+
+[`d=-\frac{D}{\sqrt{a^2+b^2+c^2}}=-\frac{D}{\sqrt{A^2+B^2+C^2}}.`]
+
+Thus the POV code would look like this.
+
+[|plane { <A,B,C>, -D/sqrt(A*A+B*B+C*C) }|]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-28-NewWaysToCreatePlaneEquations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-28-NewWaysToCreatePlaneEquations.pg
@@ -1,0 +1,61 @@
+## DESCRIPTION
+## Connect standard form plane equation to POV-Ray code for a plane
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Dot product, length, and unit vectors)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('25a')
+## KEYWORDS('vectors','planes','equations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(A => 'Real');
+Context()->variables->add(B => 'Real');
+Context()->variables->add(C => 'Real');
+Context()->variables->add(D => 'Real');
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+The POV code for a plane, in its simplest form, is as follows.
+
+[| plane { <a,b,c>, d } |]
+
+The POV documentation (Section 3.4.5.3.1) states that this code creates the plane that satisfies the equation [`ax+by+cz-d\sqrt{a^2+b^2+c^2}=0`].
+
+This tells us how to translate POV plane code into an equation of a plane in standard form.
+
+Now assume we wish to convert in the other direction. Given the equation of a plane in standard form, [`Ax + By + Cz + D = 0`], you wish to render the plane in POV.  What POV code would you write?
+
+[|plane <|][_____]{"A"},[_____]{"B"},[_____]{"C"}[|>,|] [____________________]{"-D/sqrt(A*A+B*B+C*C)"} [|}|]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We want [`ax+by+cz-d\sqrt{a^2+b^2+c^2}=0`] to match [`Ax+By+Cz+D=0`].  So set [`a=A,b=B,c=C`], and then we must choose [`d`] so that [`-d\sqrt{a^2+b^2+c^2}=D`].
+
+This is not difficult to solve for [`d`], and while we’re at it we replace [`a`], [`b`], and [`c`] with their values from the standard form plane equation, giving
+
+[`d=-\frac{D}{\sqrt{a^2+b^2+c^2}}=-\frac{D}{\sqrt{A^2+B^2+C^2}}.`]
+
+Thus the POV code would look like this.
+
+[|plane { <A,B,C>, -D/sqrt(A*A+B*B+C*C) }|]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-30-LinePlaneFullIntersectionEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-30-LinePlaneFullIntersectionEssay.pg
@@ -1,0 +1,58 @@
+## DESCRIPTION
+## Explain how you can tell when a line sits inside a plane
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Planes)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('30')
+## KEYWORDS('vectors','lines','planes','intersection')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$A=non_zero_random(0,10);
+$B=non_zero_random(-1,10);
+$C=non_zero_random(0,2);
+$v1=random(1,5);
+$v2=random(1,5);
+$v3=(-$A*$v1-$B*$v2)/$C;
+$p1=random(-10,10);
+$p2=random(-10,10);
+$p3=random(-10,10);
+$D=-($A*$p1+$B*$p2+$C*$p3);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Let us assume we have the line whose parametric equations are [`x=[$p1]+[$v1]t, y=[$p2]+[$v2]t, z=[$p3]+[$v3]t`] and the plane with equation [`[$A]x+[$B]y+[$C]z+[$D]=0`].
+
+This line sits entirely inside this plane, but let's pretend we did not know that, and attempted to find their point of intersection by substituting the parametric equations into the plane equation.
+
+What goes wrong?  Be sure to phrase your answer in such a way that it explains how someone could tell, in a future situation, that a line sits entirely inside a plane.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+After substitution we have [`[$A]([$p1]+[$v1]t)+[$B]([$p2]+[$v2]t)+[$C]([$p3]+[$v3]t)+[$D]=0`], which simplifies to [`0=0`].
+
+Since that equation is always true, regardless of what value we choose for [`t`], all points on the line satisfy the plane equation, and are thus inside the plane.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-4-ParametricEquationsThroughPoints.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-4-ParametricEquationsThroughPoints.pg
@@ -1,0 +1,59 @@
+## DESCRIPTION
+## Constructing the parametric equations for a line through two points
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Lines)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('4')
+## KEYWORDS('lines','parametric equations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t => 'Real');
+$showPartialCorrectAnswers = 1;
+$px=random(-10,-0.5,0.5);
+$py=random(-10,10,0.5);
+$pz=random(-10,10,0.5);
+$qx=random(0.5,10,0.5);
+$qy=random(-10,10,0.5);
+$qz=random(-10,10,0.5);
+
+$vx=$qx-$px;
+$vy=$qy-$py;
+$vz=$qz-$pz;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Give the parametric equations for the line through the points [`([$px],[$py],[$pz])`] and [`([$qx],[$qy],[$qz])`].  Although there are many possible answers to this question, please use the first of the two points as the "main" point in the parametric equations, and use a vector that points toward the second point, because that is what the automated system expects when grading.
+
+Answer:
+
+[`x=`][__________]{"$px+$vx*t"}
+
+[`y=`][__________]{"$py+$vy*t"}
+
+[`z=`][__________]{"$pz+$vz*t"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We compute a vector from [`([$px],[$py],[$pz])`] to [`([$qx],[$qy],[$qz])`] by subtraction: [`([$qx],[$qy],[$qz])-([$px],[$py],[$pz])=\langle [$vx],[$vy],[$vz] \rangle`].  We can then use the point [`([$px],[$py],[$pz])`] and the direction vector we just computed to form the equations:
+
+[`x=[$px]+[$vx]t, y=[$py]+[$vy]t, z=[$pz]+[$vz]t`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-5-ParametricEquationsLineOfSight.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-5-ParametricEquationsLineOfSight.pg
@@ -1,0 +1,59 @@
+## DESCRIPTION
+## Constructing the parametric equations for a line of sight
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Lines)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('5')
+## KEYWORDS('lines','parametric equations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(t => 'Real');
+$showPartialCorrectAnswers = 1;
+$px=random(-10,-0.5,0.5);
+$py=random(-10,10,0.5);
+$pz=random(-10,10,0.5);
+$qx=random(0.5,10,0.5);
+$qy=random(-10,10,0.5);
+$qz=random(-10,10,0.5);
+
+$vx=$qx-$px;
+$vy=$qy-$py;
+$vz=$qz-$pz;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Give the parametric equations for the line of sight with the camera at [`([$px],[$py],[$pz])`] and through the pixel at [`([$qx],[$qy],[$qz])`].
+
+Answer:
+
+[`x=`][__________]{"$px+$vx*t"}
+
+[`y=`][__________]{"$py+$vy*t"}
+
+[`z=`][__________]{"$pz+$vz*t"}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We compute a vector from [`([$px],[$py],[$pz])`] to [`([$qx],[$qy],[$qz])`] by subtraction: [`([$qx],[$qy],[$qz])-([$px],[$py],[$pz])=\langle [$vx],[$vy],[$vz] \rangle`].  We can then use the point [`([$px],[$py],[$pz])`] and the direction vector we just computed to form the equations:
+
+[`x=[$px]+[$vx]t, y=[$py]+[$vy]t, z=[$pz]+[$vz]t`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-6-ComputeSomeDotProducts.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-6-ComputeSomeDotProducts.pg
@@ -1,0 +1,52 @@
+## DESCRIPTION
+## Compute some simple dot products
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Inner products)
+## DBsection(Computing with dot products)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('6')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+@P2D1=(random(-10,10),non_zero_random(-10,10));
+@P2D2=(non_zero_random(-10,10),random(-10,10));
+$prod1=$P2D1[0]*$P2D2[0]+$P2D1[1]*$P2D2[1];
+
+@P3D1=(random(-10,10),random(-10,10),non_zero_random(-10,10));
+@P3D2=(random(-10,10,0.1),non_zero_random(-10,10,0.1),random(-10,10,0.1));
+$prod2=$P3D1[0]*$P3D2[0]+$P3D1[1]*$P3D2[1]+$P3D1[2]*$P3D2[2];
+
+TEXT(beginproblem());
+BEGIN_PGML
+Compute the two dot products shown below.
+
+[`\langle [$P2D1[0]],[$P2D1[1]] \rangle\cdot\langle [$P2D2[0]],[$P2D2[1]] \rangle = `][__________]{$prod1}
+
+[`\langle [$P3D1[0]],[$P3D1[1]],[$P3D1[2]] \rangle\cdot\langle [$P3D2[0]],[$P3D2[1]],[$P3D2[2]] \rangle = `][__________]{$prod2}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\langle [$P2D1[0]],[$P2D1[1]] \rangle\cdot\langle [$P2D2[0]],[$P2D2[1]] \rangle = [$P2D1[0]]\cdot[$P2D2[0]]+[$P2D1[1]]\cdot[$P2D2[1]]=[$prod1]`]
+
+[`\langle [$P3D1[0]],[$P3D1[1]],[$P3D1[2]] \rangle\cdot\langle [$P3D2[0]],[$P3D2[1]],[$P3D2[2]] \rangle = [$P3D1[0]]\cdot[$P3D2[0]]+[$P3D1[1]]\cdot[$P3D2[1]]+[$P3D1[2]]\cdot[$P3D2[2]]=[$prod2]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-7-AngleBetweenVectors.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-7-AngleBetweenVectors.pg
@@ -1,0 +1,98 @@
+## DESCRIPTION
+## Compute the angle between two vectors, twice (once in 2D and once in 3D)
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Inner products)
+## DBsection(Computing with dot products)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('7')
+## KEYWORDS('vectors')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+@P2D1=(random(-10,10),non_zero_random(-10,10));
+@P2D2=(non_zero_random(-10,10),random(-10,10));
+$len2D1=sqrt($P2D1[0]**2+$P2D1[1]**2);
+$len2D2=sqrt($P2D2[0]**2+$P2D2[1]**2);
+@u2D1=($P2D1[0]/$len2D1,$P2D1[1]/$len2D1);
+@u2D2=($P2D2[0]/$len2D2,$P2D2[1]/$len2D2);
+$prod1=$u2D1[0]*$u2D2[0]+$u2D1[1]*$u2D2[1];
+$ang1rad=acos($prod1);
+$ang1deg=$ang1rad*180/3.14159265358;
+
+@P3D1=(random(-10,10),random(-10,10),non_zero_random(-10,10));
+@P3D2=(random(-10,10),non_zero_random(-10,10),random(-10,10));
+$len3D1=sqrt($P3D1[0]**2+$P3D1[1]**2+$P3D1[2]**2);
+$len3D2=sqrt($P3D2[0]**2+$P3D2[1]**2+$P3D2[2]**2);
+@u3D1=($P3D1[0]/$len3D1,$P3D1[1]/$len3D1,$P3D1[2]/$len3D1);
+@u3D2=($P3D2[0]/$len3D2,$P3D2[1]/$len3D2,$P3D2[2]/$len3D2);
+$prod2=$u3D1[0]*$u3D2[0]+$u3D1[1]*$u3D2[1]+$u3D1[2]*$u3D2[2];
+$ang2rad=acos($prod2);
+$ang2deg=$ang2rad*180/3.14159265358;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Compute the angle between the vector [`\langle [$P2D1[0]],[$P2D1[1]] \rangle`] and the vector [`\langle [$P2D2[0]],[$P2D2[1]] \rangle`].
+
+Answer: [__________]{$ang1deg} degrees
+
+Compute the angle between the vector [`\langle [$P3D1[0]],[$P3D1[1]],[$P3D1[2]] \rangle`] and the vector [`\langle [$P3D2[0]],[$P3D2[1]],[$P3D2[2]] \rangle`].
+
+Answer: [__________]{$ang2deg} degrees
+END_PGML
+
+BEGIN_PGML_SOLUTION
+First we must convert the vectors into unit vectors.  For this, we need their lengths.
+
+[`||\langle [$P2D1[0]],[$P2D1[1]] \rangle||=\sqrt{([$P2D1[0]])^2+([$P2D1[1]])^2}=[$len2D1]`]
+
+[`||\langle [$P2D2[0]],[$P2D2[1]] \rangle||=\sqrt{([$P2D2[0]])^2+([$P2D2[1]])^2}=[$len2D2]`]
+
+We then divide by those lengths to produce unit vectors.
+
+[`\frac{\langle [$P2D1[0]],[$P2D1[1]] \rangle}{[$len2D1]}=\langle [$u2D1[0]],[$u2D1[1]] \rangle`]
+
+[`\frac{\langle [$P2D2[0]],[$P2D2[1]] \rangle}{[$len2D2]}=\langle [$u2D2[0]],[$u2D2[1]] \rangle`]
+
+The angle between vectors is the inverse cosine of the dot product of the unit vectors.
+
+[`\langle [$u2D1[0]],[$u2D1[1]] \rangle\cdot\langle [$u2D2[0]],[$u2D2[1]] \rangle=[$prod1]`]
+
+[`\cos^{-1}([$prod1])=[$ang1rad]`]
+
+This is measured in radians, and if we convert to degrees, we get [$ang1deg] degrees.
+
+We can then repeat this procedure for the other pair of vectors given.
+
+[`||\langle [$P3D1[0]],[$P3D1[1]],[$P3D1[2]] \rangle||=\sqrt{([$P3D1[0]])^2+([$P3D1[1]])^2+([$P3D1[2]])^2}=[$len3D1]`]
+
+[`||\langle [$P3D2[0]],[$P3D2[1]],[$P3D2[2]] \rangle||=\sqrt{([$P3D2[0]])^2+([$P3D2[1]])^2+([$P3D2[2]])^2}=[$len3D2]`]
+
+[`\frac{\langle [$P3D1[0]],[$P3D1[1]],[$P3D1[2]] \rangle}{[$len3D1]}=\langle [$u3D1[0]],[$u3D1[1]],[$u3D1[2]] \rangle`]
+
+[`\frac{\langle [$P3D2[0]],[$P3D2[1]],[$P3D2[2]] \rangle}{[$len3D2]}=\langle [$u3D2[0]],[$u3D2[1]],[$u3D2[2]] \rangle`]
+
+[`\langle [$u3D1[0]],[$u3D1[1]],[$u3D1[2]] \rangle\cdot\langle [$u3D2[0]],[$u3D2[1]],[$u3D2[2]] \rangle=[$prod2]`]
+
+[`\cos^{-1}([$prod2])=[$ang2rad]`]
+
+[$ang2rad] radians is [$ang2deg] degrees.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-8-AreVectorsPerpendicular.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/6-8-AreVectorsPerpendicular.pg
@@ -1,0 +1,109 @@
+## DESCRIPTION
+## Determine which vectors are perpendicular
+## ENDDESCRIPTION
+
+## DBsubject(Linear Algebra)
+## DBchapter(Inner products)
+## DBsection(Computing with dot products)
+## Date(02/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('6')
+## Problem1('8')
+## KEYWORDS('vectors','angles','perpendicular')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$core = non_zero_random(-3,3);
+@A = ($core*non_zero_random(-5,5),$core*non_zero_random(-5,5),
+      $core,
+      $core*non_zero_random(-5,5),$core*non_zero_random(-5,5));
+@ansA = ($A[3],$A[4],-($A[0]*$A[3]+$A[1]*$A[4])/$A[2]);
+$correctA = "<$ansA[0],$ansA[1],$ansA[2]>";
+@choicesA = ();
+$startindex = random(0,2);
+for ( my $i = 0 ; $i < 4 ; $i++ ) {
+    @other = ($ansA[0],$ansA[1],$ansA[2]);
+    $other[($startindex+$i)%3] += non_zero_random(-6+4*$i,6+4*$i+3);
+    push @choicesA, "<$other[0],$other[1],$other[2]>";
+}
+$choicesA[random(0,3)] = $correctA;
+unshift @choicesA, '(make a choice)';
+push @choicesA, 'none of the above';
+
+$core = non_zero_random(-3,3);
+@B = ($core*non_zero_random(-5,5),$core*non_zero_random(-5,5),
+      $core,
+      $core*non_zero_random(-5,5),$core*non_zero_random(-5,5));
+@ansB = ($B[3],$B[4],-($B[0]*$B[3]+$B[1]*$B[4])/$B[2]);
+$correctB = "<$ansB[0],$ansB[1],$ansB[2]>";
+@choicesB = ();
+$startindex = random(0,2);
+for ( my $i = 0 ; $i < 4 ; $i++ ) {
+    @other = ($ansB[0],$ansB[1],$ansB[2]);
+    $other[($startindex+$i)%3] += non_zero_random(-6+4*$i,6+4*$i+3);
+    push @choicesB, "<$other[0],$other[1],$other[2]>";
+}
+$choicesB[random(0,3)] = $correctB;
+unshift @choicesB, '(make a choice)';
+push @choicesB, 'none of the above';
+
+$core = non_zero_random(-3,3);
+@C = ($core*non_zero_random(-5,5),$core*non_zero_random(-5,5),
+      $core,
+      $core*non_zero_random(-5,5),$core*non_zero_random(-5,5));
+@ansC = ($C[3],$C[4],-($C[0]*$C[3]+$C[1]*$C[4])/$C[2]);
+$correctC = "<$ansC[0],$ansC[1],$ansC[2]>";
+@choicesC = ();
+$startindex = random(0,2);
+for ( my $i = 0 ; $i < 4 ; $i++ ) {
+    @other = ($ansC[0],$ansC[1],$ansC[2]);
+    $other[($startindex+$i)%3] += non_zero_random(-6+4*$i,6+4*$i+3);
+    push @choicesC, "<$other[0],$other[1],$other[2]>";
+}
+$choicesC[random(0,3)] = $correctC;
+unshift @choicesC, '(make a choice)';
+push @choicesC, 'none of the above';
+
+TEXT(beginproblem());
+BEGIN_PGML
+The vector [`\langle [$A[0]],[$A[1]],[$A[2]] \rangle`] is perpendicular to which other vector?
+
+Pick your answer from here: [___]{PopUp( [ @choicesA ], $correctA )}
+
+The vector [`\langle [$B[0]],[$B[1]],[$B[2]] \rangle`] is perpendicular to which other vector?
+
+Pick your answer from here: [___]{PopUp( [ @choicesB ], $correctB )}
+
+The vector [`\langle [$C[0]],[$C[1]],[$C[2]] \rangle`] is perpendicular to which other vector?
+
+Pick your answer from here: [___]{PopUp( [ @choicesC ], $correctC )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The answer in each case is determined by the simple rule that two vectors are perpendicular if and only if their dot product is zero.
+
+[`\langle [$A[0]],[$A[1]],[$A[2]] \rangle \cdot
+  \langle [$ansA[0]],[$ansA[1]],[$ansA[2]] \rangle = 0`]
+
+[`\langle [$B[0]],[$B[1]],[$B[2]] \rangle \cdot
+  \langle [$ansB[0]],[$ansB[1]],[$ansB[2]] \rangle = 0`]
+
+[`\langle [$C[0]],[$C[1]],[$C[2]] \rangle \cdot
+  \langle [$ansC[0]],[$ansC[1]],[$ansC[2]] \rangle = 0`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch6/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-1-EquationOfASphere.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-1-EquationOfASphere.pg
@@ -1,0 +1,85 @@
+## DESCRIPTION
+## Constructing and using the equation of a sphere
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/21/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('1')
+## KEYWORDS('sphere','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+$showPartialCorrectAnswers = 1;
+$a = non_zero_random( -10, 10 );
+$b = non_zero_random( -10, 10 );
+$c = random( 10, 15 );
+$r = random( 4, 9 );
+$x = $a + non_zero_random( -1, 1 );
+$y = $b + non_zero_random( -1, 1 );
+$z = random( 0, $c - $r );
+
+$xma2 = ($x-$a)**2;
+$ymb2 = ($y-$b)**2;
+$B = -$c*2;
+$C = $c**2-$r**2+$xma2+$ymb2;
+$botsol = $c-sqrt($r**2-($x-$a)**2-($y-$b)**2);
+$topsol = $c+sqrt($r**2-($x-$a)**2-($y-$b)**2);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a sphere with center [`([$a],[$b],[$c])`] and radius [`[$r]`].
+
+What is its equation?  (Place the radius portion on the right hand side and the rest of the equation on the left, as in the text.)
+
+Answer:
+[____________________________________]{"(x-$a)**2 + (y-$b)**2 + (z-$c)**2"}
+=
+[_____]{"$r**2"}
+
+What point on the sphere is directly above the sphere's center (in the positive [`z`] direction)?
+
+Answer: ([_____]{$a},[_____]{$b},[_____]{$c+$r})
+
+What two points on the sphere are directly above the point [`([$x],[$y],[$z])`]?  (As before, "above" means in the positive [`z`] direction.)
+
+Lower point: ([_____]{$x},[_____]{$y},[_____]{$botsol})
+
+Upper point: ([_____]{$x},[_____]{$y},[_____]{$topsol})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The equation of a sphere is [`(x-c_1)^2+(y-c_2)^2+(z-c_3)^2=r^2`], when the center point is [`(c_1,c_2,c_3)`] and the radius is [`r`].  So in this case the equation is [`(x-[$a])^2+(y-[$b])^2+(z-[$c])^2=[$r**2]`].
+
+The top point on the sphere will be a distance [$r] from the center in the positive [`z`] direction.  So we take the center [`([$a],[$b],[$c])`] and add [$r] to its [`z`] component: [`([$a],[$b],[$c+$z])`].
+
+To find what points are above (in the [`z`] direction) [`([$x],[$y],[$z])`], we use [`x=[$x]`] and [`y=[$y]`] in the sphere equation, and solve for [`z`].
+
+[`([$x]-[$a])^2+([$y]-[$b])^2+(z-[$c])^2=[$r**2]`]
+
+[`[$xma2]+[$ymb2]+z^2-[$c*2]z+[$c**2]=[$r**2]`]
+
+[`z^2+[$B]z+[$C]=0`]
+
+[`z=\frac{-[$B]\pm\sqrt{([$B])^2-4(1)([$C])}}{2(1)}`]
+
+[`z\approx [$botsol],[$topsol]`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-1-EquationOfASphere2.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-1-EquationOfASphere2.pg
@@ -1,0 +1,114 @@
+## DESCRIPTION
+## Using the equation of a sphere
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/21/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('1')
+## KEYWORDS('sphere','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$a = non_zero_random( -10, 10 );
+$b = non_zero_random( -10, 10 );
+$c = random( 10, 15 );
+$r = random( 5, 9 );
+$dx1 = random( 1, $r-3, 0.01 );
+$dy1 = random( 1, sqrt( $r**2 - $dx1**2 ), 0.01 );
+$dz1 = sqrt( $r**2 - $dx1**2 - $dy1**2 );
+$dx2 = random( 1, $r-3, 0.01 );
+$dy2 = random( 1, sqrt( $r**2 - $dx2**2 ), 0.01 );
+$dz2 = sqrt( $r**2 - $dx2**2 - $dy2**2 );
+$wrongOne = random( 1, 2 );
+$error = non_zero_random( 1.5, 2.5, 0.1 );
+$origdz1 = $dz1;
+$origdz2 = $dz2;
+if ( $wrongOne == 1 ) {
+    $dz1 += $error;
+    $explain1 = "This equation is not true, so the point is not on the sphere.  (The discrepency is more than just one or two decimal points.)";
+    $explain2 = "This equation is true (within one or two decimal points), so the point is on the sphere.";
+} else {
+    $dz2 += $error;
+    $explain1 = "This equation is true (within one or two decimal points), so the point is on the sphere.";
+    $explain2 = "This equation is not true, so the point is not on the sphere.  (The discrepency is more than just one or two decimal points.)";
+}
+$dz1str = sprintf( "%0.2f", $dz1 );
+$dz2str = sprintf( "%0.2f", $dz2 );
+$cdz1str = sprintf( "%0.2f", $c+$dz1 );
+$cdz2str = sprintf( "%0.2f", $c+$dz2 );
+$lhs1str = sprintf( "%0.2f", $dx1**2+$dy1**2+(floor($dz1*100)/100)**2 );
+$lhs2str = sprintf( "%0.2f", $dx2**2+$dy2**2+(floor($dz2*100)/100)**2 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is multiple choice, you are permitted ONLY ONE ATTEMPT.  Use it wisely.*
+
+Consider a sphere with center [`([$a],[$b],[$c])`] and radius [`[$r]`].
+
+Is the point [`([$a+$dx1],[$b+$dy1],[$cdz1str])`] on (the surface of) the sphere?  (Note that these values have been rounded to two decimal places, so you should be forgiving to one or two decimal points when you test.)
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'Yes, the point is on the sphere',
+  'No, the point is not on the sphere',
+  'There is not enough information to tell'
+) ], ( $wrongOne == 1 ) ?
+       'No, the point is not on the sphere' :
+       'Yes, the point is on the sphere' )}
+
+Is the point [`([$a+$dx2],[$b+$dy2],[$cdz2str])`] on (the surface of) the sphere?  (Again, these values have been rounded to two decimal places, so you should be forgiving to one or two decimal points when you test.)
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'Yes, the point is on the sphere',
+  'No, the point is not on the sphere',
+  'There is not enough information to tell'
+) ], ( $wrongOne == 2 ) ?
+       'No, the point is not on the sphere' :
+       'Yes, the point is on the sphere' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We write the equation of the sphere:
+
+[`(x-[$a])^2+(y-[$b])^2+(z-[$c])^2=[$r]^2`]
+
+We test the point [`([$a+$dx1],[$b+$dy1],[$cdz1str])`] in the sphere equation:
+
+[`([$a+$dx1]-[$a])^2+([$b+$dy1]-[$b])^2+([$cdz1str]-[$c])^2=[$r]^2`]
+
+[`[$dx1]^2+[$dy1]^2+[$dz1str]^2=[$r**2]`]
+
+[`[$lhs1str]=[$r**2]`]
+
+[$explain1]
+
+We test the point [`([$a+$dx2],[$b+$dy2],[$cdz2str])`] in the sphere equation:
+
+[`([$a+$dx2]-[$a])^2+([$b+$dy2]-[$b])^2+([$cdz2str]-[$c])^2=[$r]^2`]
+
+[`[$dx2]^2+[$dy2]^2+[$dz2str]^2=[$r**2]`]
+
+[`[$lhs2str]=[$r**2]`]
+
+[$explain2]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-10-LinesOfSightAndCSG.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-10-LinesOfSightAndCSG.pg
@@ -1,0 +1,103 @@
+## DESCRIPTION
+## Intervals of t values for lines of sight and objects made using CSG
+## ENDDESCRIPTION
+
+## DBsubject(Set theory and logic)
+## DBchapter(Operations on sets)
+## DBsection(Boolean operations on sets)
+## Date(02/22/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('10')
+## KEYWORDS('sets','lines','intersection','union','difference')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$t1b = random( -5, 10, 0.1 );
+$t2a = $t1b + random( -2, -0.5, 0.1 );
+$t1a = $t1b + random( -3, -1, 0.1 );
+$t2b = $t2a + random( 1, 2, 0.1 );
+
+$ans1a = max( $t1a, $t2a );
+$ans1b = min( $t1b, $t2b );
+
+$t3a = random( $ans1a+0.1, $ans1b-0.1, 0.1 );
+$t3b = $t3a + random( 1, 5, 0.1 );
+$t4a = random( $t3a+0.1, $t3b-0.1, 0.1 );
+$t4b = $t3b + random( 1, 5, 0.1 );
+
+$ans2a = $t3a;
+$ans2b = $t4a;
+
+$ans3a = $ans1a;
+$ans3b = $ans2b;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a POV scene file in which the shapes Ball, Box, Cone, and Pyramid have been defined. Assume that POV is considering the line of sight through a pixel and has computed its intersection with each of the four objects as follows.
+
+The line of sight intersects [|object { Ball }|] when [`[$t1a]\leq t \leq[$t1b]`].
+
+The line of sight intersects [|object { Box }|] when [`[$t2a]\leq t \leq[$t2b]`].
+
+The line of sight intersects [|object { Cone }|] when [`[$t3a]\leq t \leq[$t3b]`].
+
+The line of sight intersects [|object { Pyramid }|] when [`[$t4a]\leq t \leq[$t4b]`].
+
+Consider the following block of code.
+
+[|union {|]
+
+[`\hspace{1em}`][|intersection {|]
+
+[`\hspace{1em}`][`\hspace{1em}`][|object { Ball }|]
+
+[`\hspace{1em}`][`\hspace{1em}`][|object { Box }|]
+
+[`\hspace{1em}`][|}|]
+
+[`\hspace{1em}`][|difference {|]
+
+[`\hspace{1em}`][`\hspace{1em}`][|object { Cone }|]
+
+[`\hspace{1em}`][`\hspace{1em}`][|object { Pyramid }|]
+
+[`\hspace{1em}`][|}|]
+
+[|}|]
+
+For what [`t`] values is the line of sight inside the object defined by the intersection block?
+
+Answer: [_____]{$ans1a}[`\leq t \leq`][______]{$ans1b}
+
+For what [`t`] values is the line of sight inside the object defined by the difference block?
+
+Answer: [_____]{$ans2a}[`\leq t \leq`][______]{$ans2b}
+
+For what [`t`] values is the line of sight inside the object defined by the union block?
+
+Answer: [_____]{$ans3a}[`\leq t \leq`][______]{$ans3b}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The intersection of [`[$t1a]\leq t \leq[$t1b]`] and [`[$t2a]\leq t \leq[$t2b]`] is [`[$ans1a]\leq t \leq[$ans1b]`].
+
+The difference of [`[$t3a]\leq t \leq[$t3b]`] and [`[$t4a]\leq t \leq[$t4b]`] is [`[$ans2a]\leq t \leq[$ans2b]`].
+
+The union of [`[$ans1a]\leq t \leq[$ans1b]`] and [`[$ans2a]\leq t \leq[$ans2b]`] is [`[$ans3a]\leq t \leq[$ans3b]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-19b-LineIntersectingUnitBox.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-19b-LineIntersectingUnitBox.pg
@@ -1,0 +1,86 @@
+## DESCRIPTION
+## Intervals of t values for lines of sight and objects made using CSG
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/22/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('19b')
+## KEYWORDS('lines','intersection','unit box')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+
+$innerx = random( 0.1, 0.9, 0.1 );
+$innery = random( 0.1, 0.9, 0.1 );
+$innerz = random( 0.1, 0.9, 0.1 );
+
+$v1 = random( 1, 2, 0.1 );
+$v2 = random( 1, 2, 0.1 );
+$v3 = random( 1, 2, 0.1 );
+
+$s = random( 1, 4 );
+
+$pixx = $innerx - $s * $v1;
+$pixy = $innery - $s * $v2;
+$pixz = $innerz - $s * $v3;
+
+$p1 = $pixx - $v1;
+$p2 = $pixy - $v2;
+$p3 = $pixz - $v3;
+
+$xmin = min( -$p1/$v1, (1-$p1)/$v1 );
+$xmax = max( -$p1/$v1, (1-$p1)/$v1 );
+$ymin = min( -$p2/$v2, (1-$p2)/$v2 );
+$ymax = max( -$p2/$v2, (1-$p2)/$v2 );
+$zmin = min( -$p3/$v3, (1-$p3)/$v3 );
+$zmax = max( -$p3/$v3, (1-$p3)/$v3 );
+
+$min = max( $xmin, $ymin, $zmin );
+$max = min( $xmax, $ymax, $zmax );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Assume the camera is at [`([$p1],[$p2],[$p3])`] and is looking through a pixel at the point [`([$pixx],[$pixy],[$pixz])`].  There is a box in the scene that measures 1 unit on each side, stretching from [`(0,0,0)`] to [`(1,1,1)`].
+
+Come up with a way to determine the [`t`] values for when the line of sight enters and exits that box.  Use your method to compute those [`t`] values.
+
+Answers: [______]{$min} (lower value) and [______]{$max} (higher value)
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The line of sight has direction vector [`([$pixx],[$pixy],[$pixz])-([$p1],[$p2],[$p3])=\langle [$v1],[$v2],[$v3] \rangle`] and thus its equations are:
+
+[`x=[$p1]+[$v1]t`]
+
+[`y=[$p2]+[$v2]t`]
+
+[`z=[$p3]+[$v3]t`]
+
+One way to find where this intersects the box is to consider separately the questions: When does the line have its [`x`] coordinate between 0 and 1?  When does it have its [`y`] coordinate between 0 and 1?  When does it have its [`z`] coordinate between 0 and 1?  These questions are easy to solve from the parametric equations:
+
+[`0\leq x\leq 1`] means [`0\leq [$p1]+[$v1]t\leq 1`], so we can set [`0=[$p1]+[$v1]t`] to find the one end and [`[$p1]+[$v1]t=1`] to find the other.  Solving those two simple equations gives [`t=\frac{[$p1*-1]}{[$v1]}`] and [`t=\frac{1-[$p1]}{[$v1]}`], or [`[$xmin]\leq t \leq[$xmax]`].
+
+Repeating the same exercise for [`0\leq y\leq 1`] gives [`0\leq [$p2]+[$v2]t\leq 1`], which simplifies to [`[$ymin]\leq t\leq [$ymax]`].
+
+Repeating the same exercise for [`0\leq z\leq 1`] gives [`0\leq [$p3]+[$v3]t\leq 1`], which simplifies to [`[$zmin]\leq t\leq [$zmax]`].
+
+Since all three of these must be true for the line to be inside the box, we take the intersection of all three intervals, giving [`[$min]\leq t\leq [$max]`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-3-EquationOfASphereInPOV.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-3-EquationOfASphereInPOV.pg
@@ -1,0 +1,141 @@
+## DESCRIPTION
+## The equation of a sphere and POV code
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/21/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('3')
+## KEYWORDS('sphere','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(y => 'Real');
+Context()->variables->add(z => 'Real');
+$c1 = random( -10, 10 );
+$c2 = random( -10, 10 );
+$c3 = random( -10, 10 );
+$r = random( 1, 10 );
+$camx = $c1 + $r + random( 4, 6 );
+$camy = $c2;
+$camz = $c3;
+$pixx = $c1 + $r + random( 1, 3 );
+$xdist2center = $camx - $c1;
+$xdist2pixel = $camx - $pixx;
+$ratio = $xdist2pixel / ( $xdist2pixel + $xdist2center );
+$pixy = $c2 + $r * non_zero_random( -0.7, 0.7, 0.1 ) * $ratio;
+$pixz = $c3 + $r * non_zero_random( -0.7, 0.7, 0.1 ) * $ratio;
+$pixxstr = sprintf( "%0.3f", $pixx );
+$pixystr = sprintf( "%0.3f", $pixy );
+$pixzstr = sprintf( "%0.3f", $pixz );
+$v1 = $pixx - $camx;
+$v2 = $pixy - $camy;
+$v3 = $pixz - $camz;
+$v1str = sprintf( "%0.3f", $v1 );
+$v2str = sprintf( "%0.3f", $v2 );
+$v3str = sprintf( "%0.3f", $v3 );
+$A = $v1**2 + $v2**2 + $v3**2;
+$B = 2*($v1*($camx-$c1) + $v2*($camy-$c2) + $v3*($camz-$c3));
+$C = (($camx-$c1)**2 + ($camy-$c2)**2 + ($camz-$c3)**2) - $r**2;
+$lowert = (-$B-sqrt($B**2-4*$A*$C))/(2*$A);
+$lowerx = $camx + $lowert * $v1;
+$lowery = $camy + $lowert * $v2;
+$lowerz = $camz + $lowert * $v3;
+$highert = (-$B+sqrt($B**2-4*$A*$C))/(2*$A);
+$higherx = $camx + $highert * $v1;
+$highery = $camy + $highert * $v2;
+$higherz = $camz + $highert * $v3;
+
+TEXT(beginproblem());
+BEGIN_PGML
+What is the equation of the sphere whose POV code is as follows?
+
+[|sphere { <|][$c1][|,|][$c2][|,|][$c3][|>, |][$r][| }|]
+
+(Place the radius portion on the right hand side and the rest of the equation on the left, as in the text.)
+
+Answer:
+[____________________________________]{"(x-$c1)**2 + (y-$c2)**2 + (z-$c3)**2"}
+=
+[_____]{"$r**2"}
+
+Assume the camera is at position [`([$camx],[$camy],[$camz])`] and the line of sight we're interested in passes through the pixel at [`([$pixxstr],[$pixystr],[$pixzstr])`].  Where does the line of sight intersect the sphere?
+
+Lower [`t`] value = [________]{$lowert}
+
+Corresponding point in space: ([_____]{$lowerx},[______]{$lowery},[______]{$lowerz})
+
+Higher [`t`] value = [________]{$highert}
+
+Corresponding point in space: ([_____]{$higherx},[______]{$highery},[______]{$higherz})
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The equation of the sphere:
+
+[`(x-[$c1])^2+(y-[$c2])^2+(z-[$c3])^2=[$r]^2`]
+
+The direction vector for the line of sight:
+
+[`\langle [$pixxstr]-[$camx],[$pixystr]-[$camy],[$pixzstr]-[$camz] \rangle
+ =\langle [$v1str],[$v2str],[$v3str] \rangle`]
+
+The parametric equations of the line of sight:
+
+[`x=[$camx]+[$v1str]t`]
+
+[`y=[$camy]+[$v2str]t`]
+
+[`z=[$camz]+[$v3str]t`]
+
+Substituting the parametric equations into the sphere equation:
+
+[`([$camx]+[$v1str]t-[$c1])^2+([$camy]+[$v2str]t-[$c2])^2+([$camz]+[$v3str]t-[$c3])^2=[$r]^2`]
+
+Simplifying:
+
+[`([$camx-$c1]+[$v1str]t)^2+([$camy-$c2]+[$v2str]t)^2+([$camz-$c3]+[$v3str]t)^2=[$r**2]`]
+
+Multiplying out and combining terms:
+
+[`[$A]t^2+[$B]t+[$C]=0`]
+
+[`t=\frac{-[$B]\pm\sqrt{([$B])^2-4([$A])([$C])}}{2([$A])}=[$lowert],[$highert]`]
+
+The lower [`t`] value is therefore [$lowert], and we can find the corresponding point by plugging that [`t`] value into the parametric equations of the line of sight.
+
+[`x=[$camx]+[$v1str]([$lowert])=[$lowerx]`]
+
+[`y=[$camy]+[$v2str]([$lowert])=[$lowery]`]
+
+[`z=[$camz]+[$v3str]([$lowert])=[$lowerz]`]
+
+That gives the point [`([$lowerx],[$lowery],[$lowerz])`].
+
+The higher [`t`] value is therefore [$highert], and we can find the corresponding point by plugging that [`t`] value into the parametric equations of the line of sight.
+
+[`x=[$camx]+[$v1str]([$highert])=[$higherx]`]
+
+[`y=[$camy]+[$v2str]([$highert])=[$highery]`]
+
+[`z=[$camz]+[$v3str]([$highert])=[$higherz]`]
+
+That gives the point [`([$higherx],[$highery],[$higherz])`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-4-LineIntersectingSphereEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-4-LineIntersectingSphereEssay.pg
@@ -1,0 +1,51 @@
+## DESCRIPTION
+## Relationship of camera, sphere, and line of sight
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/22/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('4')
+## KEYWORDS('sphere','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+$t1 = random( 0.1, 2.0, 0.01 );
+$t2 = random( 0.1, 2.0, 0.01 );
+if ( random( 1, 2 ) == 1 ) { $t1 = -$t1; } else { $t2 = -$t2; }
+$t1str = sprintf( "%0.2f", $t1 );
+$t2str = sprintf( "%0.2f", $t2 );
+$answer = sprintf( "%0.2f", max( $t1, $t2 ) );
+
+TEXT(beginproblem());
+BEGIN_PGML
+If you solve for when a line of sight intersects a sphere and get two [`t`] values, [$t1] and [$t2], what is going on in the scene?
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+
+Which [`t`] value, if either, represents the part of the sphere that should be seen through the pixel?
+
+Answer: [`t=`][______]{$answer}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The camera is inside the sphere. The part of the sphere that should be seen is the positive [`t`] value, [$answer], which is the wall of the sphere that’s in front of the camera (seen from the inside).
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-6-MultipleSpheresInAScene.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-6-MultipleSpheresInAScene.pg
@@ -1,0 +1,168 @@
+## DESCRIPTION
+## A line of sight intersecting multiple spheres in a scene
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/22/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('6')
+## KEYWORDS('sphere','equation')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Numeric");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(t => 'Real');
+$p1 = random( 1, 10 );
+$p2 = 0;
+$p3 = 0;
+$v1 = non_zero_random( -3, 3 );
+$v2 = random( -3, 3 );
+$v3 = random( -3, 3 );
+$pixx = $p1 + $v1;
+$pixy = $p2 + $v2;
+$pixz = $p3 + $v3;
+$s1r = random( 2, 4 );
+$s1c1 = $p1 + (1+$s1r)*$v1;# + random( -1, 1 );
+$s1c2 = $p2 + (1+$s1r)*$v2;# + random( -1, 1 );
+$s1c3 = $p3 + (1+$s1r)*$v3;# + random( -1, 1 );
+$s2r = random( 2, 4 );
+$s2c1 = $p1 + (3+2*$s1r+$s2r)*$v1 + random( -1, 1 );
+$s2c2 = $p2 + (3+2*$s1r+$s2r)*$v2 + random( -1, 1 );
+$s2c3 = $p3 + (3+2*$s1r+$s2r)*$v3 + random( -1, 1 );
+$s3r = random( 2, 4 );
+$s3c1 = $p1 + 4*$v1 + random( $s3r, $s3r+2 );
+$s3c2 = $p2 + 4*$v2 + random( $s3r, $s3r+2 );
+$s3c3 = $p3 + 4*$v3 + random( $s3r, $s3r+2 );
+$s1A = $v1**2 + $v2**2 + $v3**2;
+$s1B = 2*($v1*($p1-$s1c1)+$v2*($p2-$s1c2)+$v3*($p3-$s1c3));
+$s1C = (($p1-$s1c1)**2+($p2-$s1c2)**2+($p3-$s1c3)**2)-$s1r**2;
+$s1t1 = (-$s1B-sqrt($s1B**2-4*$s1A*$s1C))/(2*$s1A);
+$s1t2 = (-$s1B+sqrt($s1B**2-4*$s1A*$s1C))/(2*$s1A);
+$s2A = $s1A;
+$s2B = 2*($v1*($p1-$s2c1)+$v2*($p2-$s2c2)+$v3*($p3-$s2c3));
+$s2C = (($p1-$s2c1)**2+($p2-$s2c2)**2+($p3-$s2c3)**2)-$s2r**2;
+$s2t1 = (-$s2B-sqrt($s2B**2-4*$s2A*$s2C))/(2*$s2A);
+$s2t2 = (-$s2B+sqrt($s2B**2-4*$s2A*$s2C))/(2*$s2A);
+$s3A = $s1A;
+$s3B = 2*($v1*($p1-$s3c1)+$v2*($p2-$s3c2)+$v3*($p3-$s3c3));
+$s3C = (($p1-$s3c1)**2+($p2-$s3c2)**2+($p3-$s3c3)**2)-$s3r**2;
+#$s3t1 = (-$s3B-sqrt($s3B**2-4*$s3A*$s3C))/(2*$s3A);
+#$s3t2 = (-$s3B+sqrt($s3B**2-4*$s3A*$s3C))/(2*$s3A);
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is/contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+Imagine a POV scene containing three shapes, defined by the following code.
+
+[|sphere { <|][$s1c1][|,|][$s1c2][|,|][$s1c3][|>, |][$s1r][| }|]
+
+[|sphere { <|][$s2c1][|,|][$s2c2][|,|][$s2c3][|>, |][$s2r][| }|]
+
+[|sphere { <|][$s3c1][|,|][$s3c2][|,|][$s3c3][|>, |][$s3r][| }|]
+
+Consider the line of sight from the camera at [`([$p1],[$p2],[$p3])`] through the pixel at [`([$pixx],[$pixy],[$pixz])`].
+
+What is the equation of that line of sight?
+
+[`x=`][__________]{"$p1+t*$v1"}
+
+[`y=`][__________]{"$p2+t*$v2"}
+
+[`z=`][__________]{"$p3+t*$v3"}
+
+Does the line of sight intersect any of the objects in the scene?  If so, which ones?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'The line of sight intersects sphere 1, but neither of the others.',
+  'The line of sight intersects sphere 2, but neither of the others.',
+  'The line of sight intersects sphere 3, but neither of the others.',
+  'The line of sight intersects spheres 1 and 2, but not sphere 3.',
+  'The line of sight intersects spheres 1 and 3, but not sphere 2.',
+  'The line of sight intersects spheres 2 and 3, but not sphere 1.',
+  'The line of sight intersects all 3 spheres.',
+  'The line of sight intersects none of the spheres.',
+) ], 'The line of sight intersects spheres 1 and 2, but not sphere 3.' )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The parametric equations of the line of sight:
+
+[`x=[$p1]+[$v1]t`]
+
+[`y=[$p2]+[$v2]t`]
+
+[`z=[$p3]+[$v3]t`]
+
+-----
+
+The equation of sphere 1:
+
+[`(x-[$s1c1])^2+(y-[$s1c2])^2+(z-[$s1c3])^2=[$s1r]^2`]
+
+Substituting the parametric equations into the sphere equation:
+
+[`([$p1]+[$v1]t-[$s1c1])^2+([$p2]+[$v2]t-[$s1c2])^2+([$p3]+[$v3]t-[$s1c3])^2=[$s1r]^2`]
+
+Simplifying through many steps yields:
+
+[`[$s1A]t^2+[$s1B]t+[$s1C]=0`]
+
+[`t=[$s1t1],[$s1t2]`]
+
+Thus the line of sight does intersect this sphere.
+
+-----
+
+The equation of sphere 2:
+
+[`(x-[$s2c1])^2+(y-[$s2c2])^2+(z-[$s2c3])^2=[$s2r]^2`]
+
+Substituting the parametric equations into the sphere equation:
+
+[`([$p1]+[$v1]t-[$s2c1])^2+([$p2]+[$v2]t-[$s2c2])^2+([$p3]+[$v3]t-[$s2c3])^2=[$s1r]^2`]
+
+Simplifying through many steps yields:
+
+[`[$s2A]t^2+[$s2B]t+[$s2C]=0`]
+
+[`t=[$s2t1],[$s2t2]`]
+
+Thus the line of sight does intersect this sphere.
+
+-----
+
+The equation of sphere 3:
+
+[`(x-[$s3c1])^2+(y-[$s3c2])^2+(z-[$s3c3])^2=[$s3r]^2`]
+
+Substituting the parametric equations into the sphere equation:
+
+[`([$p1]+[$v1]t-[$s3c1])^2+([$p2]+[$v2]t-[$s3c2])^2+([$p3]+[$v3]t-[$s3c3])^2=[$s3r]^2`]
+
+Simplifying through many steps yields:
+
+[`[$s3A]t^2+[$s3B]t+[$s3C]=0`]
+
+This has no real number solutions.
+
+Thus the line of sight does not intersect this sphere.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-7-TransformationPrincipleAndSpheres.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-7-TransformationPrincipleAndSpheres.pg
@@ -1,0 +1,174 @@
+## DESCRIPTION
+## Transformation Principle and POV spheres
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/22/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('7')
+## KEYWORDS('sphere','equation','affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+#Context()->variables->add(y => 'Real');
+#Context()->variables->add(z => 'Real');
+Context('Matrix')->variables->add(t => 'Real');
+$c1 = random( -10, 10 );
+$c2 = random( -10, 10 );
+$c3 = random( -10, 10 );
+$r = random( 1, 10 );
+$camx = $c1 + $r + random( 4, 6 );
+$camy = $c2;
+$camz = $c3;
+$pixx = $c1 + $r + random( 1, 3 );
+$xdist2center = $camx - $c1;
+$xdist2pixel = $camx - $pixx;
+$ratio = $xdist2pixel / ( $xdist2pixel + $xdist2center );
+$pixy = $c2 + $r * non_zero_random( -0.7, 0.7, 0.1 ) * $ratio;
+$pixz = $c3 + $r * non_zero_random( -0.7, 0.7, 0.1 ) * $ratio;
+$pixxstr = sprintf( "%0.2f", $pixx );
+$pixystr = sprintf( "%0.2f", $pixy );
+$pixzstr = sprintf( "%0.2f", $pixz );
+$v1 = round( ( $pixx - $camx ) * 100 ) / 100;
+$v2 = round( ( $pixy - $camy ) * 100 ) / 100;
+$v3 = round( ( $pixz - $camz ) * 100 ) / 100;
+$v1str = sprintf( "%0.2f", $v1 );
+$v2str = sprintf( "%0.2f", $v2 );
+$v3str = sprintf( "%0.2f", $v3 );
+$sx = random( 1, 3 );
+$sy = random( 2, 3 );
+$sz = random( 1, 3 );
+$tx = non_zero_random( -9, 9 );
+$ty = non_zero_random( -9, 9 );
+$tz = non_zero_random( -9, 9 );
+$Smatrix = Matrix( [
+    [ $sx, 0, 0, 0 ], [ 0, $sy, 0, 0 ], [ 0, 0, $sz, 0 ], [ 0, 0, 0, 1 ]
+] );
+$Tmatrix = Matrix( [
+    [ 1, 0, 0, $tx ], [ 0, 1, 0, $ty ], [ 0, 0, 1, $tz ], [ 0, 0, 0, 1 ]
+] );
+$Amatrix = $Tmatrix * $Smatrix;
+$Ainverse = $Amatrix->inverse;
+$Colvec = Matrix( [ [ Formula( "$camx+t*$v1" ) ],
+                    [ Formula( "$camy+t*$v2" ) ],
+                    [ Formula( "$camz+t*$v3" ) ],
+                    [ 1 ] ] );
+$P1 = $camx/$sx-$tx/$sx;
+$P2 = $camy/$sy-$ty/$sy;
+$P3 = $camz/$sz-$tz/$sz;
+$V1 = $v1/$sx;
+$V2 = $v2/$sy;
+$V3 = $v3/$sz;
+$XfmColvec = Matrix( [ [ Formula( "$P1+t*$V1" ) ],
+                       [ Formula( "$P2+t*$V2" ) ],
+                       [ Formula( "$P3+t*$V3" ) ],
+                       [ 1 ] ] );
+$A = $V1**2 + $V2**2 + $V3**2;
+$B = 2*($V1*($P1-$c1) + $V2*($P2-$c2) + $V3*($P3-$c3));
+$C = (($P1-$c1)**2 + ($P2-$c2)**2 + ($P3-$c3)**2) - $r**2;
+$lowert = (-$B-sqrt($B**2-4*$A*$C))/(2*$A);
+$highert = (-$B+sqrt($B**2-4*$A*$C))/(2*$A);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Suppose we wish to figure out when a line of sight intersects the
+sphere given by the following POV code.
+
+[|sphere { |]
+
+[`\hspace{1em}`][|  <|][$c1][|,|][$c2][|,|][$c3][|>, |][$r]
+
+[`\hspace{1em}`][|  scale <|][$sx][|,|][$sy][|,|][$sz][|>|]
+
+[`\hspace{1em}`][|  translate <|][$tx][|,|][$ty][|,|][$tz][|>|]
+
+[| }|]
+
+Assume the camera is at position [`([$camx],[$camy],[$camz])`] and the line of sight we're interested in passes through the pixel at [`([$pixxstr],[$pixystr],[$pixzstr])`].
+
+The sphere undergoes the transformation [`T_{[$tx],[$ty],[$tz]}S_{[$sx],[$sy],[$sz]}`].  Call this transformation [`A`].
+
+Create the matrix for the transformation [`A`].
+
+Answer: [__]*{$Amatrix}
+
+Create the matrix for the transformation [`A^{-1}`].
+
+Answer: [__]*{$Ainverse}
+
+Write the parametric equations for the line of sight as a column vector.
+
+Answer: [__]*{$Colvec}
+
+Apply the transformation [`A^{-1}`] to that column vector.
+
+Answer: [__]*{$XfmColvec}
+
+What is the equation of the (unaltered) sphere?  (Place the radius portion on the right hand side and the rest of the equation on the left, as in the text.)
+
+Answer:
+[_______________________________________]{"(x-$c1)^2+(y-$c2)^2+(z-$c3)^2"}
+=
+[_____]{$r**2}
+
+Solve for when the transformed line of sight intersects the unaltered sphere.
+
+Lower [`t`] value = [________]{$lowert}
+
+Higher [`t`] value = [________]{$highert}
+
+For what [`t`] values does the original line of sight intersect the transformed sphere?
+
+Lower [`t`] value = [________]{$lowert}
+
+Higher [`t`] value = [________]{$highert}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+We form [`A`] by multiplying the translation and scaling.
+
+[`[$Tmatrix][$Smatrix]=[$Amatrix]`]
+
+We form [`A^{-1}`] by multiplying the inverses of those matrices in the other order.
+
+[`[$Smatrix->inverse][$Tmatrix->inverse]=[$Ainverse]`]
+
+The column vector for the line of sight:
+
+[`[$Colvec]`]
+
+We therefore multiply as follows.
+
+[`[$Ainverse][$Colvec]=[$XfmColvec]`]
+
+The sphere equation is [`(x-[$c1])^2+(y-[$c2])^2+(z-[$c3])^2=[$r]^2`].
+
+We can substitute into it as follows:
+
+[`([$P1]+[$V1]t-[$c1])^2+([$P2]+[$V2]t-[$c2])^2+([$P3]+[$V3]t-[$c3])^2=[$r]^2`]
+
+After many steps of simplification, we have this:
+
+[`[$A]t^2+[$B]t+[$C]=0`]
+
+Using the quadratic formula gives [`t=[$lowert],[$highert]`].
+
+Those are the [`t`] values for the inverse-transformed line of sight intersecting the untransformed sphere.  The Transformation Principle says they're the same [`t`] values for the original line of sight intersecting the transformed sphere.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-8-TransformationPrincipleAndPlanes.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/7-8-TransformationPrincipleAndPlanes.pg
@@ -1,0 +1,152 @@
+## DESCRIPTION
+## Transformation Principle and POV planes
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Shapes)
+## DBsection(Properties of Shapes)
+## Date(02/22/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('7')
+## Problem1('8')
+## KEYWORDS('plane','equation','affine transformations')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context('Matrix')->variables->add(t => 'Real');
+$N = random( 5, 15 );
+$p1 = random( -10, 10 );
+$p2 = random( -10, 10 );
+$p3 = random( -10, 10 );
+$pixx = $p1 + random( 10, 12 );
+$pixy = $p2 + random( 1, 2 );
+$pixz = $p3 + random( 1, 2 );
+$v1 = $pixx - $p1;
+$v2 = $pixy - $p2;
+$v3 = $pixz - $p3;
+$rx = 0;
+$ry = 0;
+$rz = 0;
+$which = random( 1, 3 );
+$angle = list_random( 30, 45, 60, -30, -45, -60 );
+$cos = cos( $angle*3.14159265358/180 );
+$sin = sin( $angle*3.14159265358/180 );
+if ( $which == 1 ) {
+    $rx = $angle;
+    $Rmatrix = Matrix( [ [ 1, 0, 0, 0 ], [ 0, $cos, -$sin, 0 ], [ 0, $sin, $cos, 0 ], [ 0, 0, 0, 1 ] ] );
+} elsif ( $which == 2 ) {
+    $ry = $angle;
+    $Rmatrix = Matrix( [ [ $cos, 0, $sin, 0 ], [ 0, 1, 0, 0 ], [ -$sin, 0, $cos, 0 ], [ 0, 0, 0, 1 ] ] );
+} else {
+    $rz = $angle;
+    $Rmatrix = Matrix( [ [ $cos, -$sin, 0, 0 ], [ $sin, $cos, 0, 0 ], [ 0, 0, 1, 0 ], [ 0, 0, 0, 1 ] ] );
+}
+$Colvec = Matrix( [ [ Formula( "$p1+t*$v1" ) ],
+                    [ Formula( "$p2+t*$v2" ) ],
+                    [ Formula( "$p3+t*$v3" ) ],
+                    [ 1 ] ] );
+$Pcolvec = Matrix( [ [ $p1 ], [ $p2 ], [ $p3 ], [ 1 ] ] );
+$Vcolvec = Matrix( [ [ $v1 ], [ $v2 ], [ $v3 ], [ 1 ] ] );
+$XfmPcolvec = ( $Rmatrix->inverse ) * $Pcolvec;
+$XfmVcolvec = ( $Rmatrix->inverse ) * $Vcolvec;
+$P1 = $XfmPcolvec->element(1,1);
+$P2 = $XfmPcolvec->element(2,1);
+$P3 = $XfmPcolvec->element(3,1);
+$V1 = $XfmVcolvec->element(1,1);
+$V2 = $XfmVcolvec->element(2,1);
+$V3 = $XfmVcolvec->element(3,1);
+$XfmColvec = Matrix( [ [ Formula( "$P1+t*$V1" ) ],
+                       [ Formula( "$P2+t*$V2" ) ],
+                       [ Formula( "$P3+t*$V3" ) ],
+                       [ 1 ] ] );
+$t = ( $N - $P1 ) / $V1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Suppose we wish to figure out when a line of sight intersects the
+plane given by the following POV code.
+
+[|sphere { |]
+
+[`\hspace{1em}`][|  <1,0,0>, |][$N]
+
+[`\hspace{1em}`][|  rotate <|][$sx][|,|][$sy][|,|][$sz][|>|]
+
+[| }|]
+
+This plane has normal vector [`\langle 1,0,0 \rangle`] and contains the point [`([$N],0,0)`] before it undergoes the transformation [`R_{[$rx]^\circ,[$ry]^\circ,[$rz]^\circ}`].
+
+Create the matrix for the transformation [`R_{[$rx]^\circ,[$ry]^\circ,[$rz]^\circ}`].
+
+Answer: [__]*{$Rmatrix}
+
+Create the matrix for the transformation [`R^{-1}_{[$rx]^\circ,[$ry]^\circ,[$rz]^\circ}`].
+
+Answer: [__]*{$Rmatrix->inverse}
+
+Assume the camera is at position [`([$p1],[$p2],[$p3])`] and the line of sight we're interested in passes through the pixel at [`([$pixx],[$pixy],[$pixz])`].
+
+Write the parametric equations for the line of sight as a column vector.
+
+Answer: [__]*{$Colvec}
+
+Apply the transformation [`R^{-1}_{[$rx]^\circ,[$ry]^\circ,[$rz]^\circ}`] to that column vector.
+
+Answer: [__]*{$XfmColvec}
+
+What is the equation of the (unaltered) plane?
+
+Answer:
+[_______________________________________]{"x-$N"}
+=0
+
+Solve for when the transformed line of sight intersects the unaltered plane.
+
+[`t=`][________]{$t}
+
+For what [`t`] value does the original line of sight intersect the transformed plane?
+
+[`t=`][________]{$t}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Using formulas from the text, the transformation [`R_{[$rx]^\circ,[$ry]^\circ,[$rz]^\circ}`] has the following matrix form.
+
+[`[$Rmatrix]`]
+
+Its inverse is the same as  [`R_{[$rx*-1]^\circ,[$ry*-1]^\circ,[$rz*-1]^\circ}`], which therefore has the following matrix form.
+
+[`[$Rmatrix->inverse]`]
+
+The column vector for the line of sight is based on the direction vector [`([$pixx],[$pixy],[$pixz])-([$p1],[$p2],[$p3])=\langle [$v1],[$v2],[$v3] \rangle`]:
+
+[`[$Colvec]`]
+
+We therefore multiply as follows.
+
+[`[$Rmatrix->inverse][$Colvec]=[$XfmColvec]`]
+
+Because of all the zeros in the normal vector and point in the plane, its equation simplifies down to [`x=[$N]`], or [`x-[$N]=0`].
+
+We can substitute into it as follows:
+
+[`[$P1]+[$V1]t-[$N]=0`]
+
+[`t=\frac{[$N]-[$P1]}{[$V1]}=[$t]`]
+
+That is the [`t`] value for the inverse-transformed line of sight intersecting the untransformed plane.  The Transformation Principle says that's the same [`t`] value for the original line of sight intersecting the transformed plane.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch7/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-1-CombineRGBVectorsAdditive.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-1-CombineRGBVectorsAdditive.pg
@@ -1,0 +1,99 @@
+## DESCRIPTION
+## Combining two RGB color vectors additively
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('1')
+## KEYWORDS('color vectors','RGB')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$r1 = random( 0.1, 0.5, 0.1 );
+$g1 = random( 0.1, 0.5, 0.1 );
+$b1 = random( 0.1, 0.5, 0.1 );
+$r2 = random( 0.1, 0.5, 0.1 );
+$g2 = random( 0.1, 0.5, 0.1 );
+$b2 = random( 0.1, 0.5, 0.1 );
+$ansr1 = min($r1+$r2,1);
+$ansg1 = min($g1+$g2,1);
+$ansb1 = min($b1+$b2,1);
+$r3 = random( 0.5, 0.9, 0.1 );
+$g3 = random( 0.1, 0.8, 0.1 );
+$b3 = random( 0.1, 0.8, 0.1 );
+$r4 = random( 0.5, 0.9, 0.1 );
+$g4 = random( 0.3, 1.0, 0.1 );
+$b4 = random( 0.3, 1.0, 0.1 );
+$ansr2 = min($r3+$r4,1);
+$ansg2 = min($g3+$g4,1);
+$ansb2 = min($b3+$b4,1);
+@names = (
+    'White', 'Black', 'Red', 'Green', 'Blue', 'Cyan', 'Magenta', 'Yellow'
+);
+@rs = ( 1, 0, 1, 0, 0, 0, 1, 1 );
+@gs = ( 1, 0, 0, 1, 0, 1, 0, 1 );
+@bs = ( 1, 0, 0, 0, 1, 1, 1, 0 );
+$index1 = random( 0, 7 );
+$index2 = random( 0, 6 );
+if ( $index2 >= $index1 ) { $index2++; }
+$ansr3 = min($rs[$index1]+$rs[$index2],1);
+$ansg3 = min($gs[$index1]+$gs[$index2],1);
+$ansb3 = min($bs[$index1]+$bs[$index2],1);
+
+TEXT(beginproblem());
+BEGIN_PGML
+Combine RGB color vectors using the additive formula from the textbook.
+
+[`\langle [$r1],[$g1],[$b1] \rangle + 
+\langle [$r2],[$g2],[$b2] \rangle=\langle`]
+[_____]{min($r1+$r2,1)},
+[_____]{min($g1+$g2,1)},
+[_____]{min($b1+$b2,1)}[`\rangle`]
+
+[`\langle [$r3],[$g3],[$b3] \rangle + 
+\langle [$r4],[$g4],[$b4] \rangle=\langle`]
+[_____]{min($r3+$r4,1)},
+[_____]{min($g3+$g4,1)},
+[_____]{min($b3+$b4,1)}[`\rangle`]
+
+[$names[$index1]]+[$names[$index2]][`=\langle`]
+[_____]{min($rs[$index1]+$rs[$index2],1)},
+[_____]{min($gs[$index1]+$gs[$index2],1)},
+[_____]{min($bs[$index1]+$bs[$index2],1)}[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\langle [$r1],[$g1],[$b1] \rangle + \langle [$r1],[$g2],[$b2] \rangle`]
+[`=\langle \min([$r1]+[$r2],1),\min([$g1]+[$g2],1),\min([$b1]+[$b2],1)\rangle`]
+[`=\langle \min([$r1+$r2],1),\min([$g1+$g2],1),\min([$b1+$b2],1)\rangle`]
+[`=\langle [$ansr1],[$ansg1],[$ansb1] \rangle`]
+
+[`\langle [$r3],[$g3],[$b3] \rangle + \langle [$r4],[$g4],[$b4] \rangle`]
+[`=\langle \min([$r3]+[$r4],1),\min([$g3]+[$g4],1),\min([$b3]+[$b4],1)\rangle`]
+[`=\langle \min([$r3+$r4],1),\min([$g3+$g4],1),\min([$b3+$b4],1)\rangle`]
+[`=\langle [$ansr2],[$ansg2],[$ansb2] \rangle`]
+
+[$names[$index1]]+[$names[$index2]]
+[`=\langle [$rs[$index1]],[$gs[$index1]],[$bs[$index1]] \rangle + \langle [$rs[$index2]],[$gs[$index2]],[$bs[$index2]] \rangle`]
+[`=\langle \min([$rs[$index1]]+[$rs[$index2]],1),\min([$gs[$index1]]+[$gs[$index2]],1),\min([$bs[$index1]]+[$bs[$index2]],1)\rangle`]
+[`=\langle \min([$rs[$index1]+$rs[$index2]],1),\min([$gs[$index1]+$gs[$index2]],1),\min([$bs[$index1]+$bs[$index2]],1)\rangle`]
+[`=\langle [$ansr3],[$ansg3],[$ansb3] \rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-12-HTMLHexColorCodes.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-12-HTMLHexColorCodes.pg
@@ -1,0 +1,94 @@
+## DESCRIPTION
+## Understanding hexadecimal notation in HTML color codes
+## ENDDESCRIPTION
+
+## DBsubject(Arithmetic)
+## DBchapter(Other bases)
+## DBsection(Converting)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('12')
+## KEYWORDS('color vectors','HTML','hexadecimal')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(t => 'Real');
+$dec1 = random( 1, 15 ) * 16 + random( 10, 15 );
+$dec2 = random( 50, 250 );
+$dec3 = random( 50, 250 );
+$dec4 = random( 50, 250 );
+$hex1 = sprintf( "%X", $dec1 );
+$hex1a = substr($hex1,0,1);
+$hex1b = substr($hex1,1,1);
+$dec1a = hex($hex1a);
+$dec1b = hex($hex1b);
+$hex2 = sprintf( "%X", $dec2 );
+$hex3 = sprintf( "%X", $dec3 );
+$hex4 = sprintf( "%X", $dec4 );
+$pct1 = random( 20, 80, 20 );
+$pct1ashex = sprintf( "%X", $pct1*255/100 );
+$hex2a = substr($pct1ashex,0,1);
+$hex2b = substr($pct1ashex,1,1);
+$dec2a = hex($hex2a);
+$dec2b = hex($hex2b);
+@names = ( 'one-quarter', 'half', 'three-quarters' );
+@descs = ( 'dark', 'medium', 'light' );
+@pcts = ( 25, 50, 75 );
+$index = random( 0, 2 );
+$rounded = round($pcts[$index]*255/100);
+$grayashex = sprintf( "%X", $rounded );
+
+TEXT(beginproblem());
+BEGIN_PGML
+HTML, the markup language of the web, specifies colors using the RGB model. It uses a two-digit hexadecimal (that is, base 16) representation for each component of the vector, and concatenates the three numbers together to form one large, six-digit number. For instance, the HTML color code #80FF3B has red component 80, green component FF, and blue component 3B.
+
+In hexadecimal, the digits 0 through 9 have their usual meanings, but the letters A through F also function as digits, and have the meanings 10 through 15, respectively. Because hexadecimal means base 16, a two-digit number such as 3B thus has the meaning [`16 \cdot 3 + 11 = 59`]. The 16 is used because the 3 is in the 16s place, and the 11 is the meaning of the digit B. (If you found this introduction to hexadecimal notation too brief, consult the web for more details.)
+
+What is the maximum number representable with two hexadecimal digits?
+
+Answer: [______]{255}
+
+If your answer to the previous part represents 100% (full intensity), then what percentage does the number [$hex1] represent?
+
+Answer: [______]{$dec1*100/255}%
+
+What hexadecimal number represents [$pct1]%?
+
+Answer: [______]{str_cmp($pct1ashex)}
+
+What RGB color vector does the HTML color vector [$hex2][$hex3][$hex4] represent?
+
+Answer: [`\langle`][_____]{$dec2/255},[_____]{$dec3/255},[_____]{$dec4/255}[`\rangle`]
+
+What HTML color vector represents [$names[$index]]-intensity white light (a [$descs[$index]] gray)?  (You may need to round off to the nearest whole number.)
+
+Answer: [______]{str_cmp("$grayashex$grayashex$grayashex")}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The maximum would be FF, which is 15(16)+15=255.
+
+[$hex1] is [$hex1a] in the 16s place and [$hex1b] in the 1s place.  This represents [$dec1a](16)+[$dec1b]=[$dec1].  Considering that as a percentage of 255 yields [$dec1*100/255]%.
+
+[$pct1]% of 255 is [$pct1*255/100].  Converting this to hexadecimal requires finding [`a`] and [`b`] such that [`16a+b=[$pct1*255/100]`].  Since they must be whole numbers less than 16, we can use plain old division with remainders to find [$dec2a] and [$dec2b].  In hexadecimal, we write [$pct1ashex].
+
+Repeating the conversion from hexadecimal described two paragraphs above, this time separately on [$hex2], [$hex3], and [$hex4], gives [$dec2], [$dec3], and [$dec4], respectively.  Each of these should be seen as a portion of 255, giving decimals [$dec2/255], [$dec3/255], and [$dec4/255].
+
+[$pcts[$index]]% of 255 is [$pcts[$index]*255/100], which we round to [$rounded].  Converting that to hex gives us [$grayashex], which is the value of each of the three components (red, green, and blue).  So we can just repeat it three times, yielding [$grayashex][$grayashex][$grayashex].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-18-ConvertToGrayscale.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-18-ConvertToGrayscale.pg
@@ -1,0 +1,50 @@
+## DESCRIPTION
+## Converting a color to grayscale
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('18')
+## KEYWORDS('color vectors','grayscale')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(r => 'Real');
+Context()->variables->add(g => 'Real');
+Context()->variables->add(b => 'Real');
+
+TEXT(beginproblem());
+BEGIN_PGML
+Write the formula for the mathematical function that takes as input an RGB color vector [`\langle r,g,b \rangle`] and yields as output the RGB color vector that is the unique shade of gray whose total amount of light [`(r +g+b)`] is equal to that of the input.
+
+Answer: [`\langle`]
+[__________]{"(r+g+b)/3"},
+[__________]{"(r+g+b)/3"},
+[__________]{"(r+g+b)/3"}
+[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+For it to be grayscale, all components must be equal.  Thus we want to have a vector that looks like [`\langle x,x,x \rangle`] for some unknown [`x`].  But we want [`x+x+x=r+g+b`], or [`3x=r+g+b`], so we must have [`x=\frac{r+g+b}{3}`].  Thus the answer is
+
+[`\left\langle \frac{r+g+b}{3},\frac{r+g+b}{3},\frac{r+g+b}{3} \right\rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-2-BrightnessAndLuminance.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-2-BrightnessAndLuminance.pg
@@ -1,0 +1,109 @@
+## DESCRIPTION
+## Comaring two RGB color vectors for brightness and luminance
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('2')
+## KEYWORDS('color vectors','RGB','brightness','luminance')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "parserPopUp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+#r1>r2-0.1 => r2<r1+0.1
+#g1>g2-0.1 => g2<g1+0.1
+#b1>b2-0.1 => b2<b1+0.1
+#c1r1+c2g1+c3b1<c1r2+c2g2+c3b2<c1r1+c2g1+c3b1+0.1(c1+c2+c3)
+#(c1r1+c2g1+c3b1-c1r2-c2g2)/c3<b2
+#(c1(r1-r2)+c2(g1-g2)+c3b1)/c3<b2
+#(c1/c3)(r1-r2)+(c2/c3)(g1-g2)+b1<b2
+#2.949(r1-r2)+9.921(g1-g2)+b1<b2<b1+0.1
+#2.949(r1-r2)+9.921(g1-g2)<0.1
+#2.949(r1-r2)<0.1 & 9.921(g1-g2)=0 (g1=g2)
+#r1-r2<0.033 & g1=g2 & b2=b1+(0.1+2.949(r1-r2))/2
+#r1=r2+0.02 & g1=g2 & b2=b1+(0.1+2.949*0.02)/2
+#r1=r2+0.02 & g1=g2 & b2=b1+0.08
+#r2:=r1-0.02 & g2:=g1 & b2:=b1+0.08
+$r1 = random( 0.1, 0.9, 0.01 );
+$g1 = random( 0.1, 0.9, 0.01 );
+$b1 = random( 0.1, 0.9, 0.01 );
+$r2 = $r1 - random( 0.01, 0.02, 0.01 );
+$g2 = $g1 + random( 0.00, 0.01, 0.01 );
+$b2 = $b1 + random( 0.07, 0.09, 0.01 );
+
+$lum1 = 0.2126*$r1 + 0.7153*$g1 + 0.0721*$b1;
+$lum2 = 0.2126*$r2 + 0.7153*$g2 + 0.0721*$b2;
+
+if ( $lum1 > $lum2 ) {
+    $ans = 'The left vector would be perceived as slightly brighter';
+} else {
+    $ans = 'The right vector would be perceived as slightly brighter';
+}
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is/contains multiple choice, you are permitted A LIMITED NUMBER OF ATTEMPTS.  Use them wisely.*
+
+In the RGB color model, which of the following two vectors would cause a display to emit more light?
+
+[`\langle [$r1],[$g1],[$b1] \rangle \hspace{1in}
+  \langle [$r2],[$g2],[$b2] \rangle`]
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'The vector on the left emits much more light',
+  'The vector on the left emits slightly more light',
+  'The vector on the right emits slightly more light',
+  'The vector on the right emits much more light',
+) ], 'The vector on the right emits slightly more light' )}
+
+Human perception of brightness is correlated to a quantity called luminance, not discussed in Chaper 8 of the text.  One typical formula for the luminance of an RGB color vector [`\langle r,g,b \rangle`] is [`0.2126r + 0.7153g + 0.0721b`]. Compute the luminance of each RGB color vector above.
+
+Luminance of [`\langle [$r1],[$g1],[$b1] \rangle=`][________]{$lum1}
+
+Luminance of [`\langle [$r2],[$g2],[$b2] \rangle=`][________]{$lum2}
+
+Which of the two would probably therefore be perceived as brighter?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'The left vector would be perceived as slightly brighter',
+  'The right vector would be perceived as slightly brighter',
+) ], $ans )}
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The total light emitted of the right vector is more, but not by much:
+
+Left: [`[$r1]+[$g1]+[$b1]=[$r1+$g1+$b1]`]
+
+Right: [`[$r2]+[$g2]+[$b2]=[$r2+$g2+$b2]`] (slightly more)
+
+The luminance of the left vector is:
+
+[`0.2126([$r1]) + 0.7153([$g1]) + 0.0721([$b1]) = [$lum1]`]
+
+The luminance of the right vector is:
+
+[`0.2126([$r2]) + 0.7153([$g2]) + 0.0721([$b2]) = [$lum2]`]
+
+Therefore: [$ans]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-4-ExplainingAdditiveColorCombinations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-4-ExplainingAdditiveColorCombinations.pg
@@ -1,0 +1,79 @@
+## DESCRIPTION
+## Combining two RGB color vectors additively, explained
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('4')
+## KEYWORDS('color vectors','RGB')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+@primaries = ( 'Red', 'Green', 'Blue' );
+@secondaries = ( 'Cyan', 'Magenta', 'Yellow' );
+$index = random( 0, 2 );
+@primrs = ( 1, 0, 0 );
+@primgs = ( 0, 1, 0 );
+@primbs = ( 0, 0, 1 );
+@secrs = ( 0, 1, 1 );
+@secgs = ( 1, 0, 1 );
+@secbs = ( 1, 1, 0 );
+$A = $primaries[$index];
+$B = $secondaries[$index];
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider combining the colors [$A] and [$B] additively.
+
+Explain how you could discern the answer from Figure 8.3 of the textbook.
+
+[@ ANS(essay_cmp); essay_box(3,50) @]*
+
+Explain how you could discern the answer from Figure 8.6 of the textbook.
+
+[@ ANS(essay_cmp); essay_box(3,50) @]*
+
+Explain how you can compute the answer by adding RGB color vectors.
+
+[@ ANS(essay_cmp); essay_box(3,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+In Figure 8.3, the only area inside the [$A] circle and the [$B] football shape is White, in the very center.
+
+In Figure 8.6, the only node accessible by proceeding upwards from both [$A] and [$B] is White.  (Consequently, it is also the lowest such node.)
+
+Adding RGB color vectors:
+
+[$A]+[$B]
+[`=\langle [$primrs[$index]],[$primgs[$index]],[$primbs[$index]] \rangle
+ + \langle [$secrs[$index]],[$secgs[$index]],[$secbs[$index]] \rangle`]
+
+[`=\langle  \min([$primrs[$index]]+[$secrs[$index]],1),
+            \min([$primgs[$index]]+[$secgs[$index]],1),
+            \min([$primbs[$index]]+[$secbs[$index]],1) \rangle`]
+
+[`=\langle  \min([$primrs[$index]+$secrs[$index]],1),
+            \min([$primgs[$index]+$secgs[$index]],1),
+            \min([$primbs[$index]+$secbs[$index]],1) \rangle
+  = \langle 1,1,1 \rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-5-ExplainingSubtractiveColorCombinations.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-5-ExplainingSubtractiveColorCombinations.pg
@@ -1,0 +1,72 @@
+## DESCRIPTION
+## Combining two RGB color vectors subtractively, explained
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('5')
+## KEYWORDS('color vectors','RGB')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+  "parserPopUp.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+@primaries = ( 'Red', 'Green', 'Blue' );
+@secondaries = ( 'Cyan', 'Magenta', 'Yellow' );
+$ansindex = random( 0, 2 );
+$Aindex = ( $ansindex + 1 ) % 3;
+$Bindex = ( $ansindex + 2 ) % 3;
+if ( $Aindex > $Bindex ) {
+    $tmp = $Aindex; $Aindex = $Bindex; $Bindex = $tmp;
+}
+@primrs = ( 1, 0, 0 );
+@primgs = ( 0, 1, 0 );
+@primbs = ( 0, 0, 1 );
+@secrs = ( 0, 1, 1 );
+@secgs = ( 1, 0, 1 );
+@secbs = ( 1, 1, 0 );
+$ans = $primaries[$ansindex];
+$A = $secondaries[$Aindex];
+$B = $secondaries[$Bindex];
+
+TEXT(beginproblem());
+BEGIN_PGML
+*WARNING: Because this problem is multiple choice, you are permitted ONLY ONE ATTEMPT.  Use it wisely.*
+
+What does combining [$A] and [$B] subtractively yield?
+
+Pick your answer from here: [___]{PopUp( [ (
+  '(make a choice)',
+  'Red',  'Green',  'Blue',
+  'Cyan',  'Magenta',  'Yellow',
+  'Black',  'White',
+) ], $ans )}
+
+Explain how the lattice in Figure 8.6 can tell you the answer.
+
+[@ ANS(essay_cmp); essay_box(3,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Combining colors subtractively can be done using the lattice in Figure 8.6 as follows:  Find the two colors you wish to combine.  Their combination is the highest node that sits below both of the colors you're combining.  (By "sits below," we mean connected by the diagonal paths in the diagram.)
+
+In the case of [$A] and [$B], the only colors below both are [$ans] and Black.  The highest of those is [$ans].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-6-LineThroughRGBColorSpace.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-6-LineThroughRGBColorSpace.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Explaining a grayscale line through RGB color space
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('6')
+## KEYWORDS('color vectors','RGB','grayscale','lines')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(t => 'Real');
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the RGB color space shown as a cube in Figure 8.9 of the textbook.
+
+Write the parametric equations of a line through that space such that [`t = 0`] gives the point Black [`= (0,0,0)`] and [`t = 1`] gives the point White [`= (1,1,1)`].
+
+[`x=`][______]{"t"}
+
+[`y=`][______]{"t"}
+
+[`z=`][______]{"t"}
+
+What colors are on the line, for [`t`] in [`[0,1]`]?
+
+[@ ANS(essay_cmp); essay_box(2,25) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The line [`x=t,y=t,z=t`] satisfies the required conditions.
+
+The points on the line are all of the form [`(t,t,t)`] and are thus equal in red, green, and blue light, making all of those colors gray.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-7-LineThroughHSBColorSpace.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-7-LineThroughHSBColorSpace.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Explaining a grayscale line through HSB color space
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('6')
+## KEYWORDS('color vectors','RGB','grayscale','lines')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(t => 'Real');
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the RGB color space shown as a cube in Figure 8.9 of the textbook.
+
+Write the parametric equations of a line through that space such that [`t = 0`] gives the point Black [`= (0,0,0)`] and [`t = 1`] gives the point White [`= (1,1,1)`].
+
+[`x=`][______]{"t"}
+
+[`y=`][______]{"t"}
+
+[`z=`][______]{"t"}
+
+What colors are on the line, for [`t`] in [`[0,1]`]?
+
+[@ ANS(essay_cmp); essay_box(2,25) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The line [`x=t,y=t,z=t`] satisfies the required conditions.
+
+The points on the line are all of the form [`(t,t,t)`] and are thus equal in red, green, and blue light, making all of those colors gray.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-7-LineThroughRGBColorCylinder.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-7-LineThroughRGBColorCylinder.pg
@@ -1,0 +1,54 @@
+## DESCRIPTION
+## Explaining a grayscale line through RGB color space
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('6')
+## KEYWORDS('color vectors','RGB','grayscale','lines')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(t => 'Real');
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the RGB color space shown as a cube in Figure 8.9 of the textbook.
+
+Write the parametric equations of a line through that space such that [`t = 0`] gives the point Black [`= (0,0,0)`] and [`t = 1`] gives the point White [`= (1,1,1)`].
+
+[`x=`][______]{"t"}
+
+[`y=`][______]{"t"}
+
+[`z=`][______]{"t"}
+
+What colors are on the line, for [`t`] in [`[0,1]`]?
+
+[@ ANS(essay_cmp); essay_box(2,25) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The line [`x=t,y=t,z=t`] satisfies the required conditions.
+
+The points on the line are all of the form [`(t,t,t)`] and are thus equal in red, green, and blue light, making all of those colors gray.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-7-LineThroughRGBColorSpace2.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/8-7-LineThroughRGBColorSpace2.pg
@@ -1,0 +1,76 @@
+## DESCRIPTION
+## Explaining a cyan line through RGB color space
+## ENDDESCRIPTION
+
+## DBsubject(Geometry)
+## DBchapter(Vector geometry)
+## DBsection(Vectors and vector arithmetic)
+## Date(02/25/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('8')
+## Problem1('7')
+## KEYWORDS('color vectors','RGB','lines')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+Context()->variables->add(t => 'Real');
+@secondaries = ( 'Cyan', 'Magenta', 'Yellow' );
+@where = ( 'left', 'bottom', 'right' );
+@rs = ( 0, 1, 1 );
+@gs = ( 1, 0, 1 );
+@bs = ( 1, 1, 0 );
+$index = random( 0, 2, 2 ); # can't pick magenta...not visible in figure
+$color = $secondaries[$index];
+$fx = Formula( "t*$rs[$index]" )->reduce;
+$fy = Formula( "t*$gs[$index]" )->reduce;
+$fz = Formula( "t*$bs[$index]" )->reduce;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the RGB color space shown as a cube in Figure 8.9 of the textbook.
+
+Write the parametric equations of a line through that space such that [`t = 0`] gives the point Black [`= (0,0,0)`] and [`t = 1`] gives the point [$color] [`= ([$rs[$index]],[$gs[$index]],[$bs[$index]])`].
+
+[`x=`][______]{"t*$rs[$index]"}
+
+[`y=`][______]{"t*$gs[$index]"}
+
+[`z=`][______]{"t*$bs[$index]"}
+
+Where on the cube in Figure 8.9 of the textbook do we see this line, for [`t`] in [`[0,1]`]?
+
+[@ ANS(essay_cmp); essay_box(2,25) @]*
+
+What colors are the points on the line segment?
+
+[@ ANS(essay_cmp); essay_box(2,25) @]*
+
+Where do we see the same colors in the HSB color space cylinder?
+
+[@ ANS(essay_cmp); essay_box(2,25) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The line [`x=[$fx],y=[$fy],z=[$fz]`] satisfies the required conditions.
+
+The line begins at the bottom corner of the cube and proceeds diagonally across the [$where[$index]] face to the top [$where[$index]] point, which is [$color].
+
+Various shades of [$color], from dark (near black) to full intensity (near [$color] itself).
+
+They form a vertical line that goes from the bottom of the cylinder straight upward, ending at the [$color] point on the outer rim of the top face of the cylinder.
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch8/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-1-AmbientLightComputation.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-1-AmbientLightComputation.pg
@@ -1,0 +1,56 @@
+## DESCRIPTION
+## Computing the ambient light contribution to an object's color
+## ENDDESCRIPTION
+
+## No good DBsubject/DBchapter/DBsection for this problem
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('1')
+## KEYWORDS('ambient light','color vector')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$objectr = random( 0.1, 1.0, 0.1 );
+$objectg = random( 0.1, 1.0, 0.1 );
+$objectb = random( 0.1, 1.0, 0.1 );
+$lightr = random( 0.1, 0.3, 0.1 );
+$lightg = random( 0.1, 0.3, 0.1 );
+$lightb = random( 0.1, 0.3, 0.1 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider an object with RGB color vector [`\langle [$objectr],[$objectg],[$objectb] \rangle`]. If the ambient light in a scene is modeled with the RGB color vector [`\langle [$lightr],[$lightg],[$lightb] \rangle`], then what is the contribution of ambient light to the color of each pixel through which that object is seen?
+
+[`\langle`]
+[_____]{$objectr*$lightr},
+[_____]{$objectg*$lightg},
+[_____]{$objectb*$lightb}
+[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\langle
+[$objectr] \cdot [$lightr],
+[$objectg] \cdot [$lightg],
+[$objectb] \cdot [$lightb]
+\rangle = \langle
+[$objectr*$lightr],
+[$objectg*$lightg],
+[$objectb*$lightb]
+\rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-10-AmbientEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-10-AmbientEssay.pg
@@ -1,0 +1,51 @@
+## DESCRIPTION
+## Thinking about ambient light in the real world
+## ENDDESCRIPTION
+
+## There are no good DBsubject/DBchapter/DBsection options for this question.
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('10')
+## KEYWORDS('ambient light','examples')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Name two different real world environments in which ambient light should be set to a high value.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+
+Name two different real world environments in which ambient light should be set to either zero or nearly zero.
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+There are many possible answers.  Here are some:
+
+For question 1:
+
+in an institutional lighting situation (for example, copious white fluorescent light in the ceiling); or outdoors during the daytime
+
+For question 2:
+
+a room with only a single, small light source, such as a candle; or outer space
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-18-SupportingMultipleLightsEssay.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-18-SupportingMultipleLightsEssay.pg
@@ -1,0 +1,39 @@
+## DESCRIPTION
+## How would we support multiple lights in the same scene?
+## ENDDESCRIPTION
+
+## There are no good DBsubject/DBchapter/DBsection options for this question.
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('18')
+## KEYWORDS('light sources')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+  "PGessaymacros.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+
+TEXT(beginproblem());
+BEGIN_PGML
+If the procedures and formulas in this chapter were extended to support multiple light sources in a scene, what would need to change?
+
+[@ ANS(essay_cmp); essay_box(5,50) @]*
+END_PGML
+
+BEGIN_PGML_SOLUTION
+Rather than compute the contributions of diffuse and specular from just one light source, the two contributions would need to be computed for all light sources, and all the contributions (together with the one ambient contribution for the whole scene) summed to find the pixel color (still capping the sum at a maximum of 1 in each component).
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-2-AmbientLightFromPOVCode.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-2-AmbientLightFromPOVCode.pg
@@ -1,0 +1,76 @@
+## DESCRIPTION
+## Computing the ambient light contribution to an object's color from POV code
+## ENDDESCRIPTION
+
+## No good DBsubject/DBchapter/DBsection for this problem
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('2')
+## KEYWORDS('ambient light','color vector','POV-Ray')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$lightr = random( 0.5, 1.0, 0.1 );
+$lightg = random( 0.5, 1.0, 0.1 );
+$lightb = random( 0.5, 1.0, 0.1 );
+$index = random( 0, 5 );
+$name = ( 'Red', 'Green', 'Blue', 'Cyan', 'Magenta', 'Yellow' )[$index];
+$objectr = ( 1, 0, 0, 0, 1, 1 )[$index];
+$objectg = ( 0, 1, 0, 1, 0, 1 )[$index];
+$objectb = ( 0, 0, 1, 1, 1, 0 )[$index];
+$ratio = random( 0.2, 0.4, 0.1 );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the following snippet of POV code. What is the contribution of ambient light to the color of each pixel through which the box is seen? (Assume the simple model of ambient light introduced in Chapter 9 of the textbook.)
+
+[| global_settings { |]
+
+[`\hspace{1cm}`][| ambient_light { color < |][$lightr],[$lightg],[$lightb][| > } |]
+
+[| } |]
+
+[| box { |]
+
+[`\hspace{1cm}`][| <0,0,0>,<2,1,1> |]
+
+[`\hspace{1cm}`][| pigment { color |] [$name] [| } |]
+
+[`\hspace{1cm}`][| finish { ambient <|][$ratio],[$ratio],[$ratio][| > } |]
+
+[| } |]
+
+Answer:
+[`\langle`]
+[_____]{$objectr*$lightr*$ratio},
+[_____]{$objectg*$lightg*$ratio},
+[_____]{$objectb*$lightb*$ratio}
+[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\langle
+[$objectr] \cdot [$lightr] \cdot [$ratio],
+[$objectg] \cdot [$lightg] \cdot [$ratio],
+[$objectb] \cdot [$lightb] \cdot [$ratio]
+\rangle = \langle
+[$objectr*$lightr*$ratio],
+[$objectg*$lightg*$ratio],
+[$objectb*$lightb*$ratio]
+\rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-3-DiffuseLightComputation.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-3-DiffuseLightComputation.pg
@@ -1,0 +1,94 @@
+## DESCRIPTION
+## Computing the diffuse light contribution to a pixel's color
+## ENDDESCRIPTION
+
+## DBsubject('Geometry')
+## DBchapter('Vector geometry')
+## DBsection('Dot product, length, and unit vectors')
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('3')
+## KEYWORDS('diffuse light','color vector')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$Br = random( 0.5, 1.0, 0.1 );
+$Bg = random( 0.5, 1.0, 0.1 );
+$Bb = random( 0.5, 1.0, 0.1 );
+$Px = random( 1, 4 );
+$Py = random( 1, 4 );
+$Pz = random( 1, 4 );
+$Sx = non_zero_random( -4, 4 ) * 10;
+$Sy = random( 2, 4 ) * 10;
+$Sz = random( -2, 2 ) * 10;
+$Lx = $Sx - $Px;
+$Ly = $Sy - $Py;
+$Lz = $Sz - $Pz;
+$Llen = sqrt( $Lx**2 + $Ly**2 + $Lz**2 );
+$uLx = $Lx / $Llen;
+$uLy = $Ly / $Llen;
+$uLz = $Lz / $Llen;
+$theta = acos( $uLy ) * 180 / 3.14159265358;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a box in a scene, with RGB color vector [`\langle [$Br],[$Bg],[$Bb] \rangle`]. Assume the point [`P = ([$Px],[$Py],[$Pz])`] is on the surface of the box and a fully white light source is located at [`([$Sx],[$Sy],[$Sz])`]. Use POV's left-handed coordinate system, so "up" in the scene is in the positive y direction.
+
+Compute the vector [`\vec L`] that points from [`P`] to the light source.
+
+Answer: [`\langle`][_____]{$Lx},[_____]{$Ly},[_____]{$Lz}[`\rangle`]
+
+Compute its unit vector [`\hat L`].
+
+Answer: [`\langle`][_____]{$uLx},[_____]{$uLy},[_____]{$uLz}[`\rangle`]
+
+Assume that [`P`] is on the top of the box and that the normal vector at [`P`] is [`\vec N=\langle 0,1,0 \rangle`].  What is the unit surface normal [`\hat N`]?
+
+Answer: [`\langle`][_____]{0},[_____]{1},[_____]{0}[`\rangle`]
+
+Compute the angle [`\theta`] between [`\vec N`] and [`\vec L`].
+
+Answer: [`\theta=`][__________]{$theta} degrees
+
+Compute the contribution of the diffuse light model for this object to the color of the pixel through which [`P`] is seen.
+
+Answer:
+[`\langle`]
+[__________]{$Br*$uLy},
+[__________]{$Bg*$uLy},
+[__________]{$Bb*$uLy}
+[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec L=([$Sx],[$Sy],[$Sz])-([$Px],[$Py],[$Pz])=\langle [$Lx],[$Ly],[$Lz] \rangle`]
+
+[`||\vec L||=||\langle [$Lx],[$Ly],[$Lz] \rangle||=\sqrt{([$Lx])^2+([$Ly])^2+([$Lz])^2}\approx [$Llen]`]
+
+[`\hat L=\frac{\vec L}{||\vec L||}\approx\frac{\langle [$Lx],[$Ly],[$Lz] \rangle}{[$Llen]}\approx\langle [$uLx],[$uLy],[$uLz] \rangle`]
+
+[`\hat N = \vec N = \langle 0,1,0 \rangle`]
+
+[`\theta=\cos^{-1}(\hat N\cdot\hat L)
+=\cos^{-1}(\langle 0,1,0 \rangle\cdot\langle [$uLx],[$uLy],[$uLz] \rangle)
+=\cos^{-1}([$uLy])\approx[$theta]^{\circ}`]
+
+[`\cos^{-1}([$theta]^{\circ})\langle 1\cdot[$Br],1\cdot[$Bg],1\cdot[$Bb] \rangle
+=[$uLy]\langle [$Br],[$Bg],[$Bb] \rangle
+\approx\langle [$Br*$uLy],[$Bg*$uLy],[$Bb*$uLy] \rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-4-DiffuseLightFromPOVCode.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-4-DiffuseLightFromPOVCode.pg
@@ -1,0 +1,133 @@
+## DESCRIPTION
+## Computing the diffuse light contribution to a pixel's color from POV code
+## ENDDESCRIPTION
+
+## DBsubject('Geometry')
+## DBchapter('Vector geometry')
+## DBsection('Dot product, length, and unit vectors')
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('4')
+## KEYWORDS('diffuse light','color vector','POV-Ray')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+$Sx = random( 20, 40, 10 );
+$Sy = random( 20, 40, 10 );
+$Sz = random( 20, 40, 10 );
+$radius = random( 2, 5 );
+$Px = random( 0.1, 0.7*$radius, 0.1 );
+$Py = random( 0.1, 0.7*$radius, 0.1 );
+$Pz = round( sqrt( $radius**2 - $Px**2 - $Py**2 )*100 )/100;
+$Cx = random( -3, 3 );
+$Cy = random( -3, 3 );
+$Cz = random( -3, 3 );
+$Px += $Cx;
+$Py += $Cy;
+$Pz += $Cz;
+$Pzstr = sprintf( "%0.2f", $Pz );
+$index = random( 0, 5 );
+$name = ( 'Red', 'Green', 'Blue', 'Cyan', 'Magenta', 'Yellow' )[$index];
+$sphr = ( 1, 0, 0, 0, 1, 1 )[$index];
+$sphg = ( 0, 1, 0, 1, 0, 1 )[$index];
+$sphb = ( 0, 0, 1, 1, 1, 0 )[$index];
+
+$Lx = $Sx - $Px;
+$Ly = $Sy - $Py;
+$Lz = $Sz - $Pz;
+$Llen = sqrt( $Lx**2 + $Ly**2 + $Lz**2 );
+$uLx = $Lx / $Llen;
+$uLy = $Ly / $Llen;
+$uLz = $Lz / $Llen;
+$Nx = 2*($Px - $Cx);
+$Ny = 2*($Py - $Cy);
+$Nz = 2*($Pz - $Cz);
+$Nlen = sqrt( $Nx**2 + $Ny**2 + $Nz**2 );
+$uNx = $Nx / $Nlen;
+$uNy = $Ny / $Nlen;
+$uNz = $Nz / $Nlen;
+$dotprod = $uNx*$uLx + $uNy*$uLy + $uNz*$uLz;
+$theta = acos( $dotprod ) * 180 / 3.14159265358;
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider the following POV code.
+
+[`\hspace{1cm}`]
+[| light_source { < |][$Sx],[$Sy],[$Sz][| > color White } |]
+
+[`\hspace{1cm}`]
+[| sphere { < |][$Cx],[$Cy],[$Cz][| >, |] [$radius]
+[|  pigment { color |] [$name] [| } |]
+
+The point [`P=([$Px],[$Py],[$Pzstr])`] is (approximately) on the sphere.
+
+Compute the vector [`\vec L`] that points from [`P`] to the light source.
+
+Answer: [`\langle`][_____]{$Lx},[_____]{$Ly},[_____]{$Lz}[`\rangle`]
+
+Compute its unit vector [`\hat L`].
+
+Answer: [`\langle`][_____]{$uLx},[_____]{$uLy},[_____]{$uLz}[`\rangle`]
+
+For a sphere, the normal vector at any point on the surface is two times the vector from the sphere's center to the point on the surface.  Compute [`\vec N`] in this case.
+
+Answer: [`\langle`][_____]{$Nx},[_____]{$Ny},[_____]{$Nz}[`\rangle`]
+
+Compute the corresponding unit vector [`\hat N`].
+
+Answer: [`\langle`][_____]{$uNx},[_____]{$uNy},[_____]{$uNz}[`\rangle`]
+
+Compute the angle [`\theta`] between [`\vec N`] and [`\vec L`].
+
+Answer: [`\theta=`][__________]{$theta} degrees
+
+Compute the contribution of the diffuse light model for this object to the color of the pixel through which [`P`] is seen.
+
+Answer:
+[`\langle`]
+[__________]{$sphr*$dotprod},
+[__________]{$sphg*$dotprod},
+[__________]{$sphb*$dotprod}
+[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec L=([$Sx],[$Sy],[$Sz])-([$Px],[$Py],[$Pzstr])=\langle [$Lx],[$Ly],[$Lz] \rangle`]
+
+[`||\vec L||=||\langle [$Lx],[$Ly],[$Lz] \rangle||=\sqrt{([$Lx])^2+([$Ly])^2+([$Lz])^2}\approx [$Llen]`]
+
+[`\hat L=\frac{\vec L}{||\vec L||}\approx\frac{\langle [$Lx],[$Ly],[$Lz] \rangle}{[$Llen]}\approx\langle [$uLx],[$uLy],[$uLz] \rangle`]
+
+[`\vec N = 2(([$Px],[$Py],[$Pzstr])-([$Cx],[$Cy],[$Cz]))
+= 2\langle [$Px]-[$Cx],[$Py]-[$Cy],[$Pzstr]-[$Cz] \rangle
+= 2\langle [$Px-$Cx],[$Py-$Cy],[$Pz-$Cz] \rangle
+= \langle [$Nx],[$Ny],[$Nz] \rangle`]
+
+[`||\vec N||=||\langle [$Nx],[$Ny],[$Nz] \rangle||=\sqrt{([$Nx])^2+([$Ny])^2+([$Nz])^2}\approx [$Nlen]`]
+
+[`\hat N=\frac{\vec N}{||\vec N||}\approx\frac{\langle [$Nx],[$Ny],[$Nz] \rangle}{[$Nlen]}\approx\langle [$uNx],[$uNy],[$uNz] \rangle`]
+
+[`\theta=\cos^{-1}(\hat N\cdot\hat L)
+=\cos^{-1}(\langle [$uNx],[$uNy],[$uNz] \rangle\cdot\langle [$uLx],[$uLy],[$uLz] \rangle)
+=\cos^{-1}([$dotprod])\approx[$theta]^{\circ}`]
+
+[`\cos^{-1}([$theta]^{\circ})\langle 1\cdot[$sphr],1\cdot[$sphg],1\cdot[$sphb] \rangle
+=[$dotprod]\langle [$sphr],[$sphg],[$sphb] \rangle
+\approx\langle [$dotprod*$sphr],[$dotprod*$sphg],[$dotprod*$sphb] \rangle`]
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-5-SpecularReflection.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/9-5-SpecularReflection.pg
@@ -1,0 +1,191 @@
+## DESCRIPTION
+## Computing the specular highlight contribution to a pixel's color
+## ENDDESCRIPTION
+
+## DBsubject('Geometry')
+## DBchapter('Vector geometry')
+## DBsection('Dot product, length, and unit vectors')
+## Date(03/09/2018)
+## Institution(Bentley University)
+## Author(Nathan Carter)
+## TitleText1('Introduction to the Mathematics of Computer Graphics')
+## AuthorText1('Nathan Carter')
+## EditionText1('1')
+## Section1('9')
+## Problem1('5')
+## KEYWORDS('specular highlight','color vector','specular reflection')
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "PGML.pl",
+  "PGcourse.pl",
+);
+
+Context("Matrix");
+$showPartialCorrectAnswers = 1;
+
+$radius = random( 1, 5 );
+if ( random( 0, 1 ) == 0 ) {
+    $Px = -$radius;
+    $Py = random( -5, 5 );
+    $Pz = 0;
+    $Nx = -1;
+    $Ny = 0;
+    $Nz = 0;
+} else {
+    $Px = 0;
+    $Py = random( -5, 5 );
+    $Pz = -$radius;
+    $Nx = 0;
+    $Ny = 0;
+    $Nz = -1;
+}
+$Sx = 2 * $camx + random( 1, 3 );
+$Sy = 2 * $camy + random( 1, 3 );
+$Sz = 2 * $camz - random( 1, 3 );
+$camx = 0;
+$camy = random( 1, 4 );
+$camz = random( -$radius-5, -$radius-2 );
+$index = random( 0, 5 );
+$name = ( 'Red', 'Green', 'Blue', 'Cyan', 'Magenta', 'Yellow' )[$index];
+$colr = ( 1, 0, 0, 0, 1, 1 )[$index];
+$colg = ( 0, 1, 0, 1, 0, 1 )[$index];
+$colb = ( 0, 0, 1, 1, 1, 0 )[$index];
+$pow1 = 1;
+$pow2 = random( 2, 5 );
+$pow3 = random( 10, 20, 5 );
+
+$Cx = $camx - $Px;
+$Cy = $camy - $Py;
+$Cz = $camz - $Pz;
+$Clen = sqrt( $Cx**2 + $Cy**2 + $Cz**2 );
+$uCx = $Cx / $Clen;
+$uCy = $Cy / $Clen;
+$uCz = $Cz / $Clen;
+$Lx = $Sx - $Px;
+$Ly = $Sy - $Py;
+$Lz = $Sz - $Pz;
+$Llen = sqrt( $Lx**2 + $Ly**2 + $Lz**2 );
+$uLx = $Lx / $Llen;
+$uLy = $Ly / $Llen;
+$uLz = $Lz / $Llen;
+$midx = ( $uCx + $uLx ) / 2;
+$midy = ( $uCy + $uLy ) / 2;
+$midz = ( $uCz + $uLz ) / 2;
+$midlen = sqrt( $midx**2 + $midy**2 + $midz**2 );
+$umidx = $midx / $midlen;
+$umidy = $midy / $midlen;
+$umidz = $midz / $midlen;
+$dotprod = $umidx*$Nx + $umidy*$Ny + $umidz*$Nz;
+$phi = acos( $dotprod ) * 180 / 3.14159265359;
+$shininess1 = sprintf( "%0.8f", max(0,$dotprod)**$pow1 );
+$shininess2 = sprintf( "%0.12f", max(0,$dotprod)**$pow2 );
+$shininess3 = sprintf( "%0.12f", max(0,$dotprod)**$pow3 );
+$ans1r = sprintf( "%0.8f", $colr*(max(0,$dotprod)**$pow1) );
+$ans1g = sprintf( "%0.8f", $colg*(max(0,$dotprod)**$pow1) );
+$ans1b = sprintf( "%0.8f", $colb*(max(0,$dotprod)**$pow1) );
+$ans2r = sprintf( "%0.12f", $colr*(max(0,$dotprod)**$pow2) );
+$ans2g = sprintf( "%0.12f", $colg*(max(0,$dotprod)**$pow2) );
+$ans2b = sprintf( "%0.12f", $colb*(max(0,$dotprod)**$pow2) );
+$ans3r = sprintf( "%0.12f", $colr*(max(0,$dotprod)**$pow3) );
+$ans3g = sprintf( "%0.12f", $colg*(max(0,$dotprod)**$pow3) );
+$ans3b = sprintf( "%0.12f", $colb*(max(0,$dotprod)**$pow3) );
+
+TEXT(beginproblem());
+BEGIN_PGML
+Consider a scene containing an infinite vertical cylinder centered around the y axis with radius 1, a camera at [`([$camx],[$camy],[$camz])`], and a light source at [`([$Sx],[$Sy],[$Sz])`], in POV's left-handed coordinate system, with y pointing upwards. Consider the point [`P = ([$Px],[$Py],[$Pz])`] on the surface of the cylinder at which [`\hat N = \langle [$Nx],[$Ny],[$Nz] \rangle`].
+
+What is the [`\vec C`] vector (from [`P`] to the camera)?
+
+Answer: [`\langle`][_____]{$Cx},[_____]{$Cy},[_____]{$Cz}[`\rangle`]
+
+Compute its unit vector [`\hat C`].
+
+Answer: [`\langle`][_____]{$uCx},[_____]{$uCy},[_____]{$uCz}[`\rangle`]
+
+What is the [`\vec L`] vector (from [`P`] to the light source)?
+
+Answer: [`\langle`][_____]{$Lx},[_____]{$Ly},[_____]{$Lz}[`\rangle`]
+
+Compute the corresponding unit vector [`\hat L`].
+
+Answer: [`\langle`][_____]{$uLx},[_____]{$uLy},[_____]{$uLz}[`\rangle`]
+
+What is the angle [`\phi`] between [`\frac{\hat C+\hat L}{2}`] and [`\hat N`]?
+
+Answer: [`\phi=`][__________]{$phi} degrees
+
+Compute the specular reflection multipliers in this case for shininess ([`n`]) values of [$pow1], [$pow2], and [$pow3].
+
+Answer with [`n=[$pow1]`]: [__________]{$shininess1}
+
+Answer with [`n=[$pow2]`]: [__________]{$shininess2}
+
+Answer with [`n=[$pow3]`]: [__________]{$shininess3}
+
+If the light source is [$name] (RGB color vector [`\langle [$colr],[$colg],[$colb] \rangle`]), then what is the specular contribution to the overall pixel color, for each of the three shininess values computed above?
+
+Answer with [`n=[$pow1]`]:
+[`\langle`]
+[________]{$ans1r},
+[________]{$ans1g},
+[________]{$ans1b}
+[`\rangle`]
+
+Answer with [`n=[$pow2]`]:
+[`\langle`]
+[________]{$ans2r},
+[________]{$ans2g},
+[________]{$ans2b}
+[`\rangle`]
+
+Answer with [`n=[$pow3]`]:
+[`\langle`]
+[________]{$ans3r},
+[________]{$ans3g},
+[________]{$ans3b}
+[`\rangle`]
+END_PGML
+
+BEGIN_PGML_SOLUTION
+[`\vec C=([$camx],[$camy],[$camz])-([$Px],[$Py],[$Pz])=\langle [$Cx],[$Cy],[$Cz] \rangle`]
+
+[`||\vec C||=||\langle [$Cx],[$Cy],[$Cz] \rangle||=\sqrt{([$Cx])^2+([$Cy])^2+([$Cz])^2}\approx [$Clen]`]
+
+[`\hat C=\frac{\vec C}{||\vec C||}\approx\frac{\langle [$Cx],[$Cy],[$Cz] \rangle}{[$Clen]}\approx\langle [$uCx],[$uCy],[$uCz] \rangle`]
+
+[`\vec L=([$Sx],[$Sy],[$Sz])-([$Px],[$Py],[$Pz])=\langle [$Lx],[$Ly],[$Lz] \rangle`]
+
+[`||\vec L||=||\langle [$Lx],[$Ly],[$Lz] \rangle||=\sqrt{([$Lx])^2+([$Ly])^2+([$Lz])^2}\approx [$Llen]`]
+
+[`\hat L=\frac{\vec L}{||\vec L||}\approx\frac{\langle [$Lx],[$Ly],[$Lz] \rangle}{[$Llen]}\approx\langle [$uLx],[$uLy],[$uLz] \rangle`]
+
+To find [`\phi`], we need a unit vector in the direction of [`\frac{\hat C+\hat L}{2}`].
+
+[`\frac{\hat C+\hat L}{2}\approx\frac{\langle [$uCx],[$uCy],[$uCz] \rangle+\langle [$uLx],[$uLy],[$uLz] \rangle}{2} \approx \langle [$midx],[$midy],[$midz] \rangle`]
+
+Its length is thus [`\approx||\langle [$midx],[$midy],[$midz] \rangle||=\sqrt{([$midx])^2+([$midy])^2+([$midz])^2}\approx [$midlen]`].
+
+Its unit vector is thus [`\approx\frac{\langle [$midx],[$midy],[$midz] \rangle}{[$midlen]}\approx\langle [$umidx],[$umidy],[$umidz] \rangle`]
+
+The angle between that unit vector and [`\hat N`] is thus
+[`\cos^{-1}(\langle [$umidx],[$umidy],[$umidz] \rangle\cdot\langle [$Nx],[$Ny],[$Nz] \rangle)
+=\cos^{-1}(([$umidx])([$Nx])+([$umidy])([$Ny])+([$umidz])([$Nz]))
+\approx\cos^{-1}([$dotprod])\approx[$phi]^{\circ}`].
+
+The shininess when [`n=[$pow1]`] is [`(\cos(\phi))^{[$pow1]}\approx[$dotprod]^{[$pow1]}\approx[$shininess1]`].
+
+The shininess when [`n=[$pow2]`] is [`(\cos(\phi))^{[$pow2]}\approx[$dotprod]^{[$pow2]}\approx[$shininess2]`].
+
+The shininess when [`n=[$pow3]`] is [`(\cos(\phi))^{[$pow3]}\approx[$dotprod]^{[$pow3]}\approx[$shininess3]`].
+
+The specular contribution when [`n=[$pow1]`] is therefore [`[$shininess1]\langle [$colr],[$colg],[$colb] \rangle=\langle [$ans1r],[$ans1g],[$ans1b] \rangle`].
+
+The specular contribution when [`n=[$pow2]`] is therefore [`[$shininess2]\langle [$colr],[$colg],[$colb] \rangle=\langle [$ans2r],[$ans2g],[$ans2b] \rangle`].
+
+The specular contribution when [`n=[$pow3]`] is therefore [`[$shininess3]\langle [$colr],[$colg],[$colb] \rangle=\langle [$ans3r],[$ans3g],[$ans3b] \rangle`].
+END_PGML_SOLUTION
+
+ENDDOCUMENT();

--- a/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/blankProblem.pg
+++ b/OpenProblemLibrary/BentleyUniversity/MathematicsOfComputerGraphics/setMoCG-Ch9/blankProblem.pg
@@ -1,0 +1,72 @@
+##DESCRIPTION
+##  Algebra problem: true or false for inequality 
+##ENDDESCRIPTION
+
+##KEYWORDS('algebra', 'inequality', 'fraction')
+
+## DBsubject('Algebra')
+## DBchapter('Fundamentals')
+## DBsection('Real Numbers')
+## Date('6/3/2002')
+## Author('')
+## Institution('')
+## TitleText1('Precalculus')
+## EditionText1('3')
+## AuthorText1('Stewart, Redlin, Watson')
+## Section1('1.1')
+## Problem1('22')
+
+########################################################################
+
+DOCUMENT();      
+
+loadMacros(
+   "PGstandard.pl",     # Standard macros for PG language
+   "MathObjects.pl",
+   #"source.pl",        # allows code to be displayed on certain sites.
+   #"PGcourse.pl",      # Customization file for the course
+);
+
+# Print problem number and point value (weight) for the problem
+TEXT(beginproblem());
+
+# Show which answers are correct and which ones are incorrect
+$showPartialCorrectAnswers = 1;
+
+##############################################################
+#
+#  Setup
+#
+#
+Context("Numeric");
+
+$pi = Real("pi");
+
+##############################################################
+#
+#  Text
+#
+#
+
+Context()->texStrings;
+BEGIN_TEXT
+
+
+Enter a value for \(\pi\)
+
+\{$pi->ans_rule\}
+END_TEXT
+Context()->normalStrings;
+
+##############################################################
+#
+#  Answers
+#
+#
+
+ANS($pi->with(tolerance=>.0001)->cmp);
+# relative tolerance --3.1412 is incorrect but 3.1413 is correct
+# default tolerance is .01 or one percent.
+
+
+ENDDOCUMENT();        


### PR DESCRIPTION
In Spring 2018 I taught a course on the math of computer graphics, using my MAA Press textbook "Introduction to the Mathematics of Computer Graphics."  As I did so, I created several WeBWorK problems for each chapter from 2 through 15 of the text and assigned them to my students, 187 problems in all.  I contribute them to the Open Problem Library here, if they seem good to you.