### PR TITLE
Fix wrong endpoint for complement of a union

### DIFF
--- a/OpenProblemLibrary/Mizzou/Finite_Math/Set_Theory_Introduction/UnionIntersectionInterval1.pg
+++ b/OpenProblemLibrary/Mizzou/Finite_Math/Set_Theory_Introduction/UnionIntersectionInterval1.pg
@@ -81,7 +81,7 @@ $B = Compute("[$b1,$b2)");
 $answerUnion = Compute("($a1,$b2)");
 $answerInt = Compute("[$b1,$a2]");
 $string = "(A \cup B)' ";
-$answer3 = Compute("(-inf,$a2] U [$b2,inf) ");}
+$answer3 = Compute("(-inf,$a1] U [$b2,inf) ");}
 
 elsif($case == 6){
 $A = Compute("[$a1,$b1]");


### PR DESCRIPTION
There is a wrong endpoint in the answer for (A u B)'.  This only shows up when `$case == 5`, so most of the time the problem works fine, so it is easy to miss when testing.