### PR TITLE
Fix incorrect answer in case 2

### DIFF
--- a/OpenProblemLibrary/Mizzou/Finite_Math/Set_Theory_Introduction/UnionIntersectionInterval1.pg
+++ b/OpenProblemLibrary/Mizzou/Finite_Math/Set_Theory_Introduction/UnionIntersectionInterval1.pg
@@ -57,7 +57,7 @@ $B = Compute("($b1,inf)");
 $answerUnion = Compute("(-inf,inf)");
 $answerInt = Compute("($b1,$a2]");
 $string = "A' \cap B";
-$answer3 = Compute("{ }");}
+$answer3 = Compute("($a2,inf)");}
 
 elsif($case == 3){
 $A = Compute("(-inf,$a2]");


### PR DESCRIPTION
If `$case == 2`, the answer 3 should be `($a2,inf)`, not the empty set.