### PR TITLE
Fix square root bug in limit definition of the derivative problem.

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter3/3.2/prob4.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter3/3.2/prob4.pg
@@ -45,7 +45,7 @@ Context()->variables->are(x=>'Real',h=>'Real');
 
 ## Function definition
 $a0 = non_zero_random(-10,10);
-
+Context()->flags->set(limits=>[-$a0,-$a0+4]);
 
 $f = Formula("sqrt(x+$a0)")->reduce;
 $fxph = Formula("sqrt(x+h+$a0)")->reduce;


### PR DESCRIPTION
In particular, we are tasked with computing the derivative of
f(x) = sqrt(x + $a0) for some nonzero $a0 between -10 and 10.

By default, WeBWorK uses test points in the interval [-2, 2] to check
formulas.  However, if $a0 < 2, then there is a chance that we will
be taking the square root of a *negative* number, resulting in an error.

We fix this issue by choosing our test points in [-$a0, -$a + 4], and thus
guarantee that we will be computing square roots of nonnegative numbers.