### PR TITLE
Fix bug in logarithmic differentiation problem.

### DIFF
--- a/OpenProblemLibrary/UCSB/Stewart5_3_8/Stewart5_3_8_40.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_3_8/Stewart5_3_8_40.pg
@@ -46,6 +46,7 @@ $PAR
 END_TEXT
 
 $ans = Compute("$a*x^($a/x)(1-ln(x))/x^2");
+$ans->{limits} = [1,5];
 ANS($ans -> cmp);
 
 ENDDOCUMENT();


### PR DESCRIPTION
One of my students got a "Can't generate enough valid points for comparison"
error when inputting the correct answer for this problem.  They used
e^(7ln(x)/x) instead of the equivalent x^(7/x) in their answer, so perhaps
that was what caused the problem.

The error disappears when we change the limits to [1,5] to ensure positive
inputs to ln.