### PR TITLE
Fix a small typo

### DIFF
--- a/Contrib/OKState/ODE/nonlin-systems/bendixson-dulac1.pg
+++ b/Contrib/OKState/ODE/nonlin-systems/bendixson-dulac1.pg
@@ -99,7 +99,7 @@ BEGIN_TEXT
 $BR
 $BR
 Consider the following systems \(x' = f(x,y), y' = g(x,y) \).
-Copmpute the expression in the (simpler) Bendixson-Dulac theorem
+Compute the expression in the (simpler) Bendixson-Dulac theorem
 (\( \frac{\partial f}{\partial x}+\frac{\partial g}{\partial y} \)) and 
 decide if the theorem applies or not (if it applies, then the system
 has no closed trajectory).  The region you take

--- a/OpenProblemLibrary/OKState/ODE/nonlin-systems/bendixson-dulac1.pg
+++ b/OpenProblemLibrary/OKState/ODE/nonlin-systems/bendixson-dulac1.pg
@@ -100,7 +100,7 @@ No partial credit is awarded for this question.
 $BR
 $BR
 Consider the following systems \(x' = f(x,y), y' = g(x,y) \).
-Copmpute the expression in the (simpler) Bendixson-Dulac theorem
+Compute the expression in the (simpler) Bendixson-Dulac theorem
 (\( \frac{\partial f}{\partial x}+\frac{\partial g}{\partial y} \)) and 
 decide if the theorem applies or not (if it applies, then the system
 has no closed trajectory).  The region you take


### PR DESCRIPTION
Fix a minor typo: "Copmpute" => "Compute"