### PR TITLE
Add missing image to related rates problem.

### DIFF
--- a/OpenProblemLibrary/UCSB/Stewart5_3_10/Stewart5_3_10_22.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_3_10/Stewart5_3_10_22.pg
@@ -17,7 +17,8 @@ DOCUMENT();
 loadMacros(
   "PGstandard.pl",
   "PGchoicemacros.pl",
-  "PGcourse.pl"
+  "PGcourse.pl",
+  "PGgraphmacros.pl",
 );
 
 TEXT(&beginproblem);
@@ -26,12 +27,86 @@ $a=random(1,10,1)*random(-1,1,2);
 $b=random(1,10,1)*random(-1,1,2);
 $c=random(1,10,1)*random(-1,1,2);
 
+$gr = init_graph(-1, -5, 45, 10, size=>[460, 150]);
+
+$gr->moveTo(1, 5);
+$gr->lineTo(6, 0, "blue");
+$gr->lineTo(18, 0, "blue");
+$gr->lineTo(94/3, 5, "blue");
+$gr->lineTo(1, 5, "blue");
+$gr->fillRegion([20, 4.5, "blue"]);
+
+$gr->moveTo(0, 9);
+$gr->lineTo(0, 6, "black", 2);
+$gr->lineTo(6, 0, "black", 2);
+$gr->lineTo(18, 0, "black", 2);
+$gr->lineTo(34, 6, "black", 2);
+$gr->lineTo(40, 6, "black", 2);
+$gr->lineTo(40, 9, "black", 2);
+
+$gr->moveTo(0, -2);
+$gr->lineTo(0, -3);
+$gr->moveTo(6, -2);
+$gr->lineTo(6, -3,);
+$gr->moveTo(18, -2);
+$gr->lineTo(18, -3);
+$gr->moveTo(34, -2);
+$gr->lineTo(34, -3);
+$gr->moveTo(40, -2);
+$gr->lineTo(40, -3);
+
+$gr->moveTo(42, 9);
+$gr->lineTo(43, 9);
+$gr->moveTo(42, 6);
+$gr->lineTo(43, 6);
+$gr->moveTo(42, 0);
+$gr->lineTo(43, 0);
+
+$gr->moveTo(3, -2.5);
+$gr->arrowTo(0, -2.5);
+$gr->moveTo(3, -2.5);
+$gr->arrowTo(6, -2.5);
+$gr->moveTo(12, -2.5);
+$gr->arrowTo(6, -2.5);
+$gr->moveTo(12, -2.5);
+$gr->arrowTo(18, -2.5);
+$gr->moveTo(26, -2.5);
+$gr->arrowTo(18, -2.5);
+$gr->moveTo(26, -2.5);
+$gr->arrowTo(34, -2.5);
+$gr->moveTo(37, -2.5);
+$gr->arrowTo(34, -2.5);
+$gr->moveTo(37, -2.5);
+$gr->arrowTo(40, -2.5);
+
+$gr->moveTo(42.5, 7.5);
+$gr->arrowTo(42.5, 6);
+$gr->moveTo(42.5, 7.5);
+$gr->arrowTo(42.5, 9);
+$gr->moveTo(42.5, 3);
+$gr->arrowTo(42.5, 6);
+$gr->moveTo(42.5, 3);
+$gr->arrowTo(42.5, 0);
+
+$gr->lb(new Label(3, -3 ,'6', 'black','center','top'));
+$gr->lb(new Label(12, -3 ,'12', 'black','center','top'));
+$gr->lb(new Label(26, -3 ,'16', 'black','center','top'));
+$gr->lb(new Label(37, -3 ,'6', 'black','center','top'));
+
+$gr->lb(new Label(43.5, 3 ,'6', 'black','left','middle'));
+$gr->lb(new Label(43.5, 7.5 ,'3', 'black','left','middle'));
+
+
 BEGIN_TEXT
 
 $PAR
 
 A swimming pool is \(20\,ft\) wide, \(40\,ft\) long, \(3\,ft\) deep at the shallow end, and \(9\,ft\) deep at its deepest point.  If the pool is being filled at a rate of \(.8\,ft^3/min\), how fast is the water level rising when the depth at the deepest point is \(5\,ft\)?
+$PAR
 
+$BCENTER
+\{image(insertGraph($gr), width=>460, height=>150) \}
+$ECENTER
 $PAR
 
 \{ans_rule(20)\} \(ft/min\)


### PR DESCRIPTION
This related rates problem is missing an image which is essential for
completing the problem, as I discovered while working with a student
today in office hours!  Without it, there is not enough information relating
the volume and height of the water.

I referenced the corresponding problem in my hardcopy of Stewart to create
this dynamic image instead of uploading a scanned image.  This way, if this
problem is ever updated to use randomly-generated numbers instead of hardcoded
ones, the image can be updated automatically.