### PR TITLE
Fix bug in optimization problem.

### DIFF
--- a/OpenProblemLibrary/UCSB/Stewart5_4_7/Stewart5_4_7_17.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_4_7/Stewart5_4_7_17.pg
@@ -56,8 +56,8 @@ $PAR
 END_TEXT
 
 ANS(num_cmp(1/(1-$b)));
-ANS(num_cmp(-sqrt($b-$b/((1-$b)^2))));
+ANS(num_cmp(-sqrt($b-$b/((1-$b)**2))));
 ANS(num_cmp(1/(1-$b)));
-ANS(num_cmp(sqrt($b-$b/((1-$b)^2))));
+ANS(num_cmp(sqrt($b-$b/((1-$b)**2))));
 
 ENDDOCUMENT();


### PR DESCRIPTION
The y-coordinates of the solutions involving squaring a number, but the
problem was using "^2" instead of the Perl-native "**2".  Since it was using
num_cmp to check the answers, it was marking the correct answers as wrong.