### PR TITLE
Westmont/ActiveCalculus/Preview_4_4: graph labels, allow partial credit

### DIFF
--- a/OpenProblemLibrary/Westmont/ActiveCalculus/Preview_4_4/preview_4_4_abcde.pg
+++ b/OpenProblemLibrary/Westmont/ActiveCalculus/Preview_4_4/preview_4_4_abcde.pg
@@ -47,6 +47,15 @@ size=>[300,300]
 add_functions($gr, "$velx for x in <0,2>" . 
   " using color:blue and weight:2");
 $gr->lb( 'reset' );
+$gr->lb( new Label(1,-2,'1','black','left','middle'));
+$gr->lb( new Label(0,-2,'(0,0)','black','left','middle'));
+$gr->lb( new Label(1.97,-2,'2','black','right','middle'));
+$gr->lb( new Label(.03,8,'8','black','left','middle'));
+$gr->lb( new Label(.03,-8,'-8','black','left','middle'));
+$gr->lb( new Label(.03,-16,'-16','black','left','middle'));
+$gr->lb( new Label(.03,-24,'-24','black','left','middle'));
+$gr->lb( new Label(.03,-32,'-32','black','left','middle'));
+$gr->lb( new Label(.03,-40,'-40','black','left','middle'));
 $gr->lb( new Label(0.1,14,'velocity (ft/sec)',
     'black','left','middle'));
 $gr->lb( new Label(1.95,2.8,'time (sec)',
@@ -100,7 +109,7 @@ tossed until the time it lands? $BR
 Total vertical distance = \{ ans_rule(10) \}
 $PAR
 
-The graph of the velocity function \(y=v(t)\) on the interval \([0,2]\) is
+The graph of the velocity function \(y=v(t)= $vel\) on the interval \([0,2]\) is
 shown below.
  $PAR
 $BCENTER
@@ -122,7 +131,7 @@ END_TEXT
 
 Context()->normalStrings;
 
-$showPartialCorrectAnswers = 0;
+$showPartialCorrectAnswers = 1;
 ANS($pos->cmp() );
 ANS($tmax->cmp() );
 ANS($tland->cmp() );


### PR DESCRIPTION
The graph without any labels can be confusing to students, since a natural assumption to make is that an unlabeled grid has the same scale both horizontally and vertically.  Also, I don't think there's any reason not to show partial correct answers on this problem (there are no multiple-choice parts).