### PR TITLE
New hyperbolic integral problem.

### DIFF
--- a/Contrib/Piedmont/APEXCalculus/6-TechniquesOfAntidifferentiation/6.6.45.pg
+++ b/Contrib/Piedmont/APEXCalculus/6-TechniquesOfAntidifferentiation/6.6.45.pg
@@ -1,0 +1,46 @@
+## DESCRIPTION
+## Easy definite integral involving hyperbolic sine function.
+## ENDDESCRIPTION
+
+## DBsubject(Calculus - single variable )
+## DBchapter(Techniques of integration)
+## DBsection(Hyperbolic functions)
+## Level(2)
+## KEYWORDS('definite integral','hyperbolic functions')
+## TitleText1(APEX Calculus)
+## EditionText1(4.0)
+## AuthorText1(Hartman)
+## Section1(6.6)
+## Problem1(45)
+## Author(Doug Torrance)
+## Institution(Piedmont)
+
+DOCUMENT();
+
+loadMacros(
+   "PGstandard.pl",
+   "MathObjects.pl",
+);
+
+TEXT(beginproblem());
+Context("Numeric");
+
+$a = random(-6, -1);
+$b = random(1, 6);
+$ans = Compute("cosh($b)-cosh($a)");
+
+BEGIN_TEXT
+
+Evaluate the given definite integral.
+$PAR
+
+\[\int_{$a}^{$b}\sinh x\,dx\]
+$PAR
+
+\{$ans->ans_rule\}
+
+END_TEXT
+
+ANS($ans->cmp);
+
+ENDDOCUMENT();


### PR DESCRIPTION
The rest of the problems in the OPL with integrals involving hyperbolic
functions require some additional integration techniques (substitution, parts,
etc.).  This commit adds a more trivial "warm-up" problem requiring only
the FTC and knowing that the hyperbolic cosine is an antiderivative of the
hyperbolic sine.