### PR TITLE
Add several problems where students compute "at least one" probabilities

### DIFF
--- a/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.24.pg
+++ b/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.24.pg
@@ -1,0 +1,65 @@
+# DESCRIPTION
+# One Bad Apple - Probabilities of At Least One
+# Spark Plugs
+# ENDDESCRIPTION
+
+## DBsubject(Probability)
+## DBchapter(Sample Space)
+## DBsection(Probability: direct computation, inclusion/exclusion)
+## Level(2)
+## KEYWORDS('probability','independent','complement')
+## TitleText1(Introduction to Statistics: Think & Do)
+## EditionText1(4.1)
+## AuthorText1(Stevens)
+## Section1(4.5)
+## Problem1(24)
+## Author(Doug Torrance)
+## Institution(Piedmont)
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "parserRadioButtons.pl",
+  "PGnumericalmacros.pl",
+  "PGstatisticsmacros.pl",
+  "niceTables.pl",
+);
+
+TEXT(beginproblem());
+
+Context("Numeric");
+
+$p = random(2,8);
+$n = random(3,10);
+
+$a = Compute("(100 - $p)/100");
+$b = Compute("$a^$n");
+$c = Compute("1-$b");
+
+BEGIN_TEXT
+
+Assume that $p% of all spark-plugs are defective.
+$PAR
+
+(a) If you buy one spark plug, what is the probability that it is not defective?
+$BR
+\{ans_rule(20)\}
+$PAR
+
+(b) If you buy $n spark plugs, what is the probability that all $n are not defective?
+$BR
+\{ans_rule(20)\}
+$PAR
+
+(c) If you buy $n spark plugs, what is the probability that at least one is defective?
+$BR
+\{ans_rule(20)\}
+
+END_TEXT
+
+ANS($a->cmp);
+ANS($b->cmp);
+ANS($c->cmp);
+
+ENDDOCUMENT();

--- a/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.25.pg
+++ b/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.25.pg
@@ -1,0 +1,50 @@
+# DESCRIPTION
+# One Bad Apple - Probabilities of At Least One
+# At Least One Girl
+# ENDDESCRIPTION
+
+## DBsubject(Probability)
+## DBchapter(Sample Space)
+## DBsection(Probability: direct computation, inclusion/exclusion)
+## Level(2)
+## KEYWORDS('probability','independent','complement')
+## TitleText1(Introduction to Statistics: Think & Do)
+## EditionText1(4.1)
+## AuthorText1(Stevens)
+## Section1(4.5)
+## Problem1(25)
+## Author(Doug Torrance)
+## Institution(Piedmont)
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "parserRadioButtons.pl",
+  "PGnumericalmacros.pl",
+  "PGstatisticsmacros.pl",
+  "niceTables.pl",
+);
+
+TEXT(beginproblem());
+
+Context("Numeric");
+
+$n = random(2,12);
+
+$ans = Compute("1-.5^$n");
+
+BEGIN_TEXT
+
+Suppose a couple plans to have $n children and the probability of a boy is 0.50.
+$PAR
+
+Find the probability that the couple has at least one girl.
+$BR
+\{ans_rule(20)\}
+
+END_TEXT
+
+ANS($ans->cmp);
+
+ENDDOCUMENT();

--- a/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.26.pg
+++ b/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.26.pg
@@ -1,0 +1,51 @@
+# DESCRIPTION
+# One Bad Apple - Probabilities of At Least One
+# Lie Detector
+# ENDDESCRIPTION
+
+## DBsubject(Probability)
+## DBchapter(Sample Space)
+## DBsection(Probability: direct computation, inclusion/exclusion)
+## Level(2)
+## KEYWORDS('probability','independent','complement')
+## TitleText1(Introduction to Statistics: Think & Do)
+## EditionText1(4.1)
+## AuthorText1(Stevens)
+## Section1(4.5)
+## Problem1(26)
+## Author(Doug Torrance)
+## Institution(Piedmont)
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "parserRadioButtons.pl",
+  "PGnumericalmacros.pl",
+  "PGstatisticsmacros.pl",
+  "niceTables.pl",
+);
+
+TEXT(beginproblem());
+
+Context("Numeric");
+
+$p = random(80, 99);
+$truths = random(5, 20);
+$lies = random(5, 20);
+
+$ans = Compute("1-($p/100)^$lies");
+
+BEGIN_TEXT
+
+Suppose a lie detector test can detect a lie $p% of the time. You get hooked up and tell $truths truths and $lies lies.
+$PAR
+
+What is the probability that at least one of your lies goes undetected?
+\{ans_rule(20)\}
+
+END_TEXT
+
+ANS($ans->cmp);
+
+ENDDOCUMENT();

--- a/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.27.pg
+++ b/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.27.pg
@@ -1,0 +1,68 @@
+# DESCRIPTION
+# One Bad Apple - Probabilities of At Least One
+# Alarm Clock - Redundancy
+# ENDDESCRIPTION
+
+## DBsubject(Probability)
+## DBchapter(Sample Space)
+## DBsection(Probability: direct computation, inclusion/exclusion)
+## Level(2)
+## KEYWORDS('probability','independent','complement')
+## TitleText1(Introduction to Statistics: Think & Do)
+## EditionText1(4.1)
+## AuthorText1(Stevens)
+## Section1(4.5)
+## Problem1(27)
+## Author(Doug Torrance)
+## Institution(Piedmont)
+
+DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "parserRadioButtons.pl",
+);
+
+TEXT(beginproblem());
+
+Context("Numeric");
+
+$p1 = random(80, 99);
+$p2 = random(50, 70);
+
+$a = Compute("$p1/100");
+$b = Compute("1 - (100 - $p1)/100 * (100 - $p2)/100");
+$c = RadioButtons(["Yes", "No"], "Yes");
+
+BEGIN_TEXT
+
+You have two alarm clocks. The first one is successful $p1% of the time
+and the second one is successful $p2% of the time (it turns out your second
+one was actually less reliable than the first).
+$PAR
+
+(a) Suppose you only remember to set the good alarm clock. What is the
+probability that it will succeed on the morning of an important exam?
+$BR
+\{ans_rule(20)\}
+$PAR
+
+(b) Suppose you set both alarm clocks. What is the probability that at least
+one of them is successful on the morning of an important exam?
+$BR
+\{ans_rule(20)\}
+$PAR
+
+(c) This practice of using a second device is called redundancy. Was there a
+significant increase in the probability of getting to the exam obtained
+using the second alarm clock?
+$BR
+\{$c->buttons()\}
+
+END_TEXT
+
+ANS($a->cmp);
+ANS($b->cmp);
+ANS($c->cmp);
+
+ENDDOCUMENT();

--- a/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.28.pg
+++ b/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.5.28.pg
@@ -1,0 +1,66 @@
+# DESCRIPTION
+# One Bad Apple - Probabilities of At Least One
+# Jumper-Cables
+# ENDDESCRIPTION
+
+## DBsubject(Probability)
+## DBchapter(Sample Space)
+## DBsection(Probability: direct computation, inclusion/exclusion)
+## Level(2)
+## KEYWORDS('probability','independent','complement')
+## TitleText1(Introduction to Statistics: Think & Do)
+## EditionText1(4.1)
+## AuthorText1(Stevens)
+## Section1(4.5)
+## Problem1(28)
+## Author(Doug Torrance)
+## Institution(Piedmont)
+
+DOCUMENT();
+
+loadMacros(
+  "PGstandard.pl",
+  "MathObjects.pl",
+  "parserRadioButtons.pl",
+);
+
+TEXT(beginproblem());
+
+Context("Numeric");
+
+$p = random(15, 35);
+$n = random(3, 10);
+
+$a = Compute("($p/100)^$n");
+$b = Compute("1 - ((100 - $p)/100)^$n");
+$c = RadioButtons(["Part (a)", "Part (b)"], "Part (b)");
+
+BEGIN_TEXT
+
+Assume that $p% of all car owners have jumper-cables in the car. You are
+stranded in a parking lot with a dead battery and there are $n other people
+getting into different cars nearby.
+$PAR
+(a) What is the probability that all $n people have jumper-cables in the
+car?
+$BR
+\{ans_rule(20)\}
+$PAR
+
+(b) What is the probability that at least one of the $n people have
+jumper-cables in the car?
+$BR
+\{ans_rule(20)\}
+$PAR
+
+(c) Which probability is more relevant to your current situation?
+$BR
+\{$c->buttons()\}
+
+END_TEXT
+
+ANS($a->cmp);
+ANS($b->cmp);
+ANS($c->cmp);
+
+ENDDOCUMENT();


### PR DESCRIPTION
We use Stevens' Introduction to Statistics: Think & Do for our introductory
statistics course.  It has an entire section devoted to computing
probabilities of an event occuring at least once, i.e., realizing that this
is the complement of the event never occuring.

There are few problems of this sort currently in the OPL, so I adapted some
from Stevens.