### PR TITLE
Fix square root bug in limit def'n of derivative problem, 2nd attempt

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter3/3.2/prob4.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter3/3.2/prob4.pg
@@ -45,7 +45,9 @@ Context()->variables->are(x=>'Real',h=>'Real');
 
 ## Function definition
 $a0 = non_zero_random(-10,10);
-Context()->flags->set(limits=>[-$a0,-$a0+4]);
+# we want to make sure that x + $a0 >= 0 and x + h + $a0 >= 0
+# since h is chosen randomly from [-2, 2], we want x >= 2 - $a0
+Context()->variables->set(x=>{limits=>[2 - $a0, 6 - $a0]});
 
 $f = Formula("sqrt(x+$a0)")->reduce;
 $fxph = Formula("sqrt(x+h+$a0)")->reduce;


### PR DESCRIPTION
This fixes a previous attempt (d8328a0) to fix this bug.  In particular,
the limits of *both* x and h were changed to [-$a0, -$a0 + 4].  This meant
that -$a0 <= x + h + $a0 <= -$a0 + 8.  So if $a0 is positive, then there is
still a chance that we try to take the square root of a negative number
after picking test points.

To get around this, we now *only* set the limits on x, and since h is chosen
from the default interval of [-2, 2], we set these limits to be
[2 - $a0, 6 - $a0].  So the argument of the square root should now always be
nonnegative.