### PR TITLE
Detect equivalent solutions to implicit differentiation problem.

### DIFF
--- a/OpenProblemLibrary/Wiley/setAnton_Section_3.1/Anton3_1_Q12.pg
+++ b/OpenProblemLibrary/Wiley/setAnton_Section_3.1/Anton3_1_Q12.pg
@@ -47,6 +47,12 @@ $G=Formula("sec(y)*tan(y)*(dy/dx)+4*y^3*sec(y)*(dy/dx)+y^4*sec(y)*tan(y)*(dy/dx)
 $Y=Formula("sec(y)*tan(y)+4*y^3*sec(y)+y^4*sec(y)*tan(y)+4*$a*y^3-3*x*y^2")->reduce;
 $X=Formula("y^3")->reduce;
 $ans=Formula("$X/$Y");;
+
+@y = map(non_zero_random(-2, 2, 0.1), 0..4);
+@x = map((1 + ($_)**4) * ($a + sec($_)) / ($_)**3, @y);
+@xy = map([0, 0, $x[$_], $y[$_]], 0..4); #0's are for dx and dy
+$ans->{test_points} = ~~@xy;
+
 ###################################
 # Main text
 Context()->texStrings;


### PR DESCRIPTION
Students will get different, but equivalent, answers to this problem
depending on whether they first multiply everything by the denominator of
the left-hand side of the equation before differentiating.

Previously, a student's answer would only be marked correct if they did
in fact do this.  If a student did not do this, and instead immediately
began differentiating using the quotient rule, then their answer would be
marked incorrect even if they found the derivative correctly.

While seemingly very different, the two answers obtained by these two
methods are equivalent if one substitutes on side of the original implicit
equation for the other.

However, previously the two test points for x and y are chosen at random,
and not with the implicit relationship from the original equation in mind.

We fix this by making sure that the test points for x and y which are chosen
satisfy the original equation.  The code is based on Alex Jordan's
excellent answer to my question on the WeBWorK forums [1].

[1] http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4574