### PR TITLE
Wording / tag fixes

### DIFF
--- a/Contrib/OKState/ODE/secondorder-systems/positive-eigenvalues-second-order.pg
+++ b/Contrib/OKState/ODE/secondorder-systems/positive-eigenvalues-second-order.pg
@@ -64,7 +64,7 @@ $foure1 = 4*$e1;
 Context()->texStrings;
 BEGIN_TEXT
 While often the eigenvalues for the second order linear systems end up being
-negative in applications.  The technique works just as well with positive
+negative in applications, the technique works just as well with positive
 eigenvalues.
 Take the system 
 \[

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-03.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-03.pg
@@ -12,7 +12,7 @@
 ## Level(2)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-04.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-04.pg
@@ -12,7 +12,7 @@
 ## Level(3)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-04a.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-04a.pg
@@ -12,7 +12,7 @@
 ## Level(1)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-06.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-06.pg
@@ -12,7 +12,7 @@
 ## Level(1)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-07.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-07.pg
@@ -12,7 +12,7 @@
 ## Level(2)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-09.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-09.pg
@@ -12,7 +12,7 @@
 ## Level(2)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-10.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-10.pg
@@ -12,7 +12,7 @@
 ## Level(2)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-11a.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/0-Introduction/Lebl-0-2-11a.pg
@@ -12,7 +12,7 @@
 ## Level(1)
 ## MO(1)
 ## TitleText1('Notes on Diffy Qs')
-## AuthorText1('Edwards and Penney')
+## AuthorText1('Jiri Lebl')
 ## EditionText1('4')
 ## Section1('1.1')
 ## Problem1('1')

--- a/OpenProblemLibrary/FortLewis/DiffEq/3-Linear-systems/06-Second-order-systems/mass-spring-system-04/mass-spring-system-04.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/3-Linear-systems/06-Second-order-systems/mass-spring-system-04/mass-spring-system-04.pg
@@ -175,21 +175,21 @@ display_matrix([[$multians1->ans_rule(5),$multians1->ans_rule(5)],[$multians1->a
 allowbreaks=>'yes'
 ) 
 \}
-\( x(0) = \) \{ $multians2->ans_rule(10) \} meters
+\( x_1(0) = \) \{ $multians2->ans_rule(10) \} meters
 $BR
-\( y(0) = \) \{ $multians2->ans_rule(10) \} meters
+\( x_2(0) = \) \{ $multians2->ans_rule(10) \} meters
 $BR
-\( x^{\,\prime}(0) = \) \{ $multians2->ans_rule(10) \} meters/second
+\( x_1^{\,\prime}(0) = \) \{ $multians2->ans_rule(10) \} meters/second
 $BR
-\( y^{\,\prime}(0) = \) \{ $multians2->ans_rule(10) \} meters/second
+\( x_2^{\,\prime}(0) = \) \{ $multians2->ans_rule(10) \} meters/second
 
 $ITEMSEP
 $ITEM
 Find the solution to this system of differential equations.
 $BR
-\( x(t) = \) \{ ans_rule(40) \} meters
+\( x_1(t) = \) \{ ans_rule(40) \} meters
 $BR
-\( y(t) = \) \{ ans_rule(40) \} meters
+\( x_2(t) = \) \{ ans_rule(40) \} meters
 
 $ITEMSEP
 $ITEM

--- a/OpenProblemLibrary/OKState/ODE/secondorder-systems/positive-eigenvalues-second-order.pg
+++ b/OpenProblemLibrary/OKState/ODE/secondorder-systems/positive-eigenvalues-second-order.pg
@@ -65,7 +65,7 @@ $foure1 = 4*$e1;
 Context()->texStrings;
 BEGIN_TEXT
 While often the eigenvalues for the second order linear systems end up being
-negative in applications.  The technique works just as well with positive
+negative in applications, the technique works just as well with positive
 eigenvalues.
 Take the system 
 \[


### PR DESCRIPTION
1) Fix grammar in OKState/ODE/secondorder-systems/positive-eigenvalues-second-order.pg
2) Fix "AuthorText1" for the reference in a few problems
3) Fix FortLewis/DiffEq/3-Linear-systems/06-Second-order-systems/mass-spring-system-04/mass-spring-system-04.pg.  It talks about x_1 and x_2 and then in the middle it starts talking about x and y, so make it just always talk about x_1 and x_2.