### PR TITLE
Increase minimum margin of error to avoid rounding errors from table.

### DIFF
--- a/OpenProblemLibrary/ASU-topics/setStat/kolossa55.pg
+++ b/OpenProblemLibrary/ASU-topics/setStat/kolossa55.pg
@@ -31,7 +31,7 @@ loadMacros(
 TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
-$b = random(.01,.09,.005);
+$b = random(.045,.09,.005);
 $p = random(.7,.9,.1);
 $q = 1-$p;
 


### PR DESCRIPTION
Some students may be using tables to find the critical z-values for this
sample size problem, but others may be using software.  Ideally, students
should be marked correct regardless of their source of the critical
z-values.

As the minimum sample size is computed by dividing by the square of the
desired margin of error, which is very small for proportions, rounding
errors are amplified.  For example, if dealing with a 98% confidence level
and a 0.04 margin of error, a student using software would get:
n = ceil(2.32634787539286^2 * 0.25 / 0.04^2) = 846
for part (a), which WeBWorK would accept, but a student using a table would
get:
n = ceil(2.33^2 * 0.25 / 0.04^2) = 849,
which is just outside of the problems tolerance level of 3.

I wrote a script which ran through all the possible combinations of
randomly generated values, and if the smallest possible margin of error
is 0.045, then we do not run into this problem.  In particular, the
difference between answers found using software and answers found using
values from a table is always less than 3.