### PR TITLE
More minor fixes/improvements I found ....

### DIFF
--- a/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-11.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-11.pg
@@ -40,7 +40,7 @@ TEXT(beginproblem());
 Context("Numeric");
 Context()->variables->are(
 x=>"Real",
-t=>"Real",Deltat=>"Real",
+t=>"Real",Deltat=>["Real",TeX=>"\Delta t"],
 );
 
 $f = random(2,6,1);   # flowrate (in g/L)

--- a/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-12.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-12.pg
@@ -40,7 +40,7 @@ TEXT(beginproblem());
 Context("Numeric");
 Context()->variables->are(
 x=>"Real",
-t=>"Real",Deltat=>"Real",
+t=>"Real",Deltat=>["Real",TeX=>"\Delta t"],
 c=>"Real",
 );
 

--- a/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-12b.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-12b.pg
@@ -40,7 +40,7 @@ TEXT(beginproblem());
 Context("Numeric");
 Context()->variables->are(
 x=>"Real",
-t=>"Real",Deltat=>"Real",
+t=>"Real",
 c=>"Real",
 );
 

--- a/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-9.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-9.pg
@@ -42,7 +42,7 @@ Context("Numeric");
 Context()->variables->are(
 x=>"Real",
 y=>"Real",
-t=>"Real",Deltat=>"Real",
+t=>"Real",Deltat=>["Real",TeX=>"\Delta t"],
 );
 Context()->variables->set(t => {limits => [900, 1100]});
 

--- a/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-9b.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/1-First-order/04-Linear-integrating-factor/Lebl-1-4-9b.pg
@@ -42,7 +42,7 @@ Context("Numeric");
 Context()->variables->are(
 x=>"Real",
 y=>"Real",
-t=>"Real",Deltat=>"Real",
+t=>"Real",
 );
 Context()->variables->set(t => {limits => [900, 1100]});
 

--- a/OpenProblemLibrary/Rochester/setDiffEQ4Linear1stOrder/ur_de_4_18a.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ4Linear1stOrder/ur_de_4_18a.pg
@@ -66,7 +66,7 @@ $BR $BR
 $BR 
 \(u(1)=\) \{ans_rule(10)\}. 
 $BR $BR 
-(d) Now solve the linear equation in part (b).
+(d) Now solve the linear equation in part (b),
 and find the solution that satisfies the initial condition in part (c). 
 $BR 
 \(u(x)=\) \{ans_rule(40)\}. 

--- a/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_1.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_1.pg
@@ -48,7 +48,7 @@ The graph of the function  \(f(x)  \)  is $BR
 Consider the differential equation \(x'(t) = f( x(t) ) \).
 $BR $BR  
 List the constant (or equilibrium) solutions to this differential equation
-in increasing order and indicate whether or not these equations are stable, semi-stable, or unstable.
+in increasing order and indicate whether or not these equilibra are stable, semi-stable, or unstable.
 $BR
 \{ans_rule(10) \}  \{ pop_up_list(''=>'','stable'=>'stable', 'unstable'=>'unstable', 'semi-stable' => 'semi-stable') \}
 $BR

--- a/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_1.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_1.pg
@@ -48,7 +48,7 @@ The graph of the function  \(f(x)  \)  is $BR
 Consider the differential equation \(x'(t) = f( x(t) ) \).
 $BR $BR  
 List the constant (or equilibrium) solutions to this differential equation
-in increasing order and indicate whether or not these equilibra are stable, semi-stable, or unstable.
+in increasing order and indicate whether or not these equilibria are stable, semi-stable, or unstable.
 $BR
 \{ans_rule(10) \}  \{ pop_up_list(''=>'','stable'=>'stable', 'unstable'=>'unstable', 'semi-stable' => 'semi-stable') \}
 $BR

--- a/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_2.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_2.pg
@@ -50,7 +50,7 @@ $BR
 Given the differential equation \(x'(t) = f( x(t) ) \). 
 $BR
 List the constant (or equilibrium) solutions to this differential equation
-in increasing order and indicate whether or not these equations are stable, semi-stable, or unstable.
+in increasing order and indicate whether or not these equilibria are stable, semi-stable, or unstable.
 $BR
 \{ans_rule(10) \}  \{ pop_up_list(''=>'','stable'=>'stable', 'unstable'=>'unstable', 'semi-stable' => 'semi-stable') \}
 $BR

--- a/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_3.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_3.pg
@@ -39,7 +39,7 @@ BEGIN_TEXT
 Given the differential equation \(x' = $sign(x-$a)*(x-$b)^3(x-$c)^2(x-$d) \). 
 $BR
 List the constant (or equilibrium) solutions to this differential equation
-in increasing order and indicate whether or not these equations are stable, semi-stable, or unstable.
+in increasing order and indicate whether or not these equilibria are stable, semi-stable, or unstable.
 (It helps to \{htmlLink(alias("${htmlDirectory}phaseplaneplotters/index.html"),"sketch the graph.", 
 "TARGET=~~"plotter~~"" )\} xFunctions will plot functions as well as phase planes. )
 $BR

--- a/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_4.pg
+++ b/OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_4.pg
@@ -43,7 +43,7 @@ BEGIN_TEXT
 Given the differential equation \(x'(t) =  $sgn x^4 + ${A}x^3 + ${B}x^2 + ${C}x + $D  \).
 $BR
 List the constant (or equilibrium) solutions to this differential equation
-in increasing order and indicate whether or not these equations are stable, semi-stable, or unstable.
+in increasing order and indicate whether or not these equilibria are stable, semi-stable, or unstable.
 (It helps to \{htmlLink(alias("${htmlDirectory}phaseplaneplotters/index.html"), "sketch the graph.",
 "TARGET=~~"plotter~~"" )\} xFunctions will plot
 functions as well as phase planes. )


### PR DESCRIPTION
1) The first is more of an improvement.  In several problems there was \Delta t being input as Deltat, but in the tex output it was still Deltat which is not ideal.  Change it so that it prints out "\Delta t" in the tex output.  Then two of the problems didn't use the Deltat variable at all, although it was added to the context unnecessarily, so just remove it, nobody should be typing in Deltat into those two problems.

2) Some English fixes.  First, one period that should be a comma.  Then in several of the "classify equilibria" autonomous equation problems it said to find the equilibrium solutions and to "indicate whether or not these equations are ..." which is nonsense, there is only one equation, it is the equilibrium that is stable or unstable so change it to "indicate whether or not these equilibria are ...".

One thing that doesn't work for me for two of those problems is the "sketch the graph".  I figure it is something that I do not have installed.  I wonder if the problem should handle it more gracefully if it is not installed.  I suppose I should file a bug report, since I have no clue how to fix that or if it even needs fixing.  It's the OpenProblemLibrary/Rochester/setDiffEQ6AutonomousStability/ur_de_6_3.pg and ur_de_6_4.pg in the same directory.