### PR TITLE
Use negative critical value for left-tailed hypothesis test.

### DIFF
--- a/OpenProblemLibrary/Rochester/setStatistics4HypothesisTesting/ur_stt_4_13.pg
+++ b/OpenProblemLibrary/Rochester/setStatistics4HypothesisTesting/ur_stt_4_13.pg
@@ -1,6 +1,6 @@
 ##DESCRIPTION
 ##
-## tsch tagged and PAID on 3-22-2004 
+## tsch tagged and PAID on 3-22-2004
 
 ## DBsubject(Statistics)
 ## DBchapter(Hypothesis tests)
@@ -40,7 +40,7 @@ $m2 = $mean+2;
 $s = random(1,2,.01);
 $alpha = random(.01,.05,.04);
 $mu = random($m1,$m2,.1);
-$ta = tdistr(($n-1), $alpha);
+$ta = -tdistr(($n-1), $alpha);
 
 $t = ($mean-$mu)/($s/sqrt $n);
 
@@ -51,7 +51,7 @@ $mc = new_multiple_choice();
         "There is not sufficient evidence to reject the null hypothesis that \( \mu =
 	$mu\). ");
 
-if ($t < -$ta ) {$tag = 0;} else {$tag = 1;}
+if ($t < $ta ) {$tag = 0;} else {$tag = 1;}
 
 $mc -> qa('The final conclustion is', $ans[$tag]);
 
@@ -59,12 +59,12 @@ $mc -> extra($ans[1-$tag]);
 
 
 BEGIN_TEXT
-A sample of \($n\) measurments, randomly selected from a normally distributed
+A sample of \($n\) measurements, randomly selected from a normally distributed
 population, resulted in a sample mean, \(\overline{x} = $mean\) and sample
 standard deviation \(s = $s\).  Using \(\alpha = $alpha \), test the null
 hypothesis that the mean of the population is \($mu\) against the alternative
 hypothesis that the mean of the population, \(\mu < $mu\) by giving the
-following:$BR 
+following:$BR
 (a) \( \ \) the degree of freedom \( \ \) \{ans_rule(10)\} $BR
 (b) \( \ \) the critical \(t\) value \( \ \) \{ans_rule(10)\}$BR
 (c) \( \ \) the test statistic \( \ \) \{ans_rule(10)\} $PAR


### PR DESCRIPTION
Since our claim is the that the mean is less than some value, this is a
left-tailed test and our critical value should be negative.

We also take the opportunity to fix a typo and delete some trailing
whitespace.