### PR TITLE
Fix possible division by zero error.

### DIFF
--- a/OpenProblemLibrary/Piedmont/StevensStatistics/9-HypothesisTestingTwoSamples/9.1.2.pg
+++ b/OpenProblemLibrary/Piedmont/StevensStatistics/9-HypothesisTestingTwoSamples/9.1.2.pg
@@ -35,9 +35,11 @@ $t_init = non_zero_random(-2,2,.1);
 $s_init = $dbar_init/($t_init/sqrt(10));
 
 do {
-    @d = urand($dbar_init, $s_init, 10, 0);
+    do {
+        @d = urand($dbar_init, $s_init, 10, 0);
+        $s = stats_sd(@d);
+    } until ($s != 0);
     $dbar = stats_mean(@d);
-    $s = stats_sd(@d);
     $t = Compute("$dbar/($s/sqrt(10))");
  } until ($crit2 + 0.1 < $t && $t < $crit1 - 0.1);
 


### PR DESCRIPTION
In this hypothesis test problem, there was a slim chance that we might
generate a data set with a standard deviation of 0, which would give us a
division by 0 error.