### PR TITLE
Fix incorrect domain of gof for large b

### DIFF
--- a/OpenProblemLibrary/org.sparta/Combining_Functions/AlgofRelations_prb1.pg
+++ b/OpenProblemLibrary/org.sparta/Combining_Functions/AlgofRelations_prb1.pg
@@ -62,8 +62,11 @@ $domain_f_g = Compute("$domain_fg - {$c}");
 $domain_g_f = Compute("$domain_fg - {$a}");
 $domain_fog = Compute("$domain_g - {$b^2+$c}");
 
-if (($a-$b*$c)/(1-$c) < $b) {$domain_gof = Union("(-inf,($a-$b*$c)/(1-$c)]U($b,inf)");}
-                            {$domain_gof = Union("(-inf,$b)U[($a-$b*$c)/(1-$c),inf)");};
+if (($a-$b*$c)/(1-$c) < $b) {
+    $domain_gof = Union("(-inf,($a-$b*$c)/(1-$c)]U($b,inf)");
+} else {
+    $domain_gof = Union("(-inf,$b)U[($a-$b*$c)/(1-$c),inf)");
+};
 
 
 ##############################################################


### PR DESCRIPTION
Missing `else` causes the second case to always overwrite the first one, leading to an incorrect domain (-inf, inf) in half of the cases.