### PR TITLE
Fix tutorial PDE heat separation problems and the solution in an Euler's method problem

### DIFF
--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/pde-heat1.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/pde-heat1.pg
@@ -403,7 +403,7 @@ We can ignore this case.
 $ITEMSEP
 
 $ITEM
-$BBOLD Case 2: $EBOLD \(\lambda = -\gamma^2\) 
+$BBOLD Case 2: $EBOLD \(\lambda = -\gamma^2 < 0\) 
  $SPACE $SPACE (In your answers below use ${BBOLD}gamma${EBOLD} 
                 instead of ${BBOLD}lambda${EBOLD}) $BR
 
@@ -425,7 +425,7 @@ We can ingore this case.
 $ITEMSEP
 
 $ITEM
-$BBOLD Case 3: $EBOLD \(\lambda = \gamma^2 \) 
+$BBOLD Case 3: $EBOLD \(\lambda = \gamma^2 > 0 \) 
  $SPACE $SPACE (In your answers below use ${BBOLD}gamma${EBOLD} 
                 instead of ${BBOLD}lambda${EBOLD}) $BR
 
@@ -440,7 +440,7 @@ Plugging in the boundary values into this formula gives $BR
   \(0 = X($L) = \)\{$multians_pos->ans_rule(40)\} $BR
 
 $BR
-Which leads us to the eigenvalues \(\gamma_n =\)\{ans_rule\} $BR
+Which leads us to the eigenvalues \(\lambda_n = \gamma_n^2\) where \(\gamma_n =\)\{ans_rule\} $BR
 and eigenfunctions \( X_n(x) =\)\{ans_rule\}
 $BR 
 

--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/pde-heat2.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/pde-heat2.pg
@@ -401,12 +401,14 @@ Plugging the boundary values into this formula gives $BR
 
 So \(X(x) = \)\{ans_rule(1)\}.  $BR 
 
-We will deal with this case using \(A_0\) later....
+$BR
+Which leads us to the eigenvalue \(\lambda_0 = 0\) with
+a constant eigenfunction.
 
 $ITEMSEP
 
 $ITEM
-$BBOLD Case 2: $EBOLD \(\lambda = -\gamma^2\) 
+$BBOLD Case 2: $EBOLD \(\lambda = -\gamma^2 < 0\) 
  $SPACE $SPACE (In your answers below use ${BBOLD}gamma${EBOLD}
                 instead of ${BBOLD}lambda${EBOLD}) $BR
 
@@ -428,7 +430,7 @@ We can ingore this case.
 $ITEMSEP
 
 $ITEM
-$BBOLD Case 3: $EBOLD \(\lambda = \gamma^2 \) 
+$BBOLD Case 3: $EBOLD \(\lambda = \gamma^2 > 0 \) 
  $SPACE $SPACE (In your answers below use ${BBOLD}gamma${EBOLD}
                 instead of ${BBOLD}lambda${EBOLD}) $BR
 
@@ -444,7 +446,7 @@ Plugging the boundary values into this formula gives $BR
   \(0 = X'($L) = \)\{$multians_pos->ans_rule(40)\} $BR
 
 $BR
-Which leads us to the eigenvalues \(\gamma_n =\)\{ans_rule\} $BR
+Which leads us to the eigenvalues \(\lambda_n = \gamma_n^2\) where \(\gamma_n =\)\{ans_rule\} $BR
 and eigenfunctions \( X_n(x) =\)\{ans_rule\}
 $BR 
 
@@ -477,10 +479,15 @@ $SPACE $SPACE $SPACE
 
 $PAR
 
+The eigenvalue \(\lambda_0=0\) from ${BBOLD}Case 1${EBOLD} results in both \(X_0(x)\)
+and \(T_0(t)\) being constant.
+
+$PAR
+
 Combining all of the \(X_n\) and \(T_n\) we get that $BR
 
 $SPACE $SPACE
-\(u(x,t)=\displaystyle\sum\limits_{n=0}^\infty \;A_n\)\{ans_rule(30)\} $BR
+\(u(x,t)=A_0 +  \displaystyle\sum\limits_{n=1}^\infty \;A_n\)\{ans_rule(30)\} $BR
 
 where \(A_n\) are unknown constants.
 
@@ -501,7 +508,8 @@ and setting equal to the initial heat distribution given in the problem. $BR
 
 $SPACE $SPACE
 \(u(x,0) = \displaystyle
-  \sum\limits_{n=0}^\infty A_n\)\{ans_rule(20)\}
+  A_0 +
+  \sum\limits_{n=1}^\infty A_n\)\{ans_rule(20)\}
 \( = \begin{cases}
   $f1, &      0   <  x $le1 $halfL \\
   $f2, & $halfL $le2 x   <  $L

--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/pde-heat3.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/pde-heat3.pg
@@ -405,7 +405,7 @@ We can ignore this case.
 $ITEMSEP
 
 $ITEM
-$BBOLD Case 2: $EBOLD \(\lambda = -\gamma^2\) 
+$BBOLD Case 2: $EBOLD \(\lambda = -\gamma^2 < 0\) 
  $SPACE $SPACE (In your answers below use ${BBOLD}gamma${EBOLD}
                 instead of ${BBOLD}lambda${EBOLD}) $BR
 
@@ -427,7 +427,7 @@ We can ingore this case.
 $ITEMSEP
 
 $ITEM
-$BBOLD Case 3: $EBOLD \(\lambda = \gamma^2 \) 
+$BBOLD Case 3: $EBOLD \(\lambda = \gamma^2 > 0 \) 
  $SPACE $SPACE (In your answers below use ${BBOLD}gamma${EBOLD}
                 instead of ${BBOLD}lambda${EBOLD}) $BR
 
@@ -443,13 +443,14 @@ Plugging the boundary values into this formula gives $BR
   \(0 = X($L) = \)\{$multians_pos->ans_rule(40)\} $BR
 
 $BR
-Which leads us to the eigenvalues \(\gamma_n =\)\{ans_rule\} $BR
+Which leads us to the eigenvalues \(\lambda_n = \gamma_n^2\) where \(\gamma_n =\)\{ans_rule\} $BR
 and eigenfunctions \( X_n(x) =\)\{ans_rule\}
 $BR 
 
   $SPACE $SPACE
   (${BBOLD}Notation:${EBOLD} Eigenfunctions should not include any constants 
-   ${BBOLD}a${EBOLD} or ${BBOLD}b${EBOLD}.)
+   ${BBOLD}a${EBOLD} or ${BBOLD}b${EBOLD}.  Here it is convenient to let \(n=0\) correspond to the smallest eigenvalue,
+   \(n=1\) to the second smallest, and so on.)
 
 \{ EndList('UL') \}
 
@@ -480,9 +481,9 @@ $PAR
 Combining all of the \(X_n\) and \(T_n\) we get that $BR
 
 $SPACE $SPACE
-\(u(x,t)=\displaystyle\sum\limits_{n=0}^\infty \;A_n\)\{ans_rule(50)\} $BR
+\(u(x,t)=\displaystyle\sum\limits_{n=0}^\infty \;C_n\)\{ans_rule(50)\} $BR
 
-where \(A_n\) are unknown constants.
+where \(C_n\) are unknown constants.
 
 
 END_TEXT
@@ -490,18 +491,18 @@ END_TEXT
 
 Section::End();
 ############################################################
-Section::Begin("${BBOLD}Fourier Coefficients.${EBOLD}");
+Section::Begin("${BBOLD}Eigenfunction expansion.${EBOLD}");
 
 
 BEGIN_TEXT
 
 
-We compute \(A_n\) by plugging \(t=0\) into the formula for \(u(x,t)\)
+We compute \(C_n\) by plugging \(t=0\) into the formula for \(u(x,t)\)
 and setting equal to the initial heat distribution given in the problem. $BR
 
 $SPACE $SPACE
 \(u(x,0) = \displaystyle
-  \sum\limits_{n=0}^\infty A_n\)\{ans_rule(20)\}
+  \sum\limits_{n=0}^\infty C_n\)\{ans_rule(20)\}
 \( = \begin{cases}
   $f1, &      0   <  x $le1 $halfL \\
   $f2, & $halfL $le2 x   <  $L
@@ -509,19 +510,14 @@ $SPACE $SPACE
 
 $PAR
 
-So the \(A_n\) are Fourier coefficients. $BR
+So the \(C_n\) are coefficients in the eigenfunction expansion of \(u(x,0)\) and they are computed just like the
+standard Fourier coefficients. $BR
 
 $SPACE $SPACE
 \(\displaystyle
-A_n=\frac{2}{$L}\int_{$lower}^{$upper}\)\{ans_rule(20)\} \(\hskip 3pt dx\)
-$SPACE $SPACE (for \(n\neq 0\))
+C_n=\frac{2}{$L}\int_{$lower}^{$upper}\)\{ans_rule(20)\} \(\hskip 3pt dx\)
 $BR $BR $SPACE $SPACE
 \(\hskip 16pt =\) \{ans_rule(40)\} 
-$PAR
-
-$SPACE $SPACE
-\(\displaystyle
-A_0 =\) \{ans_rule(10)\}
 
 
 END_TEXT
@@ -575,20 +571,11 @@ ANS(Formula($Default_not,"cos((2*n+1)*pi*x/(2*$L))")->cmp);
 ANS(Formula($Default_nox,"c*e^(-$k*((2*n+1)*pi/(2*$L))^2*t)")->cmp);
 ANS(Formula($Default,"e^(-$k*((2*n+1)*pi/(2*$L))^2*t)*cos((2*n+1)*pi*x/(2*$L))")->cmp);
 
-## Compute B_n
+## Compute C_n
 
 ANS(Formula($Default_not,"cos((2*n+1)*pi*x/(2*$L))")->cmp);
 ANS(Formula($Default_not,"($f1+$f2)*cos((2*n+1)*pi*x/(2*$L))")->cmp); 
 ANS($Fcoeff->cmp);
-ANS(Formula($simplify,"($f1+$f2)/2")->cmp (
-       checker=>sub {
-         my ($correct, $student, $ansHash) = @_;
-         if ($student == Formula($simplify,"$f1+$f2")) {
-           Value::Error("Divide this by 2.${BR}We wrote \(A_0\) instead of \(\frac{A_0}{2}\) in the series expression for \(u(x,0)\).");
-         }
-         return ($student == $correct);
-       }
-));
 
 
 COMMENT("Modified version of problem from D. Cook at Alfred Univ.  This version uses multians with pretty formatting and custom answer checkers to accept any correct answers (with sinh or exp).");

--- a/OpenProblemLibrary/Wiley/setAnton_Section_8.3/Anton_8_3_Q11.pg
+++ b/OpenProblemLibrary/Wiley/setAnton_Section_8.3/Anton_8_3_Q11.pg
@@ -45,6 +45,7 @@ Context("Numeric");
 Context()->variables->are(t=>'Real');
 Context()->flags->set(tolerance=>.0000000001);
 Context()->flags->set(tolType=>'absolute');
+Context()->{format}{number} = "%.8f#";
 $f=Formula("sin(pi*t)")->reduce;
 $dx=($b-$a)/5;
   @xx2[0]=$ya;


### PR DESCRIPTION
1. Wording fixes for METU-NCC/Diff_Eq/pde-heat*.pg
   1. Mark the cases by ">0" and "<0" since we said we split up by signs
   2. If we call \lambda_n the eigenvalue in one place do not call \gamma_n the eigenvalue in another
   3. pde-heat2.pg says we will "deal A_0 with later" when it neither handled it nor even explained what A_0 was at this stage.  Replace the wording to just explain what happens in the eigenvalue zero case, and actually "deal" with it in the later steps.  Also split it out of the sum instead of just assuming that n=0 means the cosine will be 1 so that it actually looks like the Fourier cosine series.  That was confusing the students when I used that problem.

2. Fix issues that arose when I last used the pde-heat3.pg problem on a homework and I forgot to report them (bad bad Jiri)
   1. In METU-NCC/Diff_Eq/pde-heat3.pg we should not call the final section "Fourier coefficients", since those are not the standard Fourier coefficients, they are coefficients of the eigenfunction expansion that arose, which happen to be Fourier coefficients but of a very different function over a different interval.  So I renamed it to "Eigenfunction expansion".  To make this clearer call the coefficients C_n and not A_n since they are not the normal A_n coefficients.  Also when the eigenfunctions are first defined we start with n=0 without warning the student.
   2. Related to the above the last section was wrong as A_0 was not what was claimed, there is no constant eigenvalue and hence no constant term, the C_0 is computed just like the rest of them.  So I just removed the last answer blank.  I think this is related to the confusion about these being Fourier coefficients which they are not.

3. Fix solution for Wiley/setAnton_Section_8.3/Anton_8_3_Q11.pg.  It asks for 6 decimal digits, but the standard format for the numbers just prints 6 digits total.  This leads to actually the wrong answer being printed in the solution.  Changing the format to always print 8 decimal digits will make the table make sense and the final answer is printed correctly to 6 digits in the solution.