### PR TITLE
Move test points to avoid rounding error problems

### DIFF
--- a/OpenProblemLibrary/Wiley/setAnton_Section_0.2/Question32.pg
+++ b/OpenProblemLibrary/Wiley/setAnton_Section_0.2/Question32.pg
@@ -76,7 +76,7 @@ $GFsimp = Formula("sqrt(x)");
 #****************************
 $QlistFG = new_aligned_list(ans_rule_len=>25, numbered=>0, tex_spacing=>"3pt");
 $QlistFG->qa("\( \small{(f \circ g)(x)} \)",
-             fun_cmp($FofG,test_points=>[-$Bound-1,-$Bound,$Bound,$Bound+1]),
+             fun_cmp($FofG,test_points=>[-$Bound-1,-$Bound-0.001,$Bound+0.001,$Bound+1]),
              "Domain", $DomainFG->cmp);
 $QlistGF = new_aligned_list(ans_rule_len=>25, numbered=>0, tex_spacing=>"3pt");
 $QlistGF->qa("\( \small{(g \circ f)(x)} \)", 


### PR DESCRIPTION
The test points at the ends of the domain did not always work, because
a rounding error moves them out of the domain.  Move them tiny bit in to
avoid that.