### PR TITLE
change scalar to subroutine call

### DIFF
--- a/OpenProblemLibrary/macros/CollegeOfIdaho/unorderedAnswer.pl
+++ b/OpenProblemLibrary/macros/CollegeOfIdaho/unorderedAnswer.pl
@@ -39,7 +39,7 @@ sub UNORDERED_ANS {
   #  $main::ans_rule_count, but we don't have access to that
   #
   foreach $i (1..$n)
-    {push(@params,ANS_NUM_TO_NAME($i+$main::ans_rule_count-$n),$cmp[$i-1])}
+    {push(@params,ANS_NUM_TO_NAME($i+main::ans_rule_count()-$n),$cmp[$i-1])}
   my @results = unordered_answer_list(@params);
   while (scalar(@results) > 0) {shift(@results), ANS(shift(@results))}
 }


### PR DESCRIPTION
In problems that use this macro library, I'm getting Perl errors. It seems that there is no scalar `$main::ans_rule_count`, but there is a subroutine `main:::ans_rule_count()` defined in macros/PG.pl. Perhaps some older version of Perl was flexible enough to deal with that. But not anymore.