### PR TITLE
Fix small typo

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.5_Surface_Integrals_of_Vector_Fields/16.5.26.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.5_Surface_Integrals_of_Vector_Fields/16.5.26.pg
@@ -65,8 +65,8 @@ $BBOLD (b) $EBOLD The flow rate through the projection of \($T\) onto the
 \(xy\)-plane [the triangle with vertices \((0,0,0)\), \((1,0,0)\), and \((0,1,0)\)]
 $PAR
 Assume distances are in meters. $PAR
-$BBOLD (a) $EBOLD \(\iint_S $vv\cdot d\mathbf{S} =\) \{ans_rule()\} $BR
-$BBOLD (b) $EBOLD \(\iint_S $vv\cdot d\mathbf{S} =\) \{ans_rule()\}
+$BBOLD (a) $EBOLD \(\iint_{$T} $vv\cdot d\mathbf{S} =\) \{ans_rule()\} $BR
+$BBOLD (b) $EBOLD \(\iint_{$T} $vv\cdot d\mathbf{S} =\) \{ans_rule()\}
 $PAR
 
 END_TEXT 
@@ -84,10 +84,10 @@ We compute the flow rate through \($T\). Since the unit normal vector is \(\math
 \[\mathbf{v}\cdot \mathbf{e_n}= \left< $a,$b,0 \right>\cdot \left< \frac{1}{\sqrt{3}},\frac{1}{\sqrt{3}},\frac{1}{\sqrt{3}} \right> =\frac{\{$a+$b\}}{\sqrt{3}} \]
 Therefore, the flow rate through \($T\)  is the following flux: $BR
 \[
-\iint_S $vv\cdot d\mathbf{S} =
-\iint_S  \left($vv\cdot \mathbf{e_n}\right) \,dS= \]\[
-\iint_S  \frac{\{$a+$b\}}{\sqrt{3}}  \,dS=
-\frac{\{$a+$b\}}{\sqrt{3}}\cdot \mathrm{Area} (S)=   \]\[
+\iint_{$T} $vv\cdot d\mathbf{S} =
+\iint_{$T}  \left($vv\cdot \mathbf{e_n}\right) \,dS= \]\[
+\iint_{$T}  \frac{\{$a+$b\}}{\sqrt{3}}  \,dS=
+\frac{\{$a+$b\}}{\sqrt{3}}\cdot \mathrm{Area} ($T)=   \]\[
 \frac{\{$a+$b\}}{\sqrt{3}}\cdot\frac{\sqrt{3}}{2}=
 \frac{\{$a+$b\}}{2}=$answera
 \]


### PR DESCRIPTION
The problem sets up a surface and names it \mathcal{T} but then writes the integrals as \iint_S instead of \iint_{\mathcal{T}}.  So fix that.  Similarly change Area(S) to Area(\mathcal{T}).