### PR TITLE
Fix bug in playing card probability problem.

### DIFF
--- a/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.2.13.pg
+++ b/Contrib/Piedmont/StevensStatistics/4-IntroductionToProbability/4.2.13.pg
@@ -31,9 +31,9 @@ Context("Numeric");
 
 $suit = list_random('\(\heartsuit\)', '\(\diamondsuit\)', '\(\spadesuit\)',
     '\(\clubsuit\)');
-@ranks = (2, 3, 4, 5, 6, 7, 8, 9, 10, 'Jack', 'Queen', 'King', 'Ace');
+@ranks = (2, 3, 4, 5, 6, 7, 8, 9, 10, 'Jack', 'Queen', 'King');
 
-$lowest_card = random(0, 11);
+$lowest_card = random(0, 8);
 @hand = map($ranks[$_] . $suit, $lowest_card .. $lowest_card + 3);
 
 $flush = Compute(9/48);


### PR DESCRIPTION
The goal of the problem is to have a hand of four consecutive cards in
the same suit, none of which are aces to allow for the possibility
of a straight with either an ace low or an ace high.

However, there was a chance that the hand could have begun with a
a jack, which meant that our highest card was already an ace and
so our probability of a straight is reduced by half.  There was
also a possibility that our hand began with a queen or king, which
ended up displaying empty strings for the highest card(s) in our
hand.

This has been fixed by ensuring that the highest card picked for
starting the hand is a 10.  Also, 'Ace' has been removed from the
list of ranks as it will never need to be displayed.