### PR TITLE
Fix a rare case of like terms

### DIFF
--- a/OpenProblemLibrary/PCC/BasicAlgebra/Exponents/exponentDivision145.pg
+++ b/OpenProblemLibrary/PCC/BasicAlgebra/Exponents/exponentDivision145.pg
@@ -14,7 +14,10 @@
 #
 # We make sure to choose m, p, r > 5 and n, q, s > 2
 #
-# Last edited: Hughes 9/6/13, Hughes 7/1/13, Yao 6/28/13
+# Last edited: Hughes 9/6/13, Hughes 7/1/13, Yao 6/28/13, Hlavacek 9/13/19
+#
+# Jan Hlavacek <jhlavace@svsu.edu>: make sure we don't end up with like terms.
+# Also, add "do not factor" to instructions.
 #
 # ENDDESCRIPTION
 
@@ -64,15 +67,23 @@ $b = non_zero_random(-13,13,1) while($b==$a);
 $c=$b;
 $c = non_zero_random(-13,13,1) while($c==$b);
 
-# exponents for x
+# first exponents
 $m = random(7,20,1);
-$p = random(6,$m-1,1);
-$r = random(5,$m-1,1);
-
-# exponents for y
 $n = random(5,20,1);
-$q = random(4,$n-1,1);
-$s = random(2,$n-1,1);
+
+# second exponents (at least one of them must be different
+# from the first exponent)
+do {
+    $p = random(6,$m-1,1);
+    $q = random(4,$n-1,1);
+} while (($p == $m) and ($q == $n));
+
+# third exponents (again, we do not want the same two exponents as in 
+# one of the previous terms)
+do {
+    $r = random(5,$m-1,1);
+    $s = random(2,$n-1,1);
+} while ((($r == $p) and ($s == $q)) or (($r == $m) and ($s == $n)));
 
 # reduction check
 $ans = Formula("$a*x^$m*y^$n+$b*x^$p*y^$q+$c*x^$r*y^$s")->reduce->reduce;
@@ -106,7 +117,7 @@ TEXT(beginproblem());
 
 BEGIN_PGML
 
-Simplify the following expression
+Simplify the following expression (do not factor)
 
     [`\displaystyle\frac{[$poly1]}{[$poly2]}= `][________________________________]
 


### PR DESCRIPTION
Sometimes the problem generates like terms, which students combine, and
their answer is not accepted.  Also, students sometimes try to factor
the result, so we tell them not to.