### PR TITLE
Missing TEXT(beginproblem()), remove debugging output, fix some spacing of dxdydz and such

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_6/prob2.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_6/prob2.pg
@@ -108,6 +108,8 @@ $Images =
   EndTable();
 
 
+TEXT(beginproblem());
+
 ##############################################
 #  Main text
 
@@ -115,8 +117,8 @@ BEGIN_TEXT
 $Images
 $PAR
 The region R is bounded by the curves \(y=$lower\), \(y=$upper\), and the y-axis, and its mass density is \(\delta (x,y) = $delta\). To find the center of gravity of the region you would compute 
-\(\displaystyle\int\int_R\delta(x,y) dA= \int_c^d\int_{p(x)}^{q(x)}\delta(x,y) dydx,\int_c^d\int_{p(x)}^{q(x)}x\delta(x,y) dydx,\) and 
-\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}y\delta(x,y)dydx\) where
+\(\displaystyle\int\int_R\delta(x,y)\, dA= \int_c^d\int_{p(x)}^{q(x)}\delta(x,y)\,dy\,dx,\int_c^d\int_{p(x)}^{q(x)}x\delta(x,y)\, dy\,dx,\) and 
+\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}y\delta(x,y)\,dy\,dx\) where
 $BR
 \(c = \)\{&ans_rule(30)\}
 $BR
@@ -126,11 +128,11 @@ $BR
 $BR
 \(q(x) = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}\delta(x,y)\;dydx = \) \{&ans_rule(30)\}
+\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}\delta(x,y)\,dy\,dx = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}x\delta(x,y)\;dydx = \) \{&ans_rule(30)\}
+\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}x\delta(x,y)\,dy\,dx = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}y\delta(x,y)\;dydx = \) \{&ans_rule(30)\}
+\(\displaystyle\int_c^d\int_{p(x)}^{q(x)}y\delta(x,y)\,dy\,dx = \) \{&ans_rule(30)\}
 $BR 
 and finally the center of gravity is 
 $BR

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_6/prob3.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_6/prob3.pg
@@ -75,6 +75,7 @@ $diagram = "prob3.gif";
 
 
 
+TEXT(beginproblem());
 
 ##############################################
 #  Main text
@@ -83,8 +84,8 @@ BEGIN_TEXT
 \{ColumnTable(Image($diagram, size=>$size, tex_size=>500, border=>0, tex_center=>1))\}
 $PAR
 A solid region R, whose boundary contains the surface in the figure, is bounded by \(z=$e, z=$b,x=$a,\) and \(x=$b\). To find the centroid of R you would compute 
-\(\displaystyle\int\int_R\delta(x,y) dV= \int_a^b\int_{c}^{d}\int_e^f dzdydx, \int_a^b\int_{c}^{d}\int_e^f xdzdydx,\int_a^b\int_{c}^{d}\int_e^f ydzdydx\) and 
-\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f zdzdydx\) where
+\(\displaystyle\int\int_R\delta(x,y) \,dV= \int_a^b\int_{c}^{d}\int_e^f dz\,dy\,dx, \int_a^b\int_{c}^{d}\int_e^f x\,dz\,dy\,dx,\int_a^b\int_{c}^{d}\int_e^f y\,dz\,dy\,dx\) and 
+\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f z\,dz\,dy\,dx\) where
 $BR
 \(a = \)\{&ans_rule(30)\}
 $BR
@@ -98,13 +99,13 @@ $BR
 $BR
 \(f = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f dzdydx = \) \{&ans_rule(30)\}
+\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f dz\,dy\,dx = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f xdzdydx = \) \{&ans_rule(30)\}
+\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f x\,dz\,dy\,dx = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f ydzdydx = \) \{&ans_rule(30)\}
+\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f y\,dz\,dy\,dx = \) \{&ans_rule(30)\}
 $BR
-\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f zdzdydx = \) \{&ans_rule(30)\} 
+\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f z\,dz\,dy\,dx = \) \{&ans_rule(30)\} 
 $BR
 and finally the centroid is 
 $BR

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_6/prob4.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_6/prob4.pg
@@ -66,6 +66,7 @@ $zcentroid = Compute(".3014908350");
 $size = [392,439];
 $diagram = "prob4.gif";
 
+TEXT(beginproblem());
 
 ##############################################
 #  Main text
@@ -74,8 +75,8 @@ BEGIN_TEXT
 \{ColumnTable(Image($diagram, size=>$size, tex_size=>500, border=>0, tex_center=>1))\}
 $PAR
 The region R is bounded by \(\displaystyle z=$e\), \(\displaystyle z=$f\)(in blue), \(\displaystyle y=$c,\) and \(y=$d\)(in red). To find the centroid of the region you would compute 
-\(\displaystyle\int\int\int_R\delta(x,y,z) dV= \int_a^b\int_{c}^{d}\int_e^f dzdydx, \int_a^b\int_{c}^{d}\int_e^f xdzdydx,\int_a^b\int_{c}^{d}\int_e^f ydzdydx\) and 
-\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f zdzdydx\) where
+\(\displaystyle\int\int\int_R\delta(x,y,z) \,dV= \int_a^b\int_{c}^{d}\int_e^f dz\,dy\,dx, \int_a^b\int_{c}^{d}\int_e^f x\,dz\,dy\,dx,\int_a^b\int_{c}^{d}\int_e^f y\,dz\,dy\,dx\) and 
+\(\displaystyle\int_a^b\int_{c}^{d}\int_e^f z\,dz\,dy\,dx\) where
 $BR
 \(a = \)\{&ans_rule(30)\}
 $BR

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_7/prob2.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_7/prob2.pg
@@ -49,6 +49,8 @@ $d = Compute(random(2,8)) + $r_squared;
 
 $f = Formula("$d-(x^2+y^2+z^2)");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 A spherical solid, centered at the origin, has radius $r_squared and mass density \(\delta(x,y,z)=$d -\left(x^2+y^2+z^2\right)\). Find its mass. 

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_7/prob3.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter15/15_7/prob3.pg
@@ -56,6 +56,7 @@ $ans = 2*pi*($n/(2*$n+2)*$b*$r**((2*$n+2)/$n)-$n/(4*$n+2)*$a*$r**((4*$n+2)/$n));
 # the code for the answer blank in a pop up, not harmful
 # but disruptive.
 
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_4/prob2.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_4/prob2.pg
@@ -32,6 +32,8 @@ Context()->strings->add("not conservative"=>{});
 
 $a = random(1,10);
 
+TEXT(beginproblem());
+
 BEGIN_TEXT
 Let C be the square oriented counterclockwise with corners (0,0),($a,0),($a,$a), and (0,$a). If we label the edges of the square as \(C_1,C_2,C_3,C_4\) starting from the bottom edge going counterclockwise, then the edges may be linearly parameterized, with \(0\leq t\leq $a\), by:
 $PAR
@@ -59,7 +61,7 @@ $BR
 $BR
 \(y_4(t)=\) \{ans_rule(20)\}
 $PAR
-\(\displaystyle\oint\limits_C y^2\,dx+x^2\,dy \)\(= \int\limits_{C_1} y^2\,dx+x^2\,dy\) \(+\int\limits_{C_2} y^2\,dx+x^2\,dy\) \(+\int\limits_{C_3} y^2\,dx+x^2\,dy\)\(+
+\(\displaystyle\oint\limits_C y^2\,dx+x^2\,dy \)\(\displaystyle{}= \int\limits_{C_1} y^2\,dx+x^2\,dy\) \(\displaystyle{}+\int\limits_{C_2} y^2\,dx+x^2\,dy\) \(\displaystyle{}+\int\limits_{C_3} y^2\,dx+x^2\,dy\)\(\displaystyle{}+
 \int\limits_{C_4} y^2\,dx+x^2\,dy\)
 $BR
 \(\hspace{15pt} = \)\{ans_rule(15)\} + \{ans_rule(16)\} + \{ans_rule(16)\}  + \{ans_rule(15)\}
@@ -68,7 +70,7 @@ Applying Green's theorem,
 $BR
 \{ BeginTable(center=>0).
       Row(['\(\displaystyle\oint\limits_C y^2\,dx+x^2\,dy \)',
-'=',tableintegral(width=>1),tableintegral(width=>1),ans_rule(15),'\(dxdy \)'],separation=>1).
+'=',tableintegral(width=>1),tableintegral(width=>1),ans_rule(15),'\(dx\,dy \)'],separation=>1).
 EndTable();\}
 \{ BeginTable(center=>0).
 Row([$SPACE,$SPACE,'=',tableintegral(width=>1),ans_rule(15),'\(dy\)','=',ans_rule(20)],separation=>1).

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_4/prob6.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_4/prob6.pg
@@ -38,6 +38,7 @@ $y2 = Formula("$r*sin(pi*t/2)");
 $x3 = Formula("0");
 $y3 = Formula("$r(1-t)");
 
+TEXT(beginproblem());
 
 BEGIN_TEXT
 Let C be the boundary of the region in the first quadrant bounded by the x-axis, a quarter-circle with radius $r, and the y-axis, oriented counterclockwise starting from the origin. 
@@ -61,15 +62,15 @@ $BR
 $BR
 \(y_3(t)=\) \{ans_rule(20)\}
 $PAR
-\(\displaystyle\oint\limits_C y^2xdx+x^2ydy\)
-\(=\int\limits_{C_1} y^2xdx+x^2ydy\) \( +\int\limits_{C_2} y^2xdx+x^2ydy\) \(+\int\limits_{C_3} y^2xdx+x^2ydy\)
+\(\displaystyle\oint\limits_C y^2x\,dx+x^2y\,dy\)
+\(\displaystyle{}=\int\limits_{C_1} y^2x\,dx+x^2y\,dy\) \(\displaystyle {}+\int\limits_{C_2} y^2x\,dx+x^2y\,dy\) \(\displaystyle{}+\int\limits_{C_3} y^2x\,dx+x^2y\,dy\)
 $BR
 \(\hspace{10pt} = \)\{ans_rule(18)\} + \{ans_rule(18)\} + \{ans_rule(18)\}
 $BR 
 Applying Green's theorem,
 $BR
 \{ BeginTable(center=>0).
-      Row(['\(\displaystyle\oint\limits_C y^2xdx+x^2ydy = \)', tableintegral(width=>1),tableintegral(lowerwidth=>1,upperwidth=>7),ans_rule(15),'\(dxdy\)'],separation=>1).
+      Row(['\(\displaystyle\oint\limits_C y^2x\,dx+x^2y\,dy = \)', tableintegral(width=>1),tableintegral(lowerwidth=>1,upperwidth=>7),ans_rule(15),'\(dx\,dy\)'],separation=>1).
    EndTable();
 \}
 \{ BeginTable(center=>0).

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_5/prob2.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_5/prob2.pg
@@ -63,6 +63,10 @@ $ru = $r->D('u')->reduce;
 $rv = $r->D('v')->reduce;
 #$prod = Formula($contextv,$ru x $rv);
 $prod = Formula($contextv,"<sin($a*v),-cos($a*v),$a*u>");
+
+
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 Suppose that surface \(\sigma\) is parameterized by
@@ -73,11 +77,11 @@ and \(f(x,y,z) = $f\).  Set up the surface integral (you don't need to evaluate 
 
 $PAR
 \{ BeginTable(center=>0).
-      Row(['\(\displaystyle\int\limits_\sigma\!\!\int f(x,y,z)dS = \int\limits_R\!\!\int f\left(x(u,v),y(u,v),z(u,v)\right)\left\Vert\frac{\partial r}{\partial u}\times\frac{\partial r}{\partial v}\right\Vert dA \)'],separation=>1).
+      Row(['\(\displaystyle\int\limits_\sigma\!\!\int f(x,y,z)\,dS = \int\limits_R\!\!\int f\left(x(u,v),y(u,v),z(u,v)\right)\left\Vert\frac{\partial r}{\partial u}\times\frac{\partial r}{\partial v}\right\Vert dA \)'],separation=>1).
    EndTable();
 \}
 \{ BeginTable(center=>0).
- Row([$SPACE,$SPACE,'=',tableintegral(width=>1),tableintegral(width=>1),ans_rule(20),'\(\Bigg\Vert\)',ans_rule(15),'\(\Bigg\Vert\hskip 3pt dudv \)'],separation=>1).
+ Row([$SPACE,$SPACE,'=',tableintegral(width=>1),tableintegral(width=>1),ans_rule(20),'\(\Bigg\Vert\)',ans_rule(15),'\(\Bigg\Vert\hskip 3pt du\,dv \)'],separation=>1).
    EndTable();
 \}
 END_TEXT

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_5/prob3.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_5/prob3.pg
@@ -62,19 +62,21 @@ $rv = $r->D('phi')->reduce;
 $prod = Vector("$ru >< $rv");
 $prod = Formula("<-$rho_squared*cos(theta)*(sin(phi))^2, -$rho_squared*sin(theta)*(sin(phi))^2,-$rho_squared*sin(phi)*cos(phi)>");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT 
-Find the surface integral \(\int\limits_\sigma\!\!\int f(x,y,z)dS\) where \(f = $f\) and \(\sigma\) is the sphere \(x^2+y^2+z^2 = $rho_squared\) above \(z = $height\).
+Find the surface integral \(\int\limits_\sigma\!\!\int f(x,y,z)\,dS\) where \(f = $f\) and \(\sigma\) is the sphere \(x^2+y^2+z^2 = $rho_squared\) above \(z = $height\).
 $BR
 Parameterize the surface integral 
 $PAR
 \{ BeginTable(center=>0).
-      Row(['\(\displaystyle\int\limits_\sigma\!\!\int f(x,y,z)dS = \int\limits_R\!\!\int f\left(x(\theta,\phi),y(\theta,\phi),z(\theta,\phi)\right)\left\Vert\frac{\partial r}{\partial \theta}\times\frac{\partial r}{\partial \phi}\right\Vert dA \)'],separation=>1).
+      Row(['\(\displaystyle\int\limits_\sigma\!\!\int f(x,y,z)\,dS = \int\limits_R\!\!\int f\left(x(\theta,\phi),y(\theta,\phi),z(\theta,\phi)\right)\left\Vert\frac{\partial r}{\partial \theta}\times\frac{\partial r}{\partial \phi}\right\Vert dA \)'],separation=>1).
    EndTable();
 \}
 \{ BeginTable(center=>0).
       Row([$SPACE,$SPACE,'=',tableintegral(width=>1),tableintegral(width=>1),
-ans_rule(20),'\(\Bigg\Vert\)',ans_rule(15),'\(\Bigg\Vert\hskip 3pt d\theta d\phi \)'],separation=>1).
+ans_rule(20),'\(\Bigg\Vert\)',ans_rule(15),'\(\Bigg\Vert\hskip 3pt d\theta\, d\phi \)'],separation=>1).
    EndTable();
 \}
 $BR

--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_5/prob6.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_5/prob6.pg
@@ -64,18 +64,20 @@ $F = $fuv*$dS;
 #  The integral answer
 $int = Real(sqrt($b**2+$c**2+1)*$a**3*($c+$b)/(6*$c**2*$b**2));
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
-Evaluate the surface integral \(\int\limits_\sigma\!\!\int f(x,y,z)dS\)
+Evaluate the surface integral \(\int\limits_\sigma\!\!\int f(x,y,z)\,dS\)
 where \(f=$f\) and \(\sigma\) is the portion of the plane \($a - $b x - $c y\) in the first octant.
 Then 
 $PAR
 \{ BeginTable(center=>0).
-      Row(['\(\displaystyle\int\limits_\sigma\!\!\int f(x,y,z)dS = \int_a^b\int_c^d F(u,v)dudv\)'],separation=>1).
+      Row(['\(\displaystyle\int\limits_\sigma\!\!\int f(x,y,z)\,dS = \int_a^b\int_c^d F(u,v)\,du\,dv\)'],separation=>1).
    EndTable();
 \}
 \{ BeginTable(center=>0).
-      Row([$SPACE,$SPACE,'=',tableintegral(),tableintegral(),ans_rule,'\(dudv  \)'],separation=>1).
+      Row([$SPACE,$SPACE,'=',tableintegral(),tableintegral(),ans_rule,'\(du\,dv  \)'],separation=>1).
    EndTable();
 \}
 $BR

--- a/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian1.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian1.pg
@@ -94,6 +94,7 @@ $tf ->choose(1);  # Using choose(3) would choose all three questions, but the or
 
 
 
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT

--- a/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian2.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian2.pg
@@ -94,6 +94,7 @@ $tf ->choose(1);  # Using choose(3) would choose all three questions, but the or
 
 
 
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT

--- a/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian3.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian3.pg
@@ -90,12 +90,11 @@ $tf ->choose(1);  # Using choose(3) would choose all three questions, but the or
 
 
 
-
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT
 $PAR
-$y1
 It can be shown that \(y_1=e^{-$a x}\)  and \(y_2=xe^{-$a x}\)  are 
 solutions to the differential equation 
 \(D^2 y +$c Dy + $d y =0\)

--- a/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian3A.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian3A.pg
@@ -91,6 +91,7 @@ $tf ->choose(1);  # Using choose(3) would choose all three questions, but the or
 
 
 
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT

--- a/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian4.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian4.pg
@@ -110,6 +110,7 @@ $tf ->choose(1);  # Using choose(3) would choose all three questions, but the or
 
 
 
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT

--- a/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian5.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/fundamentalset/Wronksian5.pg
@@ -103,6 +103,7 @@ $tf ->choose(1);  # Using choose(3) would choose all three questions, but the or
 
 
 
+TEXT(beginproblem());
 
 Context()->texStrings;
 BEGIN_TEXT

--- a/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian1.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian1.pg
@@ -52,6 +52,8 @@ $w = Compute("-($b+$a)*e^(($a-$b)x)");
 $interval = Context("Interval");
 $int = Compute("(-inf,inf)");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 $PAR

--- a/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian2.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian2.pg
@@ -50,6 +50,8 @@ $w = Formula($context,"1");
 $interval = Context("Interval");
 $int = Compute("(-inf,inf)");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 $PAR

--- a/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian3.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian3.pg
@@ -52,6 +52,8 @@ $w = Compute("e^($c*x)");
 $interval = Context("Interval");
 $int = Compute("(-inf,inf)");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 $PAR

--- a/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian3A.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian3A.pg
@@ -54,6 +54,8 @@ $w = Formula($context,"e^($c*x)*$b")->reduce;
 Context("Interval");
 $int=Compute("(-inf,inf)");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 $PAR

--- a/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian4.pg
+++ b/OpenProblemLibrary/AlfredUniv/diffeq/theorylinear/Wronskian4.pg
@@ -59,6 +59,8 @@ $w = Compute("x^(-1-$u-$v)*($u-$v)*($v-1)*($u-1)*$e");
 Context("Interval");
 $int = Compute("(0,inf)");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 $PAR


### PR DESCRIPTION
1) Add missing TEXT(beginproblem()); 
2) In Wronskian3.pg there was an out of place "$y1" (probably from a
prior debugging attempt that wasn't cleaned up), that's just the first
function which is printed correctly on the same line.
3) In some of the other problems there was no space between the dxdy
and such, making things like zdxdydz really tough to read, so add
some consistent spacing.  Some of the integrals were inconsistently
sized as well. And as a really very minor point add some "{}" to
make spacing around operators consistent.