### PR TITLE
Possible incorrect conditional probability

### DIFF
--- a/OpenProblemLibrary/UVA-Stat/setStat212-Homework04/stat212-HW04-18.pg
+++ b/OpenProblemLibrary/UVA-Stat/setStat212-Homework04/stat212-HW04-18.pg
@@ -41,6 +41,7 @@ $a = random(5,10,1);
 $b = random(25,35,1);
 $d = .01*$a;
 $e = .01*$b;
+$f = 1-$d;
 $g = 1-$e;
 
 BEGIN_TEXT
@@ -70,6 +71,6 @@ $BR
 
 END_TEXT
 
-ANS(num_cmp(($e*0.80)/(($e*0.80)+($g*$d))) );
+ANS(num_cmp(($e*$f)/(($e*$f)+($g*$d))) );
 
 ENDDOCUMENT();       # This should be the last executable line in the problem.


### PR DESCRIPTION
I always find these probability problems to be quite tricky.  Hopefully this analysis is correct.

I believe that since this is worded as the conditional probability P(rej|pos), then if this is supposed to be a Bayes' theorem problem we would have to turn it into something involving P(pos) in a law of total probability sense.  That is, P(rej|pos) = P(pos|rej)*P(rej) /  P(pos), where P(pos) = P(pos|rej)*P(rej) + P(pos|not-rej)*P(not-rej).  In words, the probability of a positive test is the sum of the situation where it's positive and actually being rejected and the one where it's positive and not being actually rejected.

The probability of P(pos|not-rej) is indeed `$d`, and `$e` and `$g` are defined to be the complementary probabilities of rejection and non-rejection.  But P(pos|rej) should be `1-$d`, since both of them are about positive tests.  The negative test number hardcoded 20 shouldn't be relevant.

My apologies for putting this all in a commit message, but I didn't want to clutter up GH by putting in a separate issue and PR when I had found the solution, or so I believe.