### PR TITLE
Answer checkers were not working in part 2

### DIFF
--- a/OpenProblemLibrary/Hope/Multi1/01-05-Lines-planes/Planes_graphical_01.pg
+++ b/OpenProblemLibrary/Hope/Multi1/01-05-Lines-planes/Planes_graphical_01.pg
@@ -186,6 +186,16 @@ sub solution_for_xz {
 } # end solution_for_xz
 
 
+$threepoints = List("($a,0,0), ($a,1,0), ($a,0,1)")->cmp(list_checker=>~~&three_point_checker);
+
+$onept1 = Point("(0,$b,0)")->cmp(showCoordinateHints => 0, checker=>~~&solution_for_y);
+
+$threevects = List("<1,0,0>, <0,0,1>")->cmp(list_checker=>~~&two_vector_checker);
+
+$onept2 = Point("(0,0,$c)")->cmp(showCoordinateHints => 0, checker=>~~&solution_for_z);
+
+$perpvect = Vector("<0,0,1>")->cmp(parallel => 1);
+
 #######################################
 
 Scaffold::Begin(
@@ -222,19 +232,19 @@ Section::Begin("Part 2: One plane");
 BEGIN_PGML
 a. A plane is uniquely determined by three distinct, non-collinear points on the plane.  Find three distinct, non-collinear points on the plane [`x = [$a]`].
 
-    + Three distinct, non-collinear points on the plane [`x=[$a]`]: [________________________]{List("($a,0,0), ($a,1,0), ($a,0,1)")->cmp(list_checker=>~~&three_point_checker)} [@ AnswerFormatHelp("points") @]*
+    + Three distinct, non-collinear points on the plane [`x=[$a]`]: [________________________]{$threepoints} [@ AnswerFormatHelp("points") @]*
 
 b. A plane is uniquely determined by one point on the plane and two non-parallel vectors that are parallel to the plane.  Find one point on the plane [`y = [$b]`] and two non-parallel vectors that are parallel to the plane [`y = [$b]`].
 
-    + One point on the plane [`y=[$b]`]: [________________________]{Point("(0,$b,0)")->cmp(showCoordinateHints => 0, checker=>~~&solution_for_y)} [@ AnswerFormatHelp("points") @]*
+    + One point on the plane [`y=[$b]`]: [________________________]{$onept1} [@ AnswerFormatHelp("points") @]*
 
-    + Two non-parallel vectors that are parallel to the plane [`y=[$b]`]: [________________________]{List("<1,0,0>, <0,0,1>")->cmp(list_checker=>~~&two_vector_checker)} [@ AnswerFormatHelp("vectors") @]*
+    + Two non-parallel vectors that are parallel to the plane [`y=[$b]`]: [________________________]{$threevects} [@ AnswerFormatHelp("vectors") @]*
 
 c. A plane is uniquely determined by one point on the plane and one vector perpendicular to the plane.  Find one point on the plane [`z = [$c]`] and one vector perpendicular to the plane [`z = [$c]`].
 
-    + One point on the plane [`z=[$c]`]: [________________________]{Point("(0,0,$c)")->cmp(showCoordinateHints => 0, checker=>~~&solution_for_z)} [@ AnswerFormatHelp("points") @]*
+    + One point on the plane [`z=[$c]`]: [________________________]{$onept2} [@ AnswerFormatHelp("points") @]*
 
-    + One vector perpendicular to the plane [`z=[$c]`]: [________________________]{Vector("<0,0,1>")->cmp(parallel => 1)} [@ AnswerFormatHelp("vectors") @]*
+    + One vector perpendicular to the plane [`z=[$c]`]: [________________________]{$perpvect} [@ AnswerFormatHelp("vectors") @]*
 END_PGML
 Section::End();
 


### PR DESCRIPTION
Move the answer checkers, create variables for them and reference them
in the PGML answer fields seems to fix it.

For some reason, the answer checkers in part 2 were all wonky.  The first one kept insisting that three points were not entered, although they clearly were.  The second answer blank has the actual code of the answer checker as correct answer, and so on. 

Moving the answer checkers into separate variables, and using the variables in the PGML answer fields instead the answer checker code seems to fix the problem.  Strangely, part 3 has actual answer checker code in the PGML answer fields, and it seems to work fine.