### PR TITLE
Fix display in solution, add consistent spacing, add parentheses

### DIFF
--- a/OpenProblemLibrary/Michigan/Chap18Sec1/Q31.pg
+++ b/OpenProblemLibrary/Michigan/Chap18Sec1/Q31.pg
@@ -109,7 +109,7 @@ ANS($cValue->cmp() );
 
 $whichAxis = ( 'x', 'y', 'z' )[$whichChg];
 $whichVec  = ( 'i', 'j', 'k' )[$whichChg];
-$ine = $cRelate->correct_ans();
+$ine = $sgn[$whichChg] eq '-' ? '>' : '<';
 
 Context()->texStrings;
 SOLUTION(EV3(<<'END_SOLUTION'));

--- a/OpenProblemLibrary/Michigan/Chap18Sec2/Q27.pg
+++ b/OpenProblemLibrary/Michigan/Chap18Sec2/Q27.pg
@@ -67,11 +67,11 @@ TEXT(beginproblem());
 BEGIN_TEXT
 
 Evaluate the line integral
-\( \int_C $a y dx + $b x dy \) where \( C \) is the
+\( \int_C $a y \, dx + $b x \, dy \) where \( C \) is the
 straight line path from \( ($x0,$y0) \) to \( ($x1, $y1) \).
 
 $PAR
-\( \int_C $a y dx + $b x dy = \) \{ ans_rule(45) \}
+\( \int_C $a y \, dx + $b x \, dy = \) \{ ans_rule(45) \}
 
 END_TEXT
 Context()->normalStrings;
@@ -92,7 +92,7 @@ Parameterize \(C\):
 \[ x= $x0 + $mx t, \qquad y = $y0 + $my t, \qquad 0\le t \le 1,\]
 so that  \(dx= $mx\, dt\) and \(dy = $my\,dt\).  Hence
 \[
-\int_C $a y dx + $b x dy =
+\int_C $a y \, dx + $b x \, dy =
 \int_0^1 $a($y0 + $my t)$mx\, dt + $b($x0 + $mx t)$my\, dt =
 \int_0^1 $k1 + $k2 t\, dt = $int.\]
 

--- a/OpenProblemLibrary/Michigan/Chap20Sec3/Q18.pg
+++ b/OpenProblemLibrary/Michigan/Chap20Sec3/Q18.pg
@@ -93,14 +93,14 @@ Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
 
-Let \( \mbox{curl}\vec F = $curlf \), let \( P =($x0,$y0,$z0) \), and let
+Let \( \mbox{curl }\vec F = $curlf \), let \( P =($x0,$y0,$z0) \), and let
 \( C \) be the circle of radius $r0 centered at \( P \) in the plane
 \( x+y+z = $z1 \), oriented clockwise when viewed from the origin.
 $PAR
 ${BBOLD}(a)$EBOLD
-Find \( \mbox{curl}\vec F\cdot(\vec i+\vec j+\vec k) \) at \( P \).
+Find \( \mbox{curl }\vec F\cdot(\vec i+\vec j+\vec k) \) at \( P \).
 $BR
-\( \mbox{curl}\vec F\cdot(\vec i+\vec j+\vec k) = \) \{ ans_rule(35) \}
+\( \mbox{curl }\vec F\cdot(\vec i+\vec j+\vec k) = \) \{ ans_rule(35) \}
 
 $PAR
 ${BBOLD}(b)$EBOLD
@@ -119,9 +119,9 @@ SOLUTION(EV3(<<'END_SOLUTION'));
 $PAR SOLUTION $PAR
 
 ${BBOLD}(a)$EBOLD
-At \(P\), we have \(\mbox{curl} \vec F = $curlf0\), so
+At \(P\), we have \(\mbox{curl } \vec F = $curlf0\), so
 \[
-\mbox{curl}\vec F\cdot(\vec i+\vec j+\vec k) =
+\mbox{curl }\vec F\cdot(\vec i+\vec j+\vec k) =
 ($cf0[0]) + ($cf0[1]) + ($cf0[2]) = $curlf0dot.
 \]
 
@@ -131,13 +131,13 @@ The definition of the curl tells us that if \(\vec n\) is the unit vector
 normal to the plane containing the circle and pointing away from the origin,
 then
 \[
-\mbox{curl} \vec F\cdot\vec n\approx
+\mbox{curl } \vec F\cdot\vec n\approx
 \frac{\int_C\vec F\cdot d\vec r}{\hbox{Area enclosed by }C}.
 \]
 Since \(\vec n=(\vec i+\vec j+\vec k)/\sqrt 3\), we have
 \[
 \int_C\vec F\cdot d\vec r\approx
-    (\mbox{curl}\vec F \cdot\vec n)\mbox{Area of circle}
+    (\mbox{curl }\vec F \cdot\vec n)(\mbox{Area of circle})
   = \frac{$curlf0dot}{\sqrt 3}\pi($r0)^2 = $circ.
 \]
 

--- a/OpenProblemLibrary/Michigan/Chap20Sec3/Q19.pg
+++ b/OpenProblemLibrary/Michigan/Chap20Sec3/Q19.pg
@@ -78,7 +78,7 @@ and around \( S_3 \) of \( $circ2 \).
 Estimate curl \( \vec G \) at the point \( ($x0, $y0, $z0) \)
 
 $PAR
-\(\mbox{curl}\vec G \approx \) \{ ans_rule(35) \}
+\(\mbox{curl }\vec G \approx \) \{ ans_rule(35) \}
 
 END_TEXT
 Context()->normalStrings;


### PR DESCRIPTION
In 18.1 Q31 correctly set up $ine so that it contains the right string and not the HTML entity to fix error in output.
In the other problems add consistent spacing (before dx and dy and after "curl")
In 20.3 Q18 also add parenthesis to make solution more readable