### PR TITLE
Fix ambiguous discrete/continuous data matching problem.

### DIFF
--- a/Contrib/Piedmont/OnlineMATH2100/MidtermExam/2.pg
+++ b/Contrib/Piedmont/OnlineMATH2100/MidtermExam/2.pg
@@ -49,7 +49,7 @@ TEXT(beginproblem());
     "Number of coins presently in someone's pockets and/or purse.",
     "The petal length of an iris flower.",
     "The age of a UK resident.",
-    "The number of cigarettes smoked per day by a UK resident."    
+    "The number of cigarettes smoked on a given day by a UK resident."
 );
 
 @answers = (


### PR DESCRIPTION
The number of cigarettes smoked "per day" could be interpreted as an average,
which could be considered continous as we'd be dividing by some unknown
sample size.

Since the variable is intended to be discrete, the wording has been changed
to "on a given day" to remove any ambiguity.