### PR TITLE
More fixes from the script (plus a couple of fixes I found along the way)

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/2.1.23.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/2.1.23.pg
@@ -1,10 +1,20 @@
 # DESCRIPTION
-# A first problem looking at subspaces
-# ENDDESCRIPTION
-
-##\{ textbook_ref_exact("Holt Linear Algebra", "2.1","23") \}
 # Solving vector equations for unknowns
 # ENDDESCRIPTION
+
+## DBsubject(Linear algebra)
+## DBchapter(Systems of linear equations)
+## DBsection(Vector equations)
+## Institution(Saint Louis University)
+## Author(Mike May)
+## MLT(LinCombVectWithParam)
+## Level(2)
+## TitleText1('Linear Algebra')
+## AuthorText1('Holt')
+## EditionText1('')
+## Section1('2.1')
+## Problem1('23')
+## KEYWORDS('linear algebra','vectors')
 
 ##\{ textbook_ref_exact("Holt Linear Algebra", "2.1","23") \}
 
@@ -75,99 +85,15 @@ ANS(num_cmp($a));
 ANS(num_cmp($b));
 
 Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
+BEGIN_SOLUTION
 $PAR 
 SOLUTION 
 $PAR
-\[a=($v31-$a2*$v21)/$a1=$a\]
-\[b=($v32-$a1*$v12)/$a2=$b\]
-
-
-
-END_SOLUTION
-Context()->normalStrings;
-
-ENDDOCUMENT();
-## DBsubject(Linear algebra)
-## DBchapter(Systems of linear equations)
-## DBsection(Vector equations)
-## Institution(Saint Louis University)
-## Author(Mike May)
-## MLT(LinCombVectWithParam)
-## Level(2)
-## TitleText1('Linear Algebra')
-## AuthorText1('Holt')
-## EditionText1('')
-## Section1('2.1')
-## Problem1('23')
-## KEYWORDS('linear algebra','vectors')
-
-DOCUMENT();
-
-# make sure we're in the context we want
-Context("Numeric");
-$v11=random(1,9,1);
-$v12=random(-9,9,1);
-$v13=random(-9,9,1);
-$v21=random(-9,9,1);
-$v22=random(1,9,1);
-$v23=random(-9,9,1);
-if($v11*$v22==$v12*$v21){$v22=-$v22;}
-$v31=random(1,9,1)*random(-1,1,2);
-$v32=random(-9,9,1);
-$v33=random(1,9,1);
-if($v11*$v22*$v33+$v21*$v32*$v13+$v31*$v12*$v23-$v13*$v22*$v31-$v23*$v32*$v11-$v33*$v12*$v21==0){$v33=-$v33;}
-
-$a1=random(1,9,1);
-$a2=random(1,9,1)*random(-1,1,2);
-$a3=random(1,9,1)*random(-1,1,2);
-
-$a=($v31-$a2*$v21)/$a1;
-$b=($v32-$a1*$v12)/$a2;
-
-
-
-
-TEXT(beginproblem());
-$showPartialCorrectAnswers = 0;
-BEGIN_TEXT
-\{ textbook_ref_exact("Holt Linear Algebra", "2.1","23") \} 
-$PAR
-Solve for the unknowns in the vector equation below. 
-$PAR
-\($a1 
-\left[\begin{matrix} a \cr $v12 \cr \end{matrix}\right] 
-+$a2
-\left[\begin{matrix} $v21 \cr b \cr \end{matrix}\right]
- =
-\left[\begin{matrix}  $v31 \cr $v32 \cr \end{matrix}\right]
-\)
-$PAR
-
-$PAR
-\(a= \)\{ans_rule(10)\}
-$PAR
-\(b= \)\{ans_rule(10)\}
-$PAR
-
-END_TEXT
-Context()->normalStrings;
-
-$showPartialCorrectAnswers = 1;
-
-ANS(num_cmp($a));
-ANS(num_cmp($b));
-
-Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
-$PAR 
-SOLUTION 
-$PAR
-\[a=($v31-$a2*$v21)/$a1\]
-\[b=($v32-$a1*$v11)/$a2\]
-
-
-
+We obtain two equations
+\($a1 a +$a2($v21) = $v31\) and
+\($a1 ($v12) +$a2 b = $v32\).  Solving for \(a\) and \(b\) we get
+\[a=\frac{$v31-($a2)($v21)}{$a1}=$a ,\]
+\[b=\frac{$v32-($a1)($v12)}{$a2}=$b .\]
 END_SOLUTION
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/2.2.32.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/2.2.32.pg
@@ -2,8 +2,18 @@
 # A first problem looking at subspaces
 # ENDDESCRIPTION
 
-## DBchapter('Euclidean Space')# DESCRIPTION
-# ENDDESCRIPTION
+## DBsubject(Linear algebra)
+## DBchapter(Euclidean spaces)
+## DBsection(Span)
+## Institution(Saint Louis University)
+## Author(Mike May)
+## Level(3)
+## TitleText1('Linear Algebra')
+## AuthorText1('Holt')
+## EditionText1('')
+## Section1('2.2')
+## Problem1('32')
+## KEYWORDS('subspaces')
 
 ##\{ textbook_ref_exact("Holt Linear Algebra", "2.2","32") \}
 
@@ -102,7 +112,7 @@ ANS( radio_cmp( $mc->correct_ans() ) );
 
 
 Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
+BEGIN_SOLUTION
 $PAR SOLUTION $PAR
 Row reducing shows us
 $PAR
@@ -112,123 +122,7 @@ $A31 & $A32 & $A33& $A34  \cr \end{matrix}}\right]\sim
  $red31 & $red32 & $red33 & $red34 \cr \end{matrix}\right]
 \]
 $PAR
-Since we have a row of zeros, we conclude that there not is a solution for every \({\bf b} \in {\mathbb R}^3\).
-END_SOLUTION
-Context()->normalStrings;
-
-ENDDOCUMENT();
-##\{ textbook_ref_exact("Holt Linear Algebra", "2.2","32") \}
-## DBsubject(Linear algebra)
-## DBchapter(Euclidean spaces)
-## DBsection(Span)
-## Institution(Saint Louis University)
-## Author(Mike May)
-## Level(3)
-## TitleText1('Linear Algebra')
-## AuthorText1('Holt')
-## EditionText1('')
-## Section1('2.2')
-## Problem1('32')
-## KEYWORDS('subspaces')
-
-DOCUMENT();
-
-# make sure we're in the context we want
-Context("Numeric");
-# We start by producing the row reduced matrix.
-# This is upper triangular
-$red11=1;
-$red12=random(1,5,1)*random(-1,1,2);
-$red13=random(1,5,1)*random(-1,1,2);
-$red21=0;
-$red22=1;
-$red23=random(1,5,1)*random(-1,1,2);
-$red31=0;
-$red32=0;
-$red33=0;
-
-# Next we produce the scalars that will be used in Gauss elimination.
-# This is an lower triangular matrix
-$m11=random(1,6,1)*random(-1,1,2);
-$m12=0;
-$m13=0;
-$m21=random(1,5,1)*random(-1,1,2);
-$m22=random(1,5,1)*random(-1,1,2);
-$m23=0;
-$m31=random(1,5,1)*random(-1,1,2);
-$m32=random(1,5,1)*random(-1,1,2);
-$m33=random(1,5,1)*random(-1,1,2);
-
-# We are ready to produce our matrix A.
-$A11=$m11*$red11+$m12*$red21+$m13*$red31;
-$A12=$m11*$red12+$m12*$red22+$m13*$red32;
-$A13=$m11*$red13+$m12*$red23+$m13*$red33;
-$A21=$m21*$red11+$m22*$red21+$m23*$red31;
-$A22=$m21*$red12+$m22*$red22+$m23*$red32;
-$A23=$m21*$red13+$m22*$red23+$m23*$red33;
-$A31=$m31*$red11+$m32*$red21+$m33*$red31;
-$A32=$m31*$red12+$m32*$red22+$m33*$red32;
-$A33=$m31*$red13+$m32*$red23+$m33*$red33;
-
-
-# the arguments of PopUp are [list of answers], 
-#    correct answer
-$mc = new_multiple_choice();
-$mc->qa(
-"",
-"There is not a solution for every \({\bf b} \in {\mathbb R}^3\)."
-);
-$mc->extra(
-"There is a solution for every \({\bf b} \in {\mathbb R}^3\).",
-);
-$mc->makeLast("We cannot tell if there is a solution for every \({\bf b} \in {\mathbb R}^3\).");
-
-TEXT(beginproblem());
-$showPartialCorrectAnswers = 0;
-Context()->texStrings;
-BEGIN_TEXT
-\{ textbook_ref_exact("Holt Linear Algebra", "2.2","32") \} 
-$PAR
-Let 
-\(A = 
-\left[{\begin{matrix}$A11 & $A12 & $A13 \cr $A21 & $A22 & $A23 \cr  
-$A31 & $A32 & $A33 \cr \end{matrix}}\right]\).
-$PAR
-We want to determine if the system  \(A{\bf x}={\bf x}\) has a solution for every \({\bf b} \in {\mathbb R}^3\).$PAR
-To check this we add \{ans_rule(6)\} times the first row to the second.  
-$BR
-We then add \{ans_rule(6)\} times the first row to the third.  
-$BR
-We then add \{ans_rule(6)\} times the new second row to the new third row.  
-$BR
-We conclude that 
-$PAR
-\{ $mc->print_a() \}
-$PAR
-
-END_TEXT
-Context()->normalStrings;
-
-$showPartialCorrectAnswers = 1;
-
-ANS(num_cmp(-$m21/$m11));
-ANS(num_cmp(-$m31/$m11));
-ANS(num_cmp(-$m32/$m22));
-ANS( radio_cmp( $mc->correct_ans() ) );
-
-
-Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
-$PAR SOLUTION $PAR
-Row reducing shows us
-$PAR
-\[\left[{\begin{matrix}$A11 & $A12 & $A13 & $A14 \cr $A21 & $A22 & $A23& $A24  \cr  
-$A31 & $A32 & $A33& $A34  \cr \end{matrix}}\right]\sim
-\left[\begin{matrix}$red11 & $red12 & $red13 & $red14 \cr $red21 & $red22 & $red23 & $red24 \cr
- $red31 & $red32 & $red33 & $red34 \cr \end{matrix}\right]
-\]
-$PAR
-Since we have a row of zeros, we conclude that there not is a solution for every \({\bf b} \in {\mathbb R}^3\).
+Since we have a row of zeros, we conclude that there is not a solution for every \({\bf b} \in {\mathbb R}^3\).
 END_SOLUTION
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.2.11.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.2.11.pg
@@ -5,18 +5,6 @@
 
 ## Tagged by reb 05/27/13
 
-
-## Textbook tags
-## \{ textbook_ref_exact("Holt Linear Algebra", "4.2","11") \}
-
-DOCUMENT();
-# DESCRIPTION
-# Problem from Holt Linear Algebra
-# WeBWorK problem written by Richard Bayne, <rbayne@howard.edu>
-# ENDDESCRIPTION
-
-## Tagged by reb 05/27/13
-
 ## DBsubject(Linear algebra)
 ## DBchapter(Euclidean spaces)
 ## DBsection(Basis and dimension)
@@ -90,13 +78,15 @@ $multians = MultiAnswer($C1,$C2)->with(
 TEXT(beginproblem());
 Context()->texStrings;
 BEGIN_TEXT
-Suppose a subspace is spanned by the set \(S\) of vectors shown below. $BR 
+Suppose a subspace is spanned by the set \(S\) of vectors shown below.
+$PAR 
 \(S = \Bigg $LBRACE\)\($C1\), \($C2\)\(\Bigg $RBRACE\)
-Find a subset of \(S\) that forms a basis for the subspace, using the method of transforming a matrix to echelon form, where the columns of the matrix represent vectors spanning the subspace. $BR
+$PAR
+Find a subset of \(S\) that forms a basis for the subspace, using the method of transforming a matrix to echelon form, where the columns of the matrix represent vectors spanning the subspace.
 
 $PAR
 
-A basis is \(\Bigg $LBRACE\)\{ $multians->ans_array\}, \{ $multians->ans_array\} \(\Bigg $RBRACE\)
+A basis for the subspace is \(\Bigg $LBRACE\)\{ $multians->ans_array\}, \{ $multians->ans_array\} \(\Bigg $RBRACE\)
 
 $PAR
 What is the dimension of the subspace? \{ans_rule(5) \}
@@ -107,16 +97,19 @@ ANS($multians->cmp());
 ANS(Real(2)->cmp());
 
 Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
-$PAR$PAR{BBOLD}SOLUTION:${EBOLD} $PAR
-Row-reduce the matrix which has the given vectors as columns.
-$BR$BR
+BEGIN_SOLUTION
+$SOL $PAR
+Row-reduce the matrix which has the given vectors as columns:
+$PAR
 \(\left[ \begin{array}{cc} $a11 & $a12 \\ 
 $a21 & $a22 \end{array}\right] \sim \left[ \begin{array}{cc} $a11 & $a12 \\ 
 0 & $b22 \end{array} \right]  \)$PAR
-so that a basis for the subspace is given by columns 1 and 2 of the original matrix corresponding to the pivot columns of the row-reduced matrix. Thus a basis for \(S\) is
+So a basis for the subspace is given by columns 1 and 2 of the original matrix corresponding to the pivot columns of the row-reduced matrix.
+In other words, a basis for the subspace is
 $PAR
-\(\Bigg $LBRACE\)\($C1\), \($C2\)\(\Bigg $RBRACE\)
+\(\Bigg $LBRACE\)\($C1\), \($C2\)\(\Bigg $RBRACE\).
+$PAR
+The dimension of the subspace is therefore 2.
 END_SOLUTION
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.3.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.3.pg
@@ -26,8 +26,6 @@
 
 DOCUMENT();
 
-DOCUMENT();
-
 loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",
@@ -222,15 +220,19 @@ ANS($rowans->cmp());
 ANS($nullans->cmp());
 
 Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
-$PAR$PAR{BBOLD}SOLUTION:${EBOLD} $PAR
+BEGIN_SOLUTION
+$SOL $PAR
 A basis for the column space, determined from the pivot columns 1 and 2, is
-$BR
- \(\left$LBRACE \left [ \begin{array}{c} $a11 & $a21 & $a31 \end{array} \right] , \left [ \begin{array}{c} $a12 \\ $a22 \\ $a32 \end{array} \right]\right$RBRACE \)
 $PAR
-A basis  for the row space is determined from the nonzero rows of the echelon form, \(\left$LBRACE \left [ \begin{array}{c} $b11 \\ $b12 \\ $b13 \\ $b14 \end{array} \right] , \left [ \begin{array}{c} $b21 \\ $b22 \\ $b23 \\ $b24 \end{array} \right]\right$RBRACE \)
+ \(\left$LBRACE \left [ \begin{array}{c} $a11 \\ $a21 \\ $a31 \end{array} \right] , \left [ \begin{array}{c} $a12 \\ $a22 \\ $a32 \end{array} \right]\right$RBRACE \) .
 $PAR
-Solve \( A{\bf x} = {\bf 0}\), to obtain \({\bf x} = s_1\left[ \begin{array}{c} -$b13 \\ -$b23 \\ 1 \\ 0 \end{array} \right] + s_2\left[ \begin{array}{c} -$b14 \\ -$b24 \\  0 \\ 1 \end{array} \right] \), and so the nullspace basis is \( \left $LBRACE \left[ \begin{array}{c} -$b13 \\ -$b23 \\ 1 \\ 0 \end{array} \right], \left[ \begin{array}{c} -$b14 \\ -$b24 \\ 0 \\ 1 \end{array} \right] \right $RBRACE\).
+A basis  for the row space is determined from the nonzero rows of the echelon form:
+$PAR
+\(\left$LBRACE \left [ \begin{array}{c} $b11 & $b12 & $b13 & $b14 \end{array} \right] , \left [ \begin{array}{c} $b21 & $b22 & $b23 & $b24 \end{array} \right]\right$RBRACE \).
+$PAR
+Solve \( A{\bf x} = {\bf 0}\), to obtain \({\bf x} = s_1\left[ \begin{array}{c} -$b13 \\ -$b23 \\ 1 \\ 0 \end{array} \right] + s_2\left[ \begin{array}{c} -$b14 \\ -$b24 \\  0 \\ 1 \end{array} \right] \), and so the basis for the nullspace is:
+$PAR
+\( \left $LBRACE \left[ \begin{array}{c} -$b13 \\ -$b23 \\ 1 \\ 0 \end{array} \right], \left[ \begin{array}{c} -$b14 \\ -$b24 \\ 0 \\ 1 \end{array} \right] \right $RBRACE\).
 
 END_SOLUTION
 Context()->normalStrings;

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/11_Parametric_Equations_Polar_Coordinates_and_Conic_Sections/11.2_Arc_Length_and_Speed/11.2.32.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/11_Parametric_Equations_Polar_Coordinates_and_Conic_Sections/11.2_Arc_Length_and_Speed/11.2.32.pg
@@ -1,13 +1,3 @@
-DOCUMENT();
-loadMacros(
-  "PGstandard.pl",
-  "PGchoicemacros.pl",
-  "Parser.pl",
-  "freemanMacros.pl",
-  "PGcourse.pl"
-);
-$context = Context();
-
 ## DBsubject(Calculus - single variable)
 ## DBchapter(Parametric)
 ## DBsection(Surface area of surfaces of revolution)
@@ -24,6 +14,13 @@ $context = Context();
 ## KEYWORDS('calculus', 'parametric', 'polar', 'conic')
 
 DOCUMENT();
+loadMacros(
+  "PGstandard.pl",
+  "PGchoicemacros.pl",
+  "Parser.pl",
+  "freemanMacros.pl",
+  "PGcourse.pl"
+);
 $context = Context();
 
 TEXT(beginproblem());

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/1_Precalculus_Review/1.4_Trigonometric_Functions/1.4.9.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/1_Precalculus_Review/1.4_Trigonometric_Functions/1.4.9.pg
@@ -50,6 +50,8 @@ $anslist = List(Compute("$numa pi / $dena"), Compute("$numb pi / $denb"));
 if($numa != 1){ $shownuma = $numa; };
 if($numb != 1){ $shownumb = $numb; };
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 \{ textbook_ref_exact("Rogawski ET 2e", "1.4","9") \}

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/1_Precalculus_Review/1.7_Technology-_Calculators_and_Computers/1.7.21.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/1_Precalculus_Review/1.7_Technology-_Calculators_and_Computers/1.7.21.pg
@@ -38,6 +38,8 @@ $ci = Compute("($c,inf)");
 @possible = (Compute("$ab U $ci"), Compute("$ia U $bc"));
 $ans = $possible[$s_sidx];
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 \{ textbook_ref_exact("Rogawski ET 2e", "1.7", "21") \}

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.2_Limits-_A_Numerical_and_Graphical_Approach/2.2.5.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.2_Limits-_A_Numerical_and_Graphical_Approach/2.2.5.pg
@@ -1,9 +1,5 @@
 #Problem 2.2.5 ET2e
 
-DOCUMENT();
-
-
-
 ## DBsubject(Calculus - single variable)
 ## DBchapter(Limits and continuity)
 ## DBsection(Finding limits using graphs)

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.6_Trigonometric_Limits/2.6.12.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.6_Trigonometric_Limits/2.6.12.pg
@@ -1,9 +1,5 @@
 #Problem 2.6.12
 
-DOCUMENT();
-
-
-
 ## DBsubject(Calculus - single variable)
 ## DBchapter(Limits and continuity)
 ## DBsection(Squeeze theorem)

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.6_Trigonometric_Limits/2.6.2.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/2_Limits/2.6_Trigonometric_Limits/2.6.2.pg
@@ -1,7 +1,5 @@
 #Problem 2.6.2
 
-DOCUMENT();
-
 ## DBsubject(Calculus - single variable)
 ## DBchapter(Limits and continuity)
 ## DBsection(Squeeze theorem)

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/3_Differentiation/3.2_The_Derivative_as_a_Function/3.2.52.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/3_Differentiation/3.2_The_Derivative_as_a_Function/3.2.52.pg
@@ -33,6 +33,8 @@ $root1 = 0;
 Context()->flags->set(reduceConstants=>0,reduceConstantFunctions=>0);
 $root2 = Formula("$a/$b");
 
+TEXT(beginproblem());
+
 Context()->texStrings;
 BEGIN_TEXT
 Find all values of \( x \) where the tangent lines to \( y=$f \) and \( y=$g \) are parallel.

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/6_Applications_of_the_Integral/6.4_The_Method_of_Cylindrical_Shells/6.4.27.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/6_Applications_of_the_Integral/6.4_The_Method_of_Cylindrical_Shells/6.4.27.pg
@@ -35,7 +35,6 @@ $n5=$n/2;
 
 BEGIN_TEXT
 \{ textbook_ref_exact("Rogawski ET 2e", "6.4","27") \}$BR
-$PAR
 Use both the Shell and Disk Methods to calculate the volume of the solid obtained
 by rotating the region under the graph of \(f (x) = $n - x^3\) for \(0 \le x \le {$n}^{\frac{1}{3}}\) 
 about the \(x\)-axis and the \(y\)-axis. $PAR
@@ -154,5 +153,4 @@ S_y&= 2\pi\int_{0}^{$n^{\frac{1}{3}}}x($n-x^3)dx\cr
 
 
 END_SOLUTION
-ENDDOCUMENT();
 ENDDOCUMENT();

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/6_Applications_of_the_Integral/6.4_The_Method_of_Cylindrical_Shells/6.4.9.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/6_Applications_of_the_Integral/6.4_The_Method_of_Cylindrical_Shells/6.4.9.pg
@@ -11,7 +11,6 @@
 ## Problem1('9')
 ## KEYWORDS('calculus', 'integration', 'integrals', 'volumes of revolution', 'revolution', 'shell method', 'area between curves')
 DOCUMENT();
-DOCUMENT();
 
 # Load whatever macros you need for the problem
 loadMacros(

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.13.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.13.pg
@@ -12,7 +12,6 @@
 ## Problem1('13')
 ## KEYWORDS('calculus', 'integrals', 'integration', 'center of mass', 'centroid')
 DOCUMENT();
-DOCUMENT();
 
 # Load whatever macros you need for the problem
 loadMacros(

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.15.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.15.pg
@@ -12,7 +12,6 @@
 ## Problem1('15')
 ## KEYWORDS('calculus', 'integrals', 'integration', 'center of mass', 'centroid')
 DOCUMENT();
-DOCUMENT();
 
 # Load whatever macros you need for the problem
 loadMacros(

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.17.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.17.pg
@@ -12,7 +12,6 @@
 ## Section1('8.3')
 ## Problem1('17')
 ## KEYWORDS('calculus', 'integrals', 'integration', 'center of mass', 'centroid')
-DOCUMENT();
 
 DOCUMENT();
 

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.21.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.21.pg
@@ -12,7 +12,6 @@
 ## Problem1('21')
 ## KEYWORDS('calculus', 'integrals', 'integration', 'center of mass', 'centroid')
 DOCUMENT();
-DOCUMENT();
 
 # Load whatever macros you need for the problem
 loadMacros(

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.23.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.23.pg
@@ -12,7 +12,6 @@
 ## Section1('8.3')
 ## Problem1('23')
 ## KEYWORDS('calculus', 'integrals', 'integration', 'center of mass', 'centroid')
-DOCUMENT();
 
 DOCUMENT();
 

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.25.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/8_Further_Applications_of_the_Integral_and_Taylor_Polynomials/8.3_Center_of_Mass/8.3.25.pg
@@ -12,7 +12,6 @@
 ## Section1('8.3')
 ## Problem1('25')
 ## KEYWORDS('calculus', 'integrals', 'integration', 'center of mass', 'centroid')
-DOCUMENT();
 
 DOCUMENT();
 


### PR DESCRIPTION
In 2.1.23 remove dead code beyond ENDDOCUMENT (although it was essentially a duplicate so git thinks I removed the first part and modified the second, while I just removed things after the first ENDDOCUMENT).  I also improved the solution, it was not nicely formatted.

In 2.2.32 again remove dead code beyond ENDDOCUMENT and fixed minor english typo (again git thinks I removed the first bit and modified the second).

In 4.2.11, I removed an extra "DOCUMENT()" and fixed the wording.  The problem is still very stupid, but it'd require remaking the answer logic.  It asks for a subset of two vectors, but the answer blanks are for two vectors, so ... At least the wording is now correct, if stupid.

In 4.3.3, I removed an extra DOCUMENT(), and fixed the solution, some column vectors were listed as row vectors and vice versa

In the rest of the problems I removed extra "DOCUMENT()"s in some and added missing "TEXT(beginproblem())"s in others