### PR TITLE
Fixes small typo: "reate" -> "rate"

### DIFF
--- a/OpenProblemLibrary/Rochester/setProbability8BinomialDist/ur_pb_8_2.pg
+++ b/OpenProblemLibrary/Rochester/setProbability8BinomialDist/ur_pb_8_2.pg
@@ -99,7 +99,7 @@ if ($tag2 == 0){
 BEGIN_TEXT
 
 The rates of on-time flights for commercial jets are continuously tracked by the U.S. Department of Transportation. 
-Recently, Southwest Air had the best reate with 80 $PERCENT of its flights arriving on time.
+Recently, Southwest Air had the best rate with 80 $PERCENT of its flights arriving on time.
 A test is conducted by randomly selecting \( $n \) Southwest flights and observing whether they arrive on time. 
 
 (a) \( \) $quest1[$tag1] $BR


### PR DESCRIPTION
This pull request fixes an innocuous, but strange, typo in the problem statement.
80% is clearly referring to a rate (not a reate).