### PR TITLE
Fix answers on line-integrals-lines2.pg.  

### DIFF
--- a/Contrib/OKState/VectorCalculus/line-integrals-lines1.pg
+++ b/Contrib/OKState/VectorCalculus/line-integrals-lines1.pg
@@ -51,13 +51,13 @@ Compute the following integrals:
 a) If [:C:] is a
 straight line from [`(0,0)`] to [`([$a],[$b])`], compute  
 [``\int_C [$c] x \, dx + [$d] y \, dy ={}``]
-[_______________]{"($b^2*$d+$a^2*$c)/2"}
+[_______________]{"($b^2*$d+$a^2*$c)/2"}{40}
 [@ AnswerFormatHelp("numbers") @]*
 
 b) If [:C:] is a
 straight line from [`([$e],[$f])`] to [`(1,0)`], compute  
 [``\int_C [$g] x^{2}y \, dx + [$h] xy^{3} \, dy ={}``]
-[_______________]{"-((12*$e+3)*$f^4*$h+(15*$e^3-5*$e^2-5*$e-5)*$f*$g)/60"}
+[_______________]{"-((12*$e+3)*$f^4*$h+(15*$e^3-5*$e^2-5*$e-5)*$f*$g)/60"}{40}
 [@ AnswerFormatHelp("numbers") @]*
 
 c) If [:C:] is a
@@ -65,7 +65,7 @@ straight line from [`(1,0)`] to [`(0,1)`]
 and [`\vec{F} = \langle [$a] \pi \cos(\pi y), \pi \sin (\pi x) + [$b] y \rangle`],
 compute  
 [``\int_C \vec{F} \cdot \hat{t} \, ds ={}``]
-[_______________]{"($b+4)/2"}
+[_______________]{"($b+4)/2"}{40}
 [@ AnswerFormatHelp("numbers") @]*
 
 d) If [:C:] is a
@@ -77,7 +77,7 @@ and [`\vec{F} = \langle
 \rangle`],
 compute  
 [``\int_C \vec{F} \cdot \hat{t} \, ds ={}``]
-[_______________]{"($b^2*$h+$a*$b*$g+$a*$c*$f+$a*$b*$e+($c^2+$a^2)*$d+$b*$c^2+2*$a*$b*$c)/2"}
+[_______________]{"($b^2*$h+$a*$b*$g+$a*$c*$f+$a*$b*$e+($c^2+$a^2)*$d+$b*$c^2+2*$a*$b*$c)/2"}{40}
 [@ AnswerFormatHelp("numbers") @]*
 END_PGML
 

--- a/Contrib/OKState/VectorCalculus/line-integrals-lines2.pg
+++ b/Contrib/OKState/VectorCalculus/line-integrals-lines2.pg
@@ -50,14 +50,14 @@ Compute the following integrals:
 a) If [:C:] is a
 straight line from [`(0,0)`] to [`([$a],[$b])`], compute  
 [``\int_C ( [$c] x^2 + [$d] y^2 + [$e] x) \, ds ={}``]
-[_______________]{"($b^2*$d+$a^2*$c)/2"}
+[_______________]{"(sqrt($b^2+$a^2)*(3*$a*$e+2*$b^2*$d+2*$a^2*$c))/6"}{40}
 [@ AnswerFormatHelp("numbers") @]*
 
 b) If [:C:] is a
 straight line from [`(1,-1,0)`] to [`([$a],[$b],[$c])`]
 compute  
 [``\int_C ([$d] xy + [$e] z^2) \, ds ={}``]
-[_______________]{"(sqrt($b^2+$a^2)*(3*$a*$e+2*$b^2*$d+2*$a^2*$c))/6"}
+[_______________]{"(sqrt($c^2+($b+1)^2+($a-1)^2)*(2*$c^2*$e+((2*$a+1)*$b-$a-2)*$d))/6"}{40}
 [@ AnswerFormatHelp("numbers") @]*
 END_PGML
 


### PR DESCRIPTION
How did 10 students get the right answer here.  It is absolutely mind boggling.

So much for "students went through these problems and didn't ask questions, the problems must be fine :)"

Also make the answer blanks longer on both of these problems.  It seems some of the students were typing out the computations, so that gives them more room.