### PR TITLE
fixing "no valid points for comparison" error

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/3_Differentiation/3.7_The_Chain_Rule/3.7.47.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/3_Differentiation/3.7_The_Chain_Rule/3.7.47.pg
@@ -38,7 +38,7 @@ $constant = list_random(4, 9, 16, 25);
 $g = Formula("$coef x + $constant") ->reduce;
 $gprime = Formula("$coef") ->reduce;
 $y = Formula("($g)^(1/2)")->reduce;
-$yprime = Formula(" (1/2) $gprime ($g)^(-1/2)") ->reduce;
+$yprime = Formula(" (1/2) $gprime ($g)^(-1/2)")->reduce->with(limits=>[-$constant/$coef,-$constant/$coef+3]);
 
 Context()->texStrings;
 


### PR DESCRIPTION

<img width="581" alt="Screen Shot 2019-10-15 at 2 49 54 PM" src="https://user-images.githubusercontent.com/3912882/66861402-f7818100-ef5c-11e9-972c-6a5a9915aabd.png">

seed: 4194 "can't generate enough valid points for comparison" even though default [-2,2] should overlap "enough". Solution: manually specify a valid domain for $yprime