### PR TITLE
Really fix bug 3898 by making all the numbers smaller.  Seed 1950 for

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_3/prob3.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_3/prob3.pg
@@ -26,7 +26,7 @@ loadMacros(
   "PGcourse.pl"
 );
 
-#TEXT(beginproblem());
+TEXT(beginproblem());
 Context("Numeric");
 Context()->variables->are(x=>'Real',y=>'Real',z=>'Real',
                           dx=>'Real',dy=>'Real',dz=>'Real');
@@ -34,32 +34,31 @@ Context()->variables->are(x=>'Real',y=>'Real',z=>'Real',
 $showPartialCorrectAnswers = 1;
 
 do {
-  $x1 = random(-10, 10);
-  $y1 = random(-10, 10);
-  $z1 = random(-10, 10);
-  $x2 = $x1 + random(1, 10);
-  $y2 = $y1 + random(1, 10);
-  $z2 = $z1 + random(1, 10);
+  $x1 = non_zero_random(-5, 5);
+  do {
+    $x2 = non_zero_random(-5,5);
+  } while ($x1 == $x2);
+  $y1 = non_zero_random(-5, 5);
+  do {
+    $y2 = non_zero_random(-5,5);
+  } while ($y1 == $y2);
+  $z1 = non_zero_random(-5, 5);
+  do {
+    $z2 = non_zero_random(-5,5);
+  } while ($z1 == $z2);
+} while (abs($x1)+abs($y1)+abs($z1) >= 10 or abs($x2)+abs($y2)+abs($z2) >= 10);
 
-  $a = non_zero_random(-10,10);
+$a = non_zero_random(-5,5);
+do {
   $n1 = random(2,5);
   $n2 = random(2,5);
   $n3 = random(2,5);
+} while($n1+$n2+$n3 >= 10);
 
-  # the function and it's derivatives 
-  $f1 = Formula("$a*x^($n1)*y^($n2)*z^($n3)")->reduce;
-  $w1 = $f1->eval(x=>$x1,y=>$y1,z=>$z1);
-  $w2 = $f1->eval(x=>$x2,y=>$y2,z=>$z2);
-} until ( 
-   abs($w1)<0.5  
-   or abs($w2)<0.5  
-   or ( 10^(-5) < abs($w2/$w1) and 10^5 > abs($w2/$w1))
-) ;  
-#  Per bug 3898, this attempts to restrict parameters to values that 
-#  enable $w1 and $w2 to be compared within the given answer tolerance, 
-#  10^(-7) (relative).
-#  $w1 and $w2 are integers so they're zero if their absolute value is less 
-#  than 0.5
+# the function and its derivatives 
+$f1 = Formula("$a*x^($n1)*y^($n2)*z^($n3)")->reduce;
+$w1 = $f1->eval(x=>$x1,y=>$y1,z=>$z1);
+$w2 = $f1->eval(x=>$x2,y=>$y2,z=>$z2);
 
 # f1 written in a different order
 $f2 = Formula("$a*y^($n2)*x^($n1)*z^($n3)")->reduce; 
@@ -81,12 +80,12 @@ $dhdy = $fz->D('y');
 $ans = Compute("$w2-$w1");
 
 Context("Vector");
-$zero = Vector(0,0,0);
+$zero = Vector(0,0,90);
 
 Context()->texStrings;
 BEGIN_TEXT
-Show that \(\int_{\left($x1,$y1,$z1\right)}^{\left($x2,$y2,$z2\right)}fdx+gdy+hdz = \int_{\left($x1,$y1,$z1\right)}^{\left($x2,$y2,$z2\right)}$diff\) is independent of path:
-$BR
+Show that \(\int_{\left($x1,$y1,$z1\right)}^{\left($x2,$y2,$z2\right)}f\,dx+g\,dy+h\,dz = \int_{\left($x1,$y1,$z1\right)}^{\left($x2,$y2,$z2\right)}$diff\) is independent of path:
+$PAR
 \(\frac {\partial h}{\partial y}\) = \{ans_rule(20)\}
 $BR
 \(\frac {\partial g}{\partial z}\) = \{ans_rule(20)\}
@@ -100,13 +99,13 @@ $BR
 \(\frac {\partial g}{\partial x}\) = \{ans_rule(20)\}
 $BR
 \(\frac {\partial f}{\partial y}\) = \{ans_rule(20)\}
-$BR
+$PAR
 Therefore curl F = \{ans_rule(20)\}
-$BR
+$PAR
 \(\int_{\left($x1,$y1,$z1\right)}^{\left($x2,$y2,$z2\right)}$diff\) = \{ans_rule(20)\}
-
 END_TEXT
 Context()->normalStrings;
+
 ANS($dhdy->cmp());
 ANS($dgdz->cmp());
 ANS($dfdz->cmp());


### PR DESCRIPTION
example was still broken because the answer was on the order of 10^10 (and 10^20 was possible with some seeds) and sometimes the problem logic was not taking it.  I have 11 students, one had issues (actually now looking at their progress, it seems that at least half of them have issues, so to be more precise, one definitely had issues while entering the correct exact answer).  Entering the exact answer for seed 1950 was not being accepted.

So make all numbers smaller.  The largest theoretically possible answer is now 500000, which does not cause trouble (tested), and the problem distinguishes different integers at that range.  Actually I've tested with a bunch of seeds just to be sure.

There is really no reason to have more possible answers than atoms in the universe.  It's less now, but there are still a huge number of possible problem variations (hundreds of thousands at least, if I am counting right).

While there, I also made sure none of the coordinates are 0, so that the function is not trivially zero at one or the other point, making sure that the student understands that it must be evaluated at both points.

And also while there, I improved the spacing somewhat and fixed a commented out TEXT(beginproblem());