### PR TITLE
Fix incorrect answer and solution

### DIFF
--- a/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C03S06-ImplicitDiff/3-6-23.pg
+++ b/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C03S06-ImplicitDiff/3-6-23.pg
@@ -85,7 +85,7 @@ $mFy = Formula(
 $mFy1_s = $mFy->substitute(x => $x1, y => $y1);
 
 Context('Fraction');
-$slope = Fraction(-$Fy1, $Fx1)->reduce;
+$slope = Fraction(-$Fx1, $Fy1)->reduce;
 
 Context()->texStrings;
 BEGIN_TEXT
@@ -113,26 +113,26 @@ Differentiating with respect to \( y \)
 (as \( y \) is to be regarded as the
 independent variable) gives
 \[
-$fa y^3 + $tb x y^2 \, \frac{dx}{dy}
-+ $tb x^2 y + $fc y x^3 \, \frac{dx}{dy}
-+ $cs x^4 - $d = 0,
+$fa y^3 \, \frac{dx}{dy} + $tb x y^2 
++ $tb x^2 y \, \frac{dx}{dy} + $cs x^4 \, \frac{dx}{dy} 
++ $fc y x^3 - $d \, \frac{dx}{dy} = 0,
 \]
 or
 \[
-($Fx) \, \frac{dx}{dy} = $mFy,
+$Fx = \left( $mFy \right) \, \frac{dx}{dy},
 \]
 and therefore
 \[
-\frac{dx}{dy} = \frac{$mFy}{$Fx}.
+\frac{dx}{dy} = \frac{$Fx}{$mFy}.
 \]
 Hence, the slope of the tangent line to the
 curve at the point \( ($x1, $y1) \) (where
 \( y \) is regarded as a function of \( x \))
 is equal to
 \[
-\frac{dx}{dy} = \frac{$mFy1_s}{$Fx1_s}
+\frac{dx}{dy} = \frac{$Fx1_s}{$mFy1_s}
 \textstyle
-= - \frac{$Fy1}{$Fx1}
+= - \frac{$Fx1}{$Fy1}
 $simp.
 \]
 END_SOLUTION


### PR DESCRIPTION
How strange -- this problem incorrectly applies partial implicit differentiation and concludes that the correct answer is the reciprocal of the ACTUAL correct answer. What's even more, someone wrote a solution to justify this incorrect conclusion!