### PR TITLE
utf8 encoding issues

### DIFF
--- a/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-063.pg
+++ b/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-063.pg
@@ -59,7 +59,7 @@ $T_outlet = $h_outlet/$Cp;
 
 
 BEGIN_TEXT
-Air at \(10°C\) and \($P_inlet\) \(kPa\) enters the diffuser of a jet engine steadily with a velocity of \($V_inlet\) \(m/s\). The inlet area of the diffuser is \($A_inlet\) \(m^2\). The air leaves the diffuser with a velocity that is very small compared with the inlet velocity. (Assume \(Cp = 1.005\) and air is ideal gas). $BR Determine: $BR
+Air at \(10^{\circ}C\) and \($P_inlet\) \(kPa\) enters the diffuser of a jet engine steadily with a velocity of \($V_inlet\) \(m/s\). The inlet area of the diffuser is \($A_inlet\) \(m^2\). The air leaves the diffuser with a velocity that is very small compared with the inlet velocity. (Assume \(Cp = 1.005\) and air is ideal gas). $BR Determine: $BR
 $SPACE 1. Specific volume of the air at diffuser inlet $BR
 $SPACE 2. the mass flow rate of the air $BR
 $SPACE 3. the enthalpy of the air leaving the diffuser $BR

--- a/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-064.pg
+++ b/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-064.pg
@@ -65,7 +65,7 @@ An insulated, vertical piston-cylinder device initially
 contains \($Mass_initial\) \(kg\) of water, \($Vapor_initial\) \(kg\) of which is in the vapor phase.
 The mass of the piston is such that it maintains a constant pressure
 of \(200\) \(kPa\) inside the cylinder. Now steam at \(0.5\) \(MPa\) and
-\(350°C\) is allowed to enter the cylinder from a supply line until
+\(350^{\circ}C\) is allowed to enter the cylinder from a supply line until
 all the liquid in the cylinder has vaporized. Determine: $BR 
 $SPACE 1. the initial enthalpy in the cylinder $BR 
 $SPACE 2. the final enthalpy in the cylinder $BR 

--- a/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-067.pg
+++ b/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-067.pg
@@ -62,7 +62,7 @@ BEGIN_TEXT
 Refrigerant-134a enters the evaporator coils placed at
 the back of the freezer section of a household refrigerator at
 \(120\) \(kPa\) with a quality of \(20% \) and leaves at \(120\) \(kPa\)
-and \(-20°C\). If the compressor consumes \($W\) \(W\) of power and
+and \(-20^{\circ}C\). If the compressor consumes \($W\) \(W\) of power and
 the COP of the refrigerator is \($COP\), determine: $BR
 $SPACE 1. the power consumed by the refrigerator  $BR
 $SPACE 2. the mass flow rate of the refrigerant $BR

--- a/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-068.pg
+++ b/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-068.pg
@@ -58,9 +58,9 @@ $QH = $QH_ratesec*($TH-$TL);
 
 BEGIN_TEXT
 The structure of a house is such that it loses heat at a
-rate of \($QH_ratehour\) \(kJ/h\) per \(°C\) difference between the indoors and
+rate of \($QH_ratehour\) \(kJ/h\) per \(^{\circ}C\) difference between the indoors and
 outdoors. A heat pump that requires a power input of \($W\) \(kW\) is
-used to maintain this house at \($TH_C °C\). Determine the lowest
+used to maintain this house at \($TH_C ^{\circ}C\). Determine the lowest
 outdoor temperature for which the heat pump can meet the
 heating requirements of this house, COP of the heat pump and the house's heat loss.
 $PAR

--- a/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-069.pg
+++ b/OpenProblemLibrary/UBC/MECH/MECH2/Thermo/Mech2_2016-2017/UBC-TH-17-069.pg
@@ -61,8 +61,8 @@ $delS = $mass*$Cp*(ln($Tf)-ln($TK));
 
 
 BEGIN_TEXT
-An insulated piston–cylinder device initially contains
-\($V_in\) \(L\) of air at \($P_in\) \(kPa\) and \($T_in °C\). Air is now heated for
+An insulated piston-cylinder device initially contains
+\($V_in\) \(L\) of air at \($P_in\) \(kPa\) and \($T_in ^{\circ}C\). Air is now heated for
 \($t\) \(min\) by a \(200\) \(W\) resistance heater placed inside the cylinder.
 The pressure of air is maintained constant during this
 process. Assume a constant specific heat of \(Cp = 1.02\) \(kJ/kg\cdot K\)). $BR Determine: $BR


### PR DESCRIPTION
These degree symbols cause invalid bytes for utf8 encoding and cause the OPL update script to throw errors.

Should there now be a scan for illegal utf8 characters when moving something from Contrib or Pending into the OPL?  If it is useful, I have found that `grep -r -a -x -v --include=\*.pg '.*' .` catches a file with an illegal character. (And it catches a bunch in Contrib right now.)