### PR TITLE
Fix an error about transpose on correct answer.

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.5.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.5.pg
@@ -88,8 +88,8 @@ Context()->normalStrings;
 ANS($multians1->cmp);
 
 #################
-$basis3=Matrix([ [1, $a12, $a13] ]);
-$basis4=Matrix([ [0, $b22, $b23] ]);
+$basis3=Matrix($a11, $a12, $a13);
+$basis4=Matrix(0, $b22, $b23);
 
 $multians2 = MultiAnswer($basis3, $basis4)->with(
   singleResult => 1,


### PR DESCRIPTION
Not sure why I didn't notice this when I tested it before.  This time I double checked that it really does accept the correct answer, including trying variations on the correct answer.  Also it seems better style to have $a11 instead of 1 in there, even though $a11 is set to 1 in the beginning.