### PR TITLE
Fix bug 4393

### DIFF
--- a/OpenProblemLibrary/METU-NCC/Diff_Eq/linear-nonhomog_euler.pg
+++ b/OpenProblemLibrary/METU-NCC/Diff_Eq/linear-nonhomog_euler.pg
@@ -124,7 +124,7 @@ $multiansBCD = MultiAnswer($y1, $y2, $Wronskian, $real_g, $iFg[0], $iFg[1])->wit
     
     # Part B:
     # check student's y1, y2
-    if ( ($y1stu->class) eq ($y1cor->class) ) {
+    if ( $y1cor->typeMatch($y1stu) ) {
       $dy1stu = $y1stu->D('t');
       $ddy1stu = $dy1stu->D('t');
       my $Ly1stu = Formula("$coef[0]*t^2*$ddy1stu + $coef[1]*t*$dy1stu + $coef[2]*$y1stu"); 
@@ -135,7 +135,7 @@ $multiansBCD = MultiAnswer($y1, $y2, $Wronskian, $real_g, $iFg[0], $iFg[1])->wit
         $self->setMessage(1,"\(y_1\) is not a fundamental solution.");
       }
     }
-    if ( ($y2stu->class) eq ($y2cor->class) ) { 
+    if ( $y2cor->typeMatch($y2stu) ) {
       $dy2stu = $y2stu->D('t');
       $ddy2stu = $dy2stu->D('t');
       my $Ly2stu = Formula("$coef[0]*t^2*$ddy2stu + $coef[1]*t*$dy2stu + $coef[2]*$y2stu"); 
@@ -155,18 +155,18 @@ $multiansBCD = MultiAnswer($y1, $y2, $Wronskian, $real_g, $iFg[0], $iFg[1])->wit
         $self->setMessage(2,"Your fundamental solutions are not independent.");
       }  
       ## check the Wronskiian
-      if ( ($Wstu->class) eq ($Wcor->class) ){ 
+      if ( $Wcor->typeMatch($Wstu) ) {
         if ( $Wstu == $wron ) { $res[2] = 1; }
         else { $self->setMessage(3,"Wronskian is wrong.");}
       }
 
       ## Part D
       ## check the integrals
-      if ( ($iFg1stu->class) eq ($iFg1cor->class) ) {
+      if ( $iFg1cor->typeMatch($iFg1stu) ) {
         if ( $iFg1stu->D('t') == $y1stu*$real_g/$wron ){ $res[4] = 1; }
         else { $self->setMessage(4, "\(\displaystyle \int \frac{y_1g}{W}dt\) is wrong."); }
       }
-      if ( ($iFg2stu->class) eq ($iFg2cor->class) ) {
+      if ( $iFg2cor->typeMatch($iFg2stu) ) {
         if ( $iFg2stu->D('t') == $y2stu*$real_g/$wron ){ $res[5] = 1;}
         else { $self->setMessage(5, "\(\displaystyle \int \frac{y_2g}{W}dt\) is wrong."); }
       }


### PR DESCRIPTION
Fix the bug in METU-NCC/Diff_Eq/linear-nonhomog.pg, in which it would not accept correct answers to the Wronskian question if the Wronskian was a constant function (e.g., it would reject 3 but accept 3t^0).