### PR TITLE
Remove "part 1 of" and "part 2 of" the Fundamental Theorem of Calculus

### DIFF
--- a/OpenProblemLibrary/Rochester/setIntegrals4FTC/sc5_4_14.pg
+++ b/OpenProblemLibrary/Rochester/setIntegrals4FTC/sc5_4_14.pg
@@ -38,7 +38,7 @@ $a1= random(1, 6, 1);
 $b1= random(2, 5, 1);
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ F(x) = \int_{x}^{$a1} \sin(t^{$b1}) dt \]
 

--- a/OpenProblemLibrary/Rochester/setIntegrals4FTC/sc5_4_18.pg
+++ b/OpenProblemLibrary/Rochester/setIntegrals4FTC/sc5_4_18.pg
@@ -36,7 +36,7 @@ $a= random(1, 5, 1);
 $b= random(2, 5, 1);
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ h(x) = \int_{-$a}^{\sin(x)} (\cos(t^$b)+t)\; dt \]
 

--- a/OpenProblemLibrary/Rochester/setIntegrals4FTC/sc5_4_18a.pg
+++ b/OpenProblemLibrary/Rochester/setIntegrals4FTC/sc5_4_18a.pg
@@ -58,7 +58,7 @@ $a= random(1, 5, 1);
 $b= random(2, 5, 1);
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ h(x) = \int_{-$a}^{\sin(x)} (\cos(t^$b)+t) dt \]
 

--- a/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-10.pg
+++ b/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-10.pg
@@ -40,7 +40,7 @@ $a= random(5,20,1);
 $b= random(2,5,1);
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ F(x) = \int_{x}^{$a} \tan(t^{$b}) dt \]
 

--- a/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-11.pg
+++ b/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-11.pg
@@ -42,7 +42,7 @@ $b = random(4,15,1);
 
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ h(x) = \int_{$a}^{1/x} {$b \arctan (t)}\, dt \]
 $BR \( h'(x) \) = \{ans_rule( 20)\} $BR

--- a/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-13.pg
+++ b/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-13.pg
@@ -44,7 +44,7 @@ $p = random(4,15,1);
 
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ y = \int_{-$a}^{\sqrt{x}} {\frac{\cos t}{t^{$p}}} dt \]
 $BR \( \frac{dy}{dx} \) = \{ans_rule( 40)\} $BR

--- a/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-15.pg
+++ b/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-15.pg
@@ -42,7 +42,7 @@ $p1 = random(3,5,1);
 $p2 = random(2,4,1);
 
 TEXT(EV2(<<EOT));
-Use part I of the Fundamental Theorem of Calculus to
+Use the Fundamental Theorem of Calculus to
 find the derivative of
 \[ y = \int_{$a-$b x}^{$c} {\frac{u^$p1}{1+u^$p2}} du \]
 $BR \( \frac{dy}{dx} \) = \{ans_rule(50)\} $BR

--- a/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-30.pg
+++ b/OpenProblemLibrary/UVA-Stew5e/setUVA-Stew5e-C05S03-FundThmCalc/5-3-30.pg
@@ -47,7 +47,7 @@ $p = random(2,5,1);
 
 TEXT(EV2(<<EOT));
 
-Use Part 2 of the Fundamental Theorem of Calculus to decide if the definite 
+Use the Fundamental Theorem of Calculus to decide if the definite 
 integral exists and either evaluate the integral or enter DNE if it does not exist.
 $BR
 $PAR


### PR DESCRIPTION
Using these names in a webwork problem reduces the number of instructors who can use them without modification (and without confusing their students), since sources and textbooks disagree about which part is the "first" and which is the "second".  For instance, [Wikipedia](https://en.wikipedia.org/wiki/Fundamental_theorem_of_calculus#Formal_statements) and [MathWorld](http://mathworld.wolfram.com/FundamentalTheoremsofCalculus.html) disagree with each other.  So it seems to me that it would be better for problems in the OPL to always just refer to "the fundamental theorem of calculus" without specifying a part number.