### PR TITLE
Make matrix visible

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.6.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.3.6.pg
@@ -80,7 +80,7 @@ $multians1 = MultiAnswer($basis1, $basis2)->with(
   BEGIN_PGML
 Find bases for the column space, the row space, and the null space of the matrix
 
-[```A = [$A]```]
+[``A = [$A]``]
 
 You should verify that the Rank-Nullity Theorem holds. 
 


### PR DESCRIPTION
Without this change, I cannot see this matrix.  I feel like there were too many tick marks in that case.  Please merge if you can verify - @gajennings did you see this problem?  Unless it's browser-dependent - I am on Safari.