### PR TITLE
unspecified operation causes incorrect answer

### DIFF
--- a/OpenProblemLibrary/ASU-topics/setChainRulePowerFunctions/5-2-19.pg
+++ b/OpenProblemLibrary/ASU-topics/setChainRulePowerFunctions/5-2-19.pg
@@ -46,7 +46,7 @@ $xp = random(-3,3,1);
 
 $fcn = Formula("(x+$a)^($b) e^($c x)")->reduce;
 
-$ans = Compute("$b ($xp + $a)^($b-1) e^($c $xp) + $c  ($xp + $a)^$b  e^($c $xp)");  
+$ans = Compute("$b ($xp + $a)^($b-1) e^($c*$xp) + $c  ($xp + $a)^$b  e^($c*$xp)");  
 
 Context()-> texStrings;
 BEGIN_TEXT


### PR DESCRIPTION
Without having an operation specified, any negative x-value causes addition in the exponent of e, rather than the intended multiplication. 

Example seed: 1234