### PR TITLE
Replace exact matrix comparison

### DIFF
--- a/OpenProblemLibrary/NAU/setLinearAlgebra/diag3x3ortho.pg
+++ b/OpenProblemLibrary/NAU/setLinearAlgebra/diag3x3ortho.pg
@@ -57,7 +57,7 @@ my @s = @{$student};
 my @c = @{$correct};
 $sP = Matrix($s[0]);
 $sPT = $sP->transpose;
-if ($sP*$sPT != $I) {
+if (!($sP*$sPT)->isOne) {
   $self->setMessage(1,"Not orthogonal.");
   return 0;
 }
@@ -73,8 +73,8 @@ if ($sD->element(1,2)!=0 or
   $self->setMessage(2,"Not diagonal.");
   return 0;
 }
-return 0 if ($sD != $sPT*$A*$sP);
-return 1;
+return 1 if ($sD - $sPT*$A*$sP)->isZero;
+return 0;
 }
 );
 


### PR DESCRIPTION
The problem directly compared P'*P to I, instead of using ->isOne, which
caused spurious confusing error messages when students used square roots in their
answers.  Also, when checking the final correct answer, direct
comparison was used.  I replaced that by ->isZero.