### PR TITLE
No quotes needed

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/7_Techniques_of_Integration/7.1_Integration_by_Parts/7.1.11.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/7_Techniques_of_Integration/7.1_Integration_by_Parts/7.1.11.pg
@@ -40,7 +40,7 @@ $dv = Formula("cos($a * x)")->reduce();
 $v = Formula("(1 / $a) * sin($a * x)")->reduce();
 $iduv = Formula("-1 * ($b / $a**2) * cos($a * x)")->reduce();
 $uv = Formula("($b / $a) * x * sin($a * x)")->reduce();
-$ans = FormulaUpToConstant("$uv - $iduv + C");
+$ans = FormulaUpToConstant($uv - $iduv);
 
 Context()->texStrings;
 BEGIN_TEXT


### PR DESCRIPTION
$uv and $iduv are formulas. Putting quotes around $uv - $iduv apparently created some problems: i.e. correct answers marked as incorrect.