### PR TITLE
Use method answerChoice instead of hacking internals

### DIFF
--- a/OpenProblemLibrary/Westmont/ActiveCalculus/Preview_2_5/preview_2_5_c.pg
+++ b/OpenProblemLibrary/Westmont/ActiveCalculus/Preview_2_5/preview_2_5_c.pg
@@ -48,9 +48,9 @@ $ma = MultiAnswer($mc,$f1,$f2)->with(
   singleResult => 1,
   checker => sub {
     my ($correct, $student, $self, $ans) = @_;
-    if($mc->{orderedChoices}[substr($student->[0], 1)] eq $ans_str->[0]) {
+    if($mc->answerChoice($student->[0]) eq $ans_str->[0]) {
       return $student->[1] == $f1 && $student->[2] == $g1;
-    } elsif($mc->{orderedChoices}[substr($student->[0], 1)] eq $ans_str->[2]) {
+    } elsif($mc->answerChoice($student->[0]) eq $ans_str->[2]) {
       return $student->[1] == $f2 && $student->[2] == $g2;
     } else {
       return 0;


### PR DESCRIPTION
The recently merged PR #763 involves some hacking with the internals of the RadioButton implementation, which might break on future updates.  The PR openwebwork/pg#502 adds methods to RadioButton that eliminate the need for such hacking; this PR updates #763 to use these methods.

However, I don't know what the practice is for mantaining compatibility between the OPL and particular versions of webwork.  It seems clear that this PR should not be merged until openwebwork/pg#502 is not only merged but incorporated in a released version of webwork, but perhaps one should wait even longer to give people time to update their webwork installations?  Is there a policy regarding this?
