### PR TITLE
Update SCalcET7-11-1-ex3.pg

### DIFF
--- a/OpenProblemLibrary/WinonaState/StewartCalcEarlyTran7ed/Chap11Section01/SCalcET7-11-1-ex3.pg
+++ b/OpenProblemLibrary/WinonaState/StewartCalcEarlyTran7ed/Chap11Section01/SCalcET7-11-1-ex3.pg
@@ -43,8 +43,8 @@ loadMacros("PG.pl",
 $a=random(4,10,1);
 $answer=random(10,99,1);
 $b=2*$answer*$a;
-$c=random(25,99,1);
-
+# $c=random(25,99,1);
+$c = $a*(($answer)**2) + 5;
 
 $popupMono=PopUp(["Select","Monotone increasing for n greater than or equal to N","Monotone decreasing for n greater than or equal to N", "Neither"],"Monotone decreasing for n greater than or equal to N");
 


### PR DESCRIPTION
The original problem design assumes that the reciprocal of an increasing function is necessarily decreasing.  That is not so for functions which are neither strictly positive nor strictly negative. The proposed fix sets the variable $c to be no longer random, in order to make sure that the denominator of each term of the sequence is strictly positive.