### PR TITLE
Fix display bug in quadratic factoring problem.

### DIFF
--- a/Contrib/Piedmont/OnlineMATH1005/Test3/9.pg
+++ b/Contrib/Piedmont/OnlineMATH1005/Test3/9.pg
@@ -1,7 +1,7 @@
 ## DESCRIPTION
 ## Piedmont College
 ## MATH 1005 Online Test 3
-## Factoring differences of squares
+## Factoring perfect squares
 ## ENDDESCRIPTION
 
 ## DBsubject(Algebra)
@@ -49,7 +49,7 @@ sub add_options {
 
 $p = non_zero_random(-9, 9);
 
-$quadratic = "\(" . Formula("x^2 - 2 * $p * x + $p**2")->reduce->TeX . "\)";
+$quadratic = "\(" . Formula("x^2 - 2 * $p * x + ($p)**2")->reduce->TeX . "\)";
 $ans = "\(" . Formula("(x - $p)^2")->reduce->TeX . "\)";
 
 $buttons = RadioButtons([add_options($ans)], $ans);


### PR DESCRIPTION
The goal of this problem is to factor a quadratic of the form
x^2 - 2px + p^2.  However, when p < 0, this was displaying as
x^2 - 2px - p^2.

We also took the opportunity to fix the problem description, which had
been incorrectly pasted from another problem.