### PR TITLE
Update 4.4.9.pg

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/4_Applications_of_the_Derivative/4.4_The_Shape_of_a_Graph/4.4.9.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/4_Applications_of_the_Derivative/4.4_The_Shape_of_a_Graph/4.4.9.pg
@@ -54,7 +54,7 @@ $cp = Compute("(9*$c^2)/64");
 # c^2 >= 7
 # c >= sqrt(7)
 
-$left_fdoubleprime = $fdoubleprime->eval(x=>non_zero_random(0,$cp->eval()));
+$left_fdoubleprime = $fdoubleprime->eval(x=>non_zero_random(0,($cp->eval())/2));
 $right_fdoubleprime = $fdoubleprime->eval(x=>$cp->eval()+1);
 
 $inflection_test = Real(sgn($left_fdoubleprime) + sgn($right_fdoubleprime));


### PR DESCRIPTION
On line 57, it is possible to be so unlucky that the output of non_zero_random(0, $cp->eval()) is exactly $cp->eval(). In that case, the problem could think there is no inflection point when there actually is.

I am not sure if it is safe to pass a non-integer argument to the non_zero_random() function. Someone more knowledgeable should probably double-check this...