### PR TITLE
Fix bugs in Rochester/setLinearAlgebra24SingularValues/ur_la_24_7.pg

### DIFF
--- a/OpenProblemLibrary/Rochester/setLinearAlgebra24SingularValues/ur_la_24_7.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra24SingularValues/ur_la_24_7.pg
@@ -31,16 +31,16 @@ Context('Matrix');
 
 foreach $i (1..4) { 
 	foreach $j (1..4) {
-	$e[$i][$j] = 1;
+	$e[$i][$j] = 1/2;
 	}
 }
 
-$e[2][3] = -1;
-$e[2][4] = -1;
-$e[3][2] = -1;
-$e[3][4] = -1;
-$e[4][2] = -1;
-$e[4][3] = -1;
+$e[2][3] = -1/2;
+$e[2][4] = -1/2;
+$e[3][2] = -1/2;
+$e[3][4] = -1/2;
+$e[4][2] = -1/2;
+$e[4][3] = -1/2;
 
 @slice1 = NchooseK(4,4);
 @slice2 = NchooseK(4,4);
@@ -53,35 +53,22 @@ foreach $i (1..4) {
 }
 
 $U = Matrix([
-[ $u[1][1], $u[1][2], $u[1][3], $u[1][4] ],
-[ $u[2][1], $u[2][2], $u[2][3], $u[2][4] ],
-[ $u[3][1], $u[3][2], $u[3][3], $u[3][4] ],
-[ $u[4][1], $u[4][2], $u[4][3], $u[4][4] ],
+  [ $u[1][1], $u[1][2], $u[1][3], $u[1][4] ],
+  [ $u[2][1], $u[2][2], $u[2][3], $u[2][4] ],
+  [ $u[3][1], $u[3][2], $u[3][3], $u[3][4] ],
+  [ $u[4][1], $u[4][2], $u[4][3], $u[4][4] ],
 ]);
 
 #$S = new Matrix(4,2);
 
-foreach $i (1..4) {
-        foreach $j (1..2) { 
-		$s[$i][$j] = 0;
-		#$S -> assign($i, $j, 0);
-	}
-}
-
-
-$sigma1 = non_zero_random(-20,20,5);
-$sigma2 = non_zero_random(-20,20,5);
-
-$s[1][1] = $sigma1;
-$s[2][2] = $sigma2; 
-#$S -> assign(1,1,$sigma1);
-#$S -> assign(2,2,$sigma2);
+$sigma1 = random(10,40,10);
+$sigma2 = random(10,40,10);
 
 $S = Matrix([
-[$sigma1,0],
-[0,$sigma2],
-[0,0],
-[0,0],
+  [$sigma1,0],
+  [0,$sigma2],
+  [0,0],
+  [0,0],
 ]);
 
 
@@ -98,14 +85,9 @@ $v[1][2] = $f[$first+1];
 $v[2][2] = $f[$first+2];
 $v[2][1] = $f[$first+3];
 
-#$V -> assign(1,1,$v[1][1]);
-#$V -> assign(1,2,$v[1][2]);
-#$V -> assign(2,1,$v[2][1]);
-#$V -> assign(2,2,$v[2][2]);
- 
 $V = Matrix([
-[ $v[1][1], $v[1][2] ],
-[ $v[2][1], $v[2][2] ],
+  [ $v[1][1], $v[1][2] ],
+  [ $v[2][1], $v[2][2] ],
 ]);
 
 #$A = new Matrix(4,2);
@@ -119,7 +101,7 @@ foreach $i (1..4) {
 foreach $i (1..2) { 
 	$bu[$i] = 0;
 	foreach $j (1..4) {
-		$bu[$i] = $bu[$i] + $b[$j]*$u[$j][$i];
+		$bu[$i] += $b[$j] * $u[$j][$i];
 	}
 }
 
@@ -142,6 +124,5 @@ END_TEXT
 Context()->normalStrings;
 
 ANS($X->cmp);
-;
-ENDDOCUMENT();       # This should be the last executable line in the problem.
 
+ENDDOCUMENT();       # This should be the last executable line in the problem.


### PR DESCRIPTION
Fix the following bugs in OpenProblemLibrary/Rochester/setLinearAlgebra24SingularValues/ur_la_24_7.pg:

   In the claimed singular value distribution, the first factor U is not unitary
   In the same claimed SVD, the singular values may (incorrectly) be negative.
   Because U is not unitary, the expected answer is off by a factor of 4.

(Regarding the last point, if the random seed is 2671, then b = (-5,-3,2,-3), and the unmodified problem expects x^* = (-137/150,11/25), for which Ax^* = (-16,-16,-2,-2).  This is clearly not a least squares fit.)

Also some code cleanups.