### PR TITLE
Update algebraMacros.pl

### DIFF
--- a/OpenProblemLibrary/macros/UMass-Amherst/algebraMacros.pl
+++ b/OpenProblemLibrary/macros/UMass-Amherst/algebraMacros.pl
@@ -149,11 +149,13 @@ sub disjointCycles
 	{
 		$result = List( map { List( join( ',', @$_ ) ) } ( @cycles ) );
 	}
-	else
+	elsif (scalar @cycles > 0 )
 	{
 		$result = List( map { List( '(' . join( ',', @$_ ) . ')' ) } @cycles );
+	} else {
+                Context()->strings->add(id => {alias => "identity"});          
+                $result = List( ( id ) );
 	}
-	
 	return $result;
 };
 


### PR DESCRIPTION
"sub disjointCycles" returns the empty string when the corresponding permutation is the identity map. 
Students appear to have no way of entering the correct answer in this case. 
If this patch is adopted, problem authors using this macro should indicate that 'id' be used to denote the identity map.