### PR TITLE
Fix a roundoff error

### DIFF
--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/04-Mechanical-vibrations/KJ-3-6-08.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/04-Mechanical-vibrations/KJ-3-6-08.pg
@@ -85,8 +85,13 @@ $T = Real("4*($x2-$x1)"); # period
 $f = Compute("1 / $T"); # frequency
 $omega = Compute("2 pi / $T"); # angular freq.
 $gamma = Compute("2 pi $x2 / $T"); # phase shift
-$y = Compute("$y2/100 cos($omega t - $gamma)");
-$y_cm = Compute("$y2 cos($omega t - $gamma)");
+#$y = Compute("$y2/100 cos($omega t - $gamma)");
+#$y_cm = Compute("$y2 cos($omega t - $gamma)");
+# plugging in the $omega and $gamma as above leads to what seems like a
+# rare roundoff error where the exact answer is not accepted, but one
+# with rounded pi's is, e.g. seed 3866
+$y = Compute("$y2/100 cos((2 pi / $T) t - (2 pi $x2 / $T))");
+$y_cm = Compute("$y2 cos((2 pi / $T) t - (2 pi $x2 / $T))");
 $y0 = $y->eval(t=>0);
 $yp0 = $y->D('t')->eval(t=>0);
 


### PR DESCRIPTION
 For example in seed 3866, the exact answer with pi is not accepted by the answer with 3.14159 is.
 
 Ran the fix past Paul, and he agrees this is a good fix.