### PR TITLE
Fix incorrect use of TeX in two problems

### DIFF
--- a/OpenProblemLibrary/UCSB/Stewart5_7_7/Stewart5_7_7_22.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_7_7/Stewart5_7_7_22.pg
@@ -29,10 +29,10 @@ BEGIN_TEXT
 $PAR
 Let \(f(x)=e^{x^2}.\)  It can be shown by direct computation that
 \(f^{(4)}(x) \le 76 e\)
-on the interval [0, 1].  Using this information and the appropriate error formula, how large should  n be so that the Simpson's Rule approximation to \(\int_{0}^{\,1} {e^{x^2}}\, dx\) is accurate to within 0.00001?  (Your answer must be a whole number.)
+on the interval [0, 1].  Using this information and the appropriate error formula, how large should \(n\) be so that the Simpson's Rule approximation to \(\int_{0}^{\,1} {e^{x^2}}\, dx\) is accurate to within 0.00001?  (Your answer must be a whole number.)
 
 $PAR
-{\it n} = \{ans_rule(40)\}
+\(n =\) \{ans_rule(40)\}
 
 END_TEXT
 

--- a/OpenProblemLibrary/UCSB/Stewart5_7_7/Stewart5_7_7_24.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_7_7/Stewart5_7_7_24.pg
@@ -86,10 +86,10 @@ $PAR
 \{$cmc -> print_a \}
 
 $PAR$HR$PAR
-(g) Using the information given in part (d) and the appropriate error formula in your textbook, how large do we have to choose n to ensure that the approximation \(S_n\) is accurate to within 0.0001?  (Your answer must be a whole number.)
+(g) Using the information given in part (d) and the appropriate error formula in your textbook, how large do we have to choose \(n\) to ensure that the approximation \(S_n\) is accurate to within 0.0001?  (Your answer must be a whole number.)
 
 $PAR
-{\it n} = \{ans_rule(40)\}
+\(n =\) \{ans_rule(40)\}
 
 END_TEXT
 


### PR DESCRIPTION
In the two problems variable name is improperly italicized with
`\it`, which does not work and shows up as `{\it n}` in the text of
the problem.  Replace it with math mode.
