### PR TITLE
Specify the required precision in the problem text

### DIFF
--- a/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_9_17.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_9_17.pg
@@ -55,6 +55,8 @@ Context()->texStrings;
 BEGIN_TEXT
 Use a linear approximation to estimate the number \(($b)^{2/3}.\)
 $PAR
+Make sure that your answer is correct to at least 9 decimal places.
+$PAR
 Answer: \{ans_rule(20)\}
 END_TEXT
 Context()->normalStrings;


### PR DESCRIPTION
The problem has absolute tolerance 0.00000001, but the problem
text does not make it clear, so students use a lot of attempts
to figure out how many decimal places are required.
