### PR TITLE
Fix bug in OpenProblemLibrary/AlfredUniv/PDE/separable/laplace/superpositionsolve.pg

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/PDE/separable/laplace/superpositionsolve.pg
+++ b/OpenProblemLibrary/AlfredUniv/PDE/separable/laplace/superpositionsolve.pg
@@ -67,7 +67,7 @@ $sinha = Formula("sinh(n*pi*a/b)");
 $sinhb = Formula("sinh(n*pi*b/a)");
 $coshb = Formula("cosh(n*pi*b/a)");
 
-$intsin = Formula($coefficient,"2*(1+(-1))^(n+1)/(n*pi)");
+$intsin = Formula($coefficient,"2*(1 + ((-1)^(n+1)))/(n*pi)");
 $intsin->{test_points}=[[1,1,1],[1,1,-1],[1,1,-2],[1,1,2],[1,1,-3],[1,1,3],[1,1,4]];
 $An = Formula($coefficient,"2*(-1)^(n+1)/(n*pi)");
 $An->{test_points}=[[1,1,1],[1,1,-1],[1,1,-2],[1,1,2],[1,1,-3],[1,1,3],[1,1,4]];


### PR DESCRIPTION
Bug reported by Vadim Panfilov vadim.panfilov@gtiit.edu.cn.

Fix a type where `$intsin` included
> `(1+(-1))^(n+1)` = 0 always
where
> `(1 + ((-1)^(n+1)))`
which alternates between 0 and 2 was needed.