### PR TITLE
Use `round` instead of `sprintf` to round percentage

### DIFF
--- a/OpenProblemLibrary/PCC/BasicMath/Percent/MTH20PercentOfNumberType2_60.pg
+++ b/OpenProblemLibrary/PCC/BasicMath/Percent/MTH20PercentOfNumberType2_60.pg
@@ -38,7 +38,7 @@ do {
    $ansNotRounded = $a/$b*100;
 } until ($ansNotRounded != int($ansNotRounded));
 
-$ans = sprintf("%.0f",$ansNotRounded);
+$ans = round($ansNotRounded);
 
 Context("LimitedPercent-strict");
 Context()->flags->set(


### PR DESCRIPTION
There are sometimes rounding errors due to  floating point issues when the percentage ends in 5,
e.g.:

```
$ perl -e 'printf("%.0f\n",  0.5)'
0
$ perl -e 'printf("%.0f\n",  1.5)'
2
```