### PR TITLE
update directions for mathquill radicals

### DIFF
--- a/Contrib/CCCS/AlgebraicLiteracy/IA_8.2/OpenStax_IA_8.2_91.pg
+++ b/Contrib/CCCS/AlgebraicLiteracy/IA_8.2/OpenStax_IA_8.2_91.pg
@@ -65,8 +65,6 @@ BEGIN_PGML
 
 Simplify each radical. Assume all variables are positive.
 
-Use *root(n, x)* to enter [`\sqrt[n]{x}`]. For example: [`\sqrt[3]{2} =`]  *root(3, 2)* and [`\sqrt[4]{y^{3}} = `] *root(4, y^3)*.
-
   (a)  [`` \sqrt{[$rad1]} = ``] [_____________]{$ans1}
   (b)  [`` \sqrt[3]{[$rad2]} = ``] [_____________]{$ans2}
   (c)  [`` \sqrt[4]{[$rad3]} = ``] [_____________]{$ans3}

--- a/Contrib/CCCS/AlgebraicLiteracy/IA_8.4/OpenStax_IA_8.4_195.pg
+++ b/Contrib/CCCS/AlgebraicLiteracy/IA_8.4/OpenStax_IA_8.4_195.pg
@@ -53,8 +53,6 @@ BEGIN_PGML
 
 Multiply and Simplify.
 
-Use *sqrt(x)* to enter [`\sqrt{x}`]. For example: [`\sqrt{2} =`]  *sqrt(2)*.
-
 [`` ([$n] + \sqrt{[$a]})([$m] - [$b]\sqrt{[$a]}) = ``] [_____________]{$ans1}
 
 END_PGML

--- a/Contrib/CCCS/AlgebraicLiteracy/IA_8.4/OpenStax_IA_8.4_205.pg
+++ b/Contrib/CCCS/AlgebraicLiteracy/IA_8.4/OpenStax_IA_8.4_205.pg
@@ -50,8 +50,6 @@ BEGIN_PGML
 
 Multiply and Simplify.
 
-Use *sqrt(x)* to enter [`\sqrt{x}`]. For example: [`\sqrt{2} =`]  *sqrt(2)*.
-
 [`` {([$m] - [$b]\sqrt{[$a]})}^{2} = ``] [_____________]{$ans1}
 
 END_PGML

--- a/Contrib/CCCS/AlgebraicLiteracy/IA_8.4/OpenStax_IA_8.4_209.pg
+++ b/Contrib/CCCS/AlgebraicLiteracy/IA_8.4/OpenStax_IA_8.4_209.pg
@@ -45,8 +45,6 @@ BEGIN_PGML
 
 Multiply and Simplify.
 
-Use *sqrt(x)* to enter [`\sqrt{x}`]. For example: [`\sqrt{2} =`]  *sqrt(2)*.
-
 [`` ([$b]\sqrt{[$a]} + [$m])([$b]\sqrt{[$a]} - [$m]) = ``] [_____________]{$ans1}
 
 END_PGML

--- a/Contrib/CCCS/AlgebraicLiteracy/IA_8.5/OpenStax_IA_8.5_249.pg
+++ b/Contrib/CCCS/AlgebraicLiteracy/IA_8.5/OpenStax_IA_8.5_249.pg
@@ -81,8 +81,6 @@ BEGIN_PGML
 
 Simplify. Use positive exponents only in your answer.
 
-Use *root(n, x)* to enter [`\sqrt[n]{x}`]. For example: [`\sqrt[3]{2} =`]  *root(3, 2)*.
-
   (a)  [`` \frac{\sqrt{[$rad1]}}{\sqrt{[$rad2]}} = ``] [_____________]{$ans1}
   
   (b)  [`` \frac{\sqrt[3]{[$rad1B]}}{\sqrt[3]{[$rad2B]}} = ``] [_____________]{$ans2}

--- a/Contrib/CCCS/AlgebraicLiteracy/IA_8.5/OpenStax_IA_8.5_255.pg
+++ b/Contrib/CCCS/AlgebraicLiteracy/IA_8.5/OpenStax_IA_8.5_255.pg
@@ -61,8 +61,6 @@ BEGIN_PGML
 
 Simplify. Use positive exponents only in your answer.
 
-Use *sqrt(x)* to enter [`\sqrt{x}`]. For example: [`\sqrt{2} =`]  *sqrt(2)*.
-
 [`` \frac{\sqrt{[$rad1]}}{\sqrt{[$rad2]}} = ``] [_____________]{$ans1}
 
 END_PGML

--- a/Contrib/CCCS/PreCalculus/10.8/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_10_8_EX16_1.pg
+++ b/Contrib/CCCS/PreCalculus/10.8/RRCC_CCCS_Openstax_AlgTrig_AT-1-001-AS_10_8_EX16_1.pg
@@ -36,7 +36,8 @@ Context("Vector");
 $a = non_zero_random(-9,9,1);
 $b = non_zero_random(-9,9,1);
 $c = non_zero_random(-9,9,1);
-$d = non_zero_random(-9,9,1);
+do{$d = non_zero_random(-9,9,1);}
+until($a*$c+$b*$d != sqrt((($a)**2 + ($b)**2)*(($c)**2 + ($d)**2))); #to make the vectors non parallel vectors, so that the angle between the two is never zero for this problem.
 
 $u = Vector($a,$b);
 $v = Vector($c,$d);


### PR DESCRIPTION
Remove directions stating to use 'sqrt' since students now have MathQuill. And a vector bug fix to ensure arccos(1) is not taken.