### PR TITLE
Fix answer for poker probability problem.

### DIFF
--- a/OpenProblemLibrary/Mizzou/Finite_Math/Probability_Introduction/Prob2.pg
+++ b/OpenProblemLibrary/Mizzou/Finite_Math/Probability_Introduction/Prob2.pg
@@ -64,11 +64,11 @@ elsif($case2 == 3){
 elsif($case2 == 4){
    $string2 = 'queens';
    $ans2 = 4*24*47/$samplespace;
-   $ans3 = (4*27*47 + 48)/$samplespace;}
+   $ans3 = (4*24*47 + 48)/$samplespace;}
 else{
    $string2 = 'aces';
    $ans2 = 4*24*47/$samplespace;
-   $ans3 = (4*27*47 + 48)/$samplespace;}
+   $ans3 = (4*24*47 + 48)/$samplespace;}
 
 ##############################################################
 #


### PR DESCRIPTION
When computing the probability of getting at least three of a
particular rank, the numerator will be:

* the number of ways of getting 3 of the given rank and 2 of
  the remaining 48 cards = choose(4, 3) * choose(48, 2)
* plus the number of ways of getting 4 of the given rank and
  1 of the remaining 48 cards = choose(4, 4) * choose(48, 1)

There was a typo in this first term.  In particular:
choose(48, 2) = 48 * 47 / 2 = 24 * 47, not 27 * 47