### PR TITLE
Use uppercase "DNE" for string alias in parabola-graphing problem

### DIFF
--- a/Contrib/PCC/BasicAlgebra/GraphingQuadratics/ParabolaIntercepts80.pg
+++ b/Contrib/PCC/BasicAlgebra/GraphingQuadratics/ParabolaIntercepts80.pg
@@ -42,7 +42,7 @@ Context()->parens->set("{" => {type => "Set", close => "}"});
 Context()->parens->set("<" => {type => "Vector", close => ">"});
 Context()->flags->set(showExtraParens=>0, reduceConstants=>0);
 Context()->noreduce("(-x)-y","(-x)+y");
-Context()->strings->add("does not exist"=>{alias=>'dne'});
+Context()->strings->add("does not exist"=>{alias=>'DNE'});
 
 $a = 1;
 $c = non_zero_random(2,10,1);


### PR DESCRIPTION
Otherwise, we get the following:

```
ERRORS from evaluating PG file:
 Alias 'dne' doesn't exist for string 'does not exist' at line 45
 of (eval 5465)
```