### PR TITLE
apparently webwork 2.16 is rounding Real to two decimal places?

### DIFF
--- a/Contrib/METU-NCC/MAT100/SE1/Line.pg
+++ b/Contrib/METU-NCC/MAT100/SE1/Line.pg
@@ -44,10 +44,10 @@ Context()->variables->are(x=>"Real",y=>"Real");
 $ans[0] = ImplicitPlane(Point($a,$b),Vector($d-$b,$a-$c));
 
 Context("Fraction");
-my $m = Fraction($c-$a,$d-$b); 
+my $det = $a*$d - $b*$c; 
 
-$ans[1] = Fraction($a-$c/$m); 
-$ans[2] = Fraction($c-$m*$a);
+$ans[1] = Fraction($det,$d-$b); 
+$ans[2] = Fraction($det,$a-$c);
 
 
 

--- a/Contrib/METU-NCC/MAT101/Chapter3/Revenue.pg
+++ b/Contrib/METU-NCC/MAT101/Chapter3/Revenue.pg
@@ -36,8 +36,12 @@ my $m = Fraction($q[2]-$q[0],$y[2]-$y[0]);
 $ans[0] = Formula("$m (x-$y[0]) + $q[0]")->reduce;
 $ans[1] = Formula("x")*$ans[0];
 $ans[2] = Real( ($m*$y[0]-$q[0]) / (2*$m) );
-$ans[3] = Real( ($m*$y[0]-$q[0]) / (2*$m) * 
-               ($m * (($m*$y[0]-$q[0]) / (2*$m) - $y[0]) + $q[0]) );
+
+
+Context("Numeric");
+
+$ans[3] = Real( $ans[1]->eval(x=>$ans[2]) );  
+
 
 if (random(0,1)==1) { @y = @y[2,1,0]; @q = @q[2,1,0]; }
 

--- a/Contrib/METU-NCC/MAT101/Chapter3/Revenue.pg
+++ b/Contrib/METU-NCC/MAT101/Chapter3/Revenue.pg
@@ -36,7 +36,8 @@ my $m = Fraction($q[2]-$q[0],$y[2]-$y[0]);
 $ans[0] = Formula("$m (x-$y[0]) + $q[0]")->reduce;
 $ans[1] = Formula("x")*$ans[0];
 $ans[2] = Real( ($m*$y[0]-$q[0]) / (2*$m) );
-$ans[3] = $ans[1]->eval(x=>$ans[2]);
+$ans[3] = Real( ($m*$y[0]-$q[0]) / (2*$m) * 
+               ($m * (($m*$y[0]-$q[0]) / (2*$m) - $y[0]) + $q[0]) );
 
 if (random(0,1)==1) { @y = @y[2,1,0]; @q = @q[2,1,0]; }
 


### PR DESCRIPTION
As far as I know this problem was working fine in webwork 2.15
There is a problem when $ans[2] is a fraction, since it is getting rounded off when being plugged into $ans[1] (in the computation of $ans[3]) yielding too much rounding error for correct answers to be accepted.  Maybe if I didn't cast it to Real right away then it wouldn't have been an issue?  Anyway, I fixed it by manually plugging in the formula for $ans[3].