### PR TITLE
Update Basis_31.pg

### DIFF
--- a/OpenProblemLibrary/Hope/Multi1/03-05-Basis-subspace/Basis_31.pg
+++ b/OpenProblemLibrary/Hope/Multi1/03-05-Basis-subspace/Basis_31.pg
@@ -29,10 +29,10 @@ $showPartialCorrectAnswers = 1;
 
 Context('Matrix');
 Context()->variables->are(
-'a1'=>['Real','TeX'=>'\mathbf{a_1}'],
-'a2'=>['Real','TeX'=>'\mathbf{a_2}'],
-'a3'=>['Real','TeX'=>'\mathbf{a_3}'],
-'a4'=>['Real','TeX'=>'\mathbf{a_4}'],
+'a1'=>['Vector3D','TeX'=>'\mathbf{a_1}'],
+'a2'=>['Vector3D','TeX'=>'\mathbf{a_2}'],
+'a3'=>['Vector3D','TeX'=>'\mathbf{a_3}'],
+'a4'=>['Vector3D','TeX'=>'\mathbf{a_4}'],
 );
 
 do {


### PR DESCRIPTION
Cast a1, a2, ... as 'Vector3D', so that answer checker accepts both a1, a2, ...  and <a, b, c> as valid answer types.