### PR TITLE
Add AnswerFormatHelp

### DIFF
--- a/OpenProblemLibrary/UMN/calculusStewartET/s_12_2_26.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartET/s_12_2_26.pg
@@ -28,6 +28,7 @@ loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",
   "parserVectorUtils.pl",
+  "AnswerFormatHelp.pl",
   "PGcourse.pl"
 );
 ########################################################################
@@ -56,7 +57,7 @@ $ans = Compute("$an");
 Context()->texStrings;
 BEGIN_TEXT
 Find a vector \(\mathbf{a}\) that has the same direction as \( \langle -$a, $b, $a \rangle\) but has length \($c\). $PAR
-Answer: \( \mathbf{a} = \) \{ ans_rule(20) \} $PAR
+Answer: \( \mathbf{a} = \) \{ ans_rule(20) \} \{ AnswerFormatHelp("vectors") \}$PAR
 END_TEXT
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/Union/setMVvectors/an12_2_17.pg
+++ b/OpenProblemLibrary/Union/setMVvectors/an12_2_17.pg
@@ -32,6 +32,7 @@ loadMacros(
   "PGunion.pl",
   "MathObjects.pl",
   "parserVectorUtils.pl",
+  "AnswerFormatHelp.pl",
   "PGcourse.pl"
 );
 
@@ -57,7 +58,6 @@ $B = $A + non_zero_point2D();
 
 Context()->texStrings;
 BEGIN_TEXT
-DEBUG $BR
 Find ${BBOLD}unit${EBOLD} vectors that satisfy the given conditions:
 $PAR
 
@@ -65,6 +65,7 @@ $PAR
 
 $ITEM
 The unit vector in the same direction as \($U\) is \{ans_rule(30)\}.
+\{ AnswerFormatHelp("vectors") \}
 $ITEMSEP
 
 $ITEM

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/12_Vector_Geometry/12.2_Vectors_in_Three_Dimensions/12.2.11.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/12_Vector_Geometry/12.2_Vectors_in_Three_Dimensions/12.2.11.pg
@@ -19,6 +19,7 @@ loadMacros(
   "PGchoicemacros.pl",
   "Parser.pl",
   "freemanMacros.pl",
+  "AnswerFormatHelp.pl",
   "PGcourse.pl"
 );
 
@@ -55,7 +56,7 @@ Find the point P such that \( \mathbf{v} = \overrightarrow{PQ} \) has the compon
 $PAR
 \( Q = $q \)
 $PAR
-\( P \)  = \{ans_rule()\}
+\( P \)  = \{ans_rule()\} \{ AnswerFormatHelp("points") \}.
 END_TEXT
 Context()->normalStrings;
 


### PR DESCRIPTION
Add use of AnswerFormatHelp to 3 problems (two on vectors, one on points).
Since the page at https://webwork.maa.org/wiki/Available_Functions  does not mention vectors or points, having these links is quite helpful if these are problems which require such syntax and are early in the course.

One problem has a line `DEBUG` at the top of the question, and it seems that is an accidental leftover from https://github.com/taniwallach/webwork-open-problem-library/commit/32a3f8100123b7417d62376f631c2cc4ce4a69df#diff-123982bdc1fa0ddfa9dc8e7c03c6b44e20947d868d5db9c2bd7ce3c7bba30b75