### PR TITLE
Bug fix for Library/Michigan/Chap14Sec3/Q03.pg

### DIFF
--- a/OpenProblemLibrary/Michigan/Chap14Sec3/Q03.pg
+++ b/OpenProblemLibrary/Michigan/Chap14Sec3/Q03.pg
@@ -108,9 +108,6 @@ $PAR
 END_TEXT
 Context()->normalStrings;
 
-# Using diagnostics => 1 was helpful when testing the reason
-# why incorrect answers were being accepted.
-#ANS($pl->cmp( diagnostics => 1 ) );
 ANS($pl->cmp() );
 
 Context()->texStrings;

--- a/OpenProblemLibrary/Michigan/Chap14Sec3/Q03.pg
+++ b/OpenProblemLibrary/Michigan/Chap14Sec3/Q03.pg
@@ -48,6 +48,26 @@ Context("Numeric");
 Context()->variables->add( y => 'Real' );
 $showPartialCorrectAnswers = 1;
 
+# The answer is always linear in x and y. In all versions there will be
+# either a "+x" or a "+y" term in the answer, but the coefficient of the
+# other variable can be significantly larger (in particular if r is 4 or 5).
+# As a result, the original code would (at least in some cases) accept
+# incorrect answers, including an omission of the "+x" or "+y" term.
+# For example, for the seed 81570490 the incorrect answers
+#      501x - 1872
+#      501x - 1872 + 2y
+#      501x - 1871 +  y
+#      501x - 1873 +  y
+# were all accepted as correct.
+#
+# Instead use an absolute tolerance, which should reasonably reliably catch
+# "small" deviations from the correct answer.
+
+Context()->flags->set(
+  tolerance => 0.0001,
+  tolType => "absolute",
+);
+
 $r = random(2,5,1);
 $a = random(1,10,1);
 
@@ -88,6 +108,9 @@ $PAR
 END_TEXT
 Context()->normalStrings;
 
+# Using diagnostics => 1 was helpful when testing the reason
+# why incorrect answers were being accepted.
+#ANS($pl->cmp( diagnostics => 1 ) );
 ANS($pl->cmp() );
 
 Context()->texStrings;


### PR DESCRIPTION
Fix a bug in `Library/Michigan/Chap14Sec3/Q03.pg` due to which answers with "small" deviations (+/- 1, +/- y) from the correct answer were being treated as correct (at least for certain seeds).
I ran into this when the seed was 81570490 (the seed when the problem code began to run after a control file select this problem from among several options).
To test:
  - Use the original problem with the seed 81570490.
  - Submit the correct answer `+y` (or `-y` or `-1` or `+1`) and before the patch these incorrect answers will get accepted.
  - Try those answers after the patch and they should be rejected.

Based on the form of the correct answers (a linear function in x,y where all coefficients should be integers) it seems very unlikely that any correct answer would be rejected with the stricter tolerance now required for any selected test points for any seed. However, the probability that all the test points for a given seed would fail to pick up an error of one in either of the coefficients should be very small.