### PR TITLE
Fix indexing in case R1 <-> R2

### DIFF
--- a/OpenProblemLibrary/Mizzou/Finite_Math/MatrixOperations/RowOp3by3e.pg
+++ b/OpenProblemLibrary/Mizzou/Finite_Math/MatrixOperations/RowOp3by3e.pg
@@ -169,7 +169,7 @@ $ans9b = $m*$a33;
 if($case2 == 1){
 $i3 = 1;
 $j3 = 2;
-$ans1c = $a12;
+$ans1c = $a21;
 $ans2c = $a22;
 $ans3c = $a23;
 $ans4c = $a11;


### PR DESCRIPTION
When swapping row 1 and row 2, there was $a12 instead of $a21.  That
would cause about 1/3 of the generated problems to have one of the 27
answers wrong.
