### PR TITLE
Move bizarro arithmetics settings

### DIFF
--- a/OpenProblemLibrary/CollegeOfIdaho/setAlgebra_06_02_AddSubRationalExpressions/62IntAlg_19_AddSubRatExp.pg
+++ b/OpenProblemLibrary/CollegeOfIdaho/setAlgebra_06_02_AddSubRationalExpressions/62IntAlg_19_AddSubRatExp.pg
@@ -33,18 +33,6 @@ TEXT(beginproblem());
 
 Context("Numeric");
 
-Context()->operators->set(
-   '/' => {class => 'bizarro::BOP::divide', isCommand => 1},
-   '/ ' => {class => 'bizarro::BOP::divide', isCommand => 1},
-   ' /' => {class => 'bizarro::BOP::divide', isCommand => 1},
-   '//' => {class => 'bizarro::BOP::divide', isCommand => 1},
-   '*' => {class => 'bizarro::BOP::multiply', isCommand => 1},
-   '* ' => {class => 'bizarro::BOP::multiply', isCommand => 1},
-   ' *' => {class => 'bizarro::BOP::multiply', isCommand => 1},
-   '+' => {class => 'bizarro::BOP::add', isCommand => 1},
-   '+ ' => {class => 'bizarro::BOP::add', isCommand => 1},
-   ' +' => {class => 'bizarro::BOP::add', isCommand => 1},);
-
 # --- Form: a/(y+b) + c/(y+d) ------------------------------------- 
 #  Note: b neq d, and (ad+cb)/(a+c) neq b nor d
 #  Answer: ((a+c)y+(ad+cb))/(y+b)(y+d)
@@ -64,6 +52,18 @@ $den2 = Formula("y + $d")->reduce;
 $f2 = Formula("($c) / $den2")->reduce->TeX;
 
 # --- For the Solution----------------------------------
+Context()->operators->set(
+   '/' => {class => 'bizarro::BOP::divide', isCommand => 1},
+   '/ ' => {class => 'bizarro::BOP::divide', isCommand => 1},
+   ' /' => {class => 'bizarro::BOP::divide', isCommand => 1},
+   '//' => {class => 'bizarro::BOP::divide', isCommand => 1},
+   '*' => {class => 'bizarro::BOP::multiply', isCommand => 1},
+   '* ' => {class => 'bizarro::BOP::multiply', isCommand => 1},
+   ' *' => {class => 'bizarro::BOP::multiply', isCommand => 1},
+   '+' => {class => 'bizarro::BOP::add', isCommand => 1},
+   '+ ' => {class => 'bizarro::BOP::add', isCommand => 1},
+   ' +' => {class => 'bizarro::BOP::add', isCommand => 1},);
+
 $lcd = Formula("(y+$b)(y+$d)")->reduce;
 $mult1 = $den2;
 $mult2 = $den1;


### PR DESCRIPTION
The bizarro arithmetics was initialized before the calculations for the
problem statement were done, leading to the problem statement being
scrambled.  This commit moves them so they only apply to the answer.
