### PR TITLE
Rewrite problem with MathObjects,PGML in order to disallow use of sqrt

### DIFF
--- a/OpenProblemLibrary/Rochester/setAlgebra11ComplexNumbers/Sqrt.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra11ComplexNumbers/Sqrt.pg
@@ -2,13 +2,12 @@
 ##   Complex Numbers
 ## ENDDESCRIPTION
 
-## Tagged by nhamblet
-
 ## DBsubject(Complex analysis)
 ## DBchapter(Arithmetic)
 ## DBsection(Powers and roots)
 ## Institution(Rochester)
 ## Level(2)
+## MO(1)
 ## KEYWORDS('Complex', 'Imaginary')
 
 DOCUMENT();        # This should be the first executable line in the problem.
@@ -16,29 +15,28 @@ DOCUMENT();        # This should be the first executable line in the problem.
 
 loadMacros(
   "PGstandard.pl",
-  "PGchoicemacros.pl",
-  "PGcomplexmacros.pl",
+  "MathObjects.pl",
+  "PGML.pl",
   "PGcourse.pl"
 );
 
 TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
+Context("Complex");
+Context()->functions->disable('sqrt');
+Context()->operators->undefine('^');
 
-$z = random(-9,9,1) + non_zero_random(-9,9,1)*i;
+do {
+    $z = non_zero_random(-5,5,1) + non_zero_random(-5,5,1)*i;
+    $z2 = $z**2;
+    } while (Re($z2) == 0);
+$ans = List($z,-$z);
 
-TEXT(EV2(<<EOT));
-Find the square root of $z so that the real part of your answer is 
-positive.
-$BR $BR 
-The square root is \{ans_rule(10)\}.
+BEGIN_PGML
+Find the square roots of [:[$z2]:].
 
-EOT
-
-$ans1 = sqrt($z);
-$ans = Re($ans1) + Im($ans1)*i;
-ANS(cplx_cmp($ans));
+The square roots are [__________]{$ans}.
+END_PGML
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.
-
-

--- a/OpenProblemLibrary/Rochester/setAlgebra11ComplexNumbers/Sqrt.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra11ComplexNumbers/Sqrt.pg
@@ -25,7 +25,13 @@ $showPartialCorrectAnswers = 1;
 
 Context("Complex");
 Context()->functions->disable('sqrt');
-Context()->operators->undefine('^');
+Context()->operators->undefine('^', '**');
+Context()->{error}{msg}{"Can't use '^' in this context"} 
+  = "Exponents are disabled for this problem. Compute the result for yourself and resubmit your answer.";
+Context()->{error}{msg}{"Can't use '**' in this context"} 
+  = "Exponents are disabled for this problem. Compute the result for yourself and resubmit your answer.";
+Context()->{error}{msg}{"Function 'sqrt' is not allowed in this context"} 
+  = "Square roots are disabled for this problem. Compute the result for yourself and resubmit your answer.";
 
 do {
     $z = non_zero_random(-5,5,1) + non_zero_random(-5,5,1)*i;


### PR DESCRIPTION
Other than making it more current, this PR makes three significant changes to the problem:

1. Students can no longer use the sqrt function in the answer (or exponentiation), which would allow them to get it correct without any work.
2. The correct answer now always has nice values, which was not the case previously.
3. The question now asks for both square roots, rather than just the one with positive Real component.

2 and 3 could be considered modifications to the spirit of the problem rather than bug fixes, but I consider them both improvements.  If there are objections to replacing the problem then I can resubmit as a new problem.