### PR TITLE
Unify answer blanks for interval

### DIFF
--- a/OpenProblemLibrary/UCSB/Stewart5_7_8/Stewart5_7_8_59.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_7_8/Stewart5_7_8_59.pg
@@ -15,38 +15,27 @@ DOCUMENT();
 
 loadMacros(
   "PGstandard.pl",
-  "PGchoicemacros.pl",
+  "PGML.pl",
   "PGcourse.pl"
 );
 
-TEXT(&beginproblem);
 $showPartialCorrectAnswers = 1;
-$a=random(1,10,1)*random(-1,1,2);
-$b=random(1,10,1)*random(-1,1,2);
-$c=random(1,10,1)*random(-1,1,2);
+Context("Numeric")->variables->are(p => ['Real', limits=>[0,8]]);
 
-BEGIN_TEXT
+BEGIN_PGML
 
-$PAR
-(a) Find the values of \(p\) for which the following integral converges:
-\[\int_{0}^{\,1} {x^p \ln(x)}\, dx\]
+[```\int_{0}^{\,1} {x^p \ln(x)}\, dx```]
 
-Input your answer by writing it as an interval.  Enter brackets or parentheses in the first and fourth blanks as appropriate, and enter the interval endpoints in the second and third blanks.  Use INF and NINF (in upper-case letters) for positive and negative infinity if needed.  If the improper integral diverges for all \(p\), type an upper-case "D" in every blank.
+a. Find the values of [`p`] for which the integral converges.
+    
+    The integral converges for all values of [`p`] in the interval: [_]{Interval("(-1,inf)")}
+  
+    [$HR]*  
+  
+a. For the values of [`p`] at which the integral converges, evaluate it.  
+    
+    [``\int_{0}^{\,1} {x^p \ln(x)}\, dx =``] [_]{Formula("-1/(p+1)^2")}
 
-$PAR
-Values of \(p\) are in the interval \{ans_rule(1)\} \{ans_rule(8)\}, \{ans_rule(8)\} \{ans_rule(1)\}
-
-$PAR$HR$PAR
-For the values of \(p\) at which the integral converges, evaluate it.
-
-Integral = \{ans_rule(30)\}
-
-END_TEXT
-
-ANS(str_cmp("("));
-ANS(std_num_str_cmp("-1", ["NINF","INF"]));
-ANS(std_num_str_cmp("INF", ["NINF","INF"]));
-ANS(str_cmp(")"));
-ANS(fun_cmp("-1/(p+1)^2", var=>["p"], limits=>[0,8]));
+END_PGML
 
 ENDDOCUMENT();


### PR DESCRIPTION
Using separate blanks for components of an interval is no longer necessary with the introduction of MathObjects. This PR updates the problem to use both MathObjects and PGML. Minimal changes have been made to the text, preserving the original intent as closely as possible.