### PR TITLE
Include Contrib in the OPL release

### DIFF
--- a/.github/workflows/bin/generate-OPL-tables.pl
+++ b/.github/workflows/bin/generate-OPL-tables.pl
@@ -616,7 +616,7 @@ sub pgfiles {
 			my $path_id = safe_get_id($tables{path}, 'path_id', qq(WHERE path = ?), [$pgpath], 1, '', $pgpath, '', '');
 
 			# pgfile table -- set 4 defaults first
-			my $level   = ($tags->{Level} =~ /\d/) ? $tags->{Level} || 0;
+			my $level   = ($tags->{Level} =~ /\d/) ? $tags->{Level} : 0;
 			my $lang    = $tags->{Language} || 'en';
 			my $mathobj = $tags->{MO}       || 0;
 			my $static  = $tags->{Static}   || 0;

--- a/.github/workflows/bin/generate-OPL-tables.pl
+++ b/.github/workflows/bin/generate-OPL-tables.pl
@@ -509,10 +509,11 @@ sub pgfiles {
 		print "\n"           if ($cnt2 % 1000) == 0;
 
 		my $pgfile = basename($name);
-		dirname($name) =~ m|^([^/]*)/(.*)|;
+		my $pgpath = dirname($name);
+		$pgpath =~ s|^$libraryRoot|Library|;
+		$pgpath =~ s|^$contribRoot|Contrib|;
+		$pgpath =~ m|^([^/]*)/(.*)|;
 		my ($pglib, $pgpath) = ($1, $2);
-		$pglib =~ s|^$libraryRoot|Library|;
-		$pglib =~ s|^$contribRoot|Contrib|;
 
 		my $tags = Tags->new($name);
 

--- a/.github/workflows/bin/generate-OPL-tables.pl
+++ b/.github/workflows/bin/generate-OPL-tables.pl
@@ -260,17 +260,17 @@ sub safe_get_id {
 sub isvalid {
 	my $tags = shift;
 	if (!defined $taxo->{ $tags->{DBsubject} }) {
-		print "\nInvalid subject $tags->{DBsubject}\n";
+		#print "\nInvalid subject $tags->{DBsubject}\n";
 		return 0;
 	}
 	if (!($tags->{DBchapter} eq 'Misc.') && !defined $taxo->{ $tags->{DBsubject} }{ $tags->{DBchapter} }) {
-		print "\nInvalid chapter $tags->{DBchapter}\n";
+		#print "\nInvalid chapter $tags->{DBchapter}\n";
 		return 0;
 	}
 	if (!($tags->{DBsection} eq 'Misc.')
 		&& !defined $taxo->{ $tags->{DBsubject} }{ $tags->{DBchapter} }{ $tags->{DBsection} })
 	{
-		print "\nInvalid section $tags->{DBsection}\n";
+		#print "\nInvalid section $tags->{DBsection}\n";
 		return 0;
 	}
 	return 1;
@@ -519,8 +519,9 @@ sub pgfiles {
 
 		if ($tags->istagged()) {
 			# Fill in missing data with Misc. instead of blank
-			print "\nNO SUBJECT $name\n" unless ($tags->{DBsubject} =~ /\S/);
+			#print "\nNO SUBJECT $name\n" unless ($tags->{DBsubject} =~ /\S/);
 
+			$tags->{DBsubject} = 'Misc.' unless $tags->{DBchapter} =~ /\S/;
 			$tags->{DBchapter} = 'Misc.' unless $tags->{DBchapter} =~ /\S/;
 			$tags->{DBsection} = 'Misc.' unless $tags->{DBsection} =~ /\S/;
 
@@ -564,7 +565,7 @@ sub pgfiles {
 				}
 			} else {
 				# Tags are not valid, error printed by validation part.
-				print "File $name\n";
+				#print "File $name\n";
 				next;
 			}
 
@@ -615,17 +616,15 @@ sub pgfiles {
 			my $path_id = safe_get_id($tables{path}, 'path_id', qq(WHERE path = ?), [$pgpath], 1, '', $pgpath, '', '');
 
 			# pgfile table -- set 4 defaults first
-
-			# TODO this is where we have to deal with crosslists, and pgfileid will be an array of id's
-			# Make an array of DBsection-id's above
-			my $level = $tags->{Level} || 0;
-			# Default language is English
+			my $level   = ($tags->{Level} =~ /\d/) ? $tags->{Level} || 0;
 			my $lang    = $tags->{Language} || 'en';
 			my $mathobj = $tags->{MO}       || 0;
 			my $static  = $tags->{Static}   || 0;
 
-			my @pgfile_ids;
 
+			# TODO this is where we have to deal with crosslists, and pgfileid will be an array of id's
+			# Make an array of DBsection-id's above
+			my @pgfile_ids;
 			for my $DBsection_id (@DBsection_ids) {
 				my $pgfile_id = safe_get_id(
 					$tables{pgfile}, 'pgfile_id',


### PR DESCRIPTION
Now that Contrib is almost as large as the OPL itself, it seems time to support the searching of Contrib alongside the OPL in the Library Browser. In order to do so, a `libraryroot` field has been added to the `OPL_pgfile` table. When paired with openwebwork/webwork2#TBD, the Library Browser will support searching all Contrib problems *that have been properly tagged*. Any Contrib problems that are not tagged according to `OpenProblemLibrary/Taxonomy2` will not be searchable in the Problem Library.

Moving forward, I will be creating an index of problems that are **not** searchable. My hope is that we can make progress in terms of sorting this content into the taxonomy (and expanding the taxonomy, where necessary). When combined with usage data submitted by our community, we will be able to use these statistics to 'approve' Contrib content that has seen significant usage (as a proxy for problem stability).