### PR TITLE
Increase minimum z-score of normal approx. to binomial dist. problem

### DIFF
--- a/Contrib/Piedmont/StevensStatistics/6-ContinuousProbabilityDistributions/6.5.13.pg
+++ b/Contrib/Piedmont/StevensStatistics/6-ContinuousProbabilityDistributions/6.5.13.pg
@@ -34,7 +34,7 @@ $p = 0.48;
 $q = 1 - $p;
 $mu = Compute($n*$p);
 $sigma = Compute(sqrt($n*$p*$q));
-$x = random(round(-3.5*$sigma + $mu), round(-2*$sigma+$mu));
+$x = random(round(-3.4*$sigma + $mu), round(-2*$sigma+$mu));
 
 $z = Compute(($x - $mu)/$sigma)->with(
     tolType => 'absolute',


### PR DESCRIPTION
The table in Stevens says to use P(Z < z) = 0.0001 for all z < -3.5, which isn't accurate when z is still near -3.5, so we avoid this by making z >= -3.4.
