### PR TITLE
Add the ability to include alt tags for unionImages and imageChoice macros

### DIFF
--- a/OpenProblemLibrary/macros/CollegeOfIdaho/imageChoice.pl
+++ b/OpenProblemLibrary/macros/CollegeOfIdaho/imageChoice.pl
@@ -1,5 +1,125 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2022 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+=head1 NAME
+
+imageChoice.pl - Provides support for randomly selecting a subset of images from
+a given set.
+
+=head1 DESCRIPTION
+
+This is similar to the ChoiceList macro for producing multiple choice problems
+however has additional features for images.
+
+To use the scaffolding macros, include the macros into your problem
+
+    loadMacros("imageChoice.pl");
+
+In the preamble of the problem, first define an array of questions and answers
+where the answers are images:
+
+    #Define the questions and answers
+    @QA = (
+    "image 1", "image1.png",
+    "image 2", "image2.png",
+    "image 3", "image3.png",
+    "image 4", "image4.png",
+    "image 5", "image5.png",
+    "image 6", "image6.png",
+    );
+
+Note that the images can be local links (like the above example) or absolute links
+where the images can be on a different server.
+
+Next, define the match list.  A default is
+
+    $ml = new_image_match_list();
+
+Often, this is used with popup lists and the following will create these:
+
+    $ml->rf_print_q(~~&pop_up_list_print_q); # use pop-up-lists
+    $ml -> ra_pop_up_list([ No_answer=>"?", A=>"A", B=>"B", C=>"C", D=>"D" ] );
+
+    $ml->qa(@QA);               #  set the questions and answers
+    $ml->choose(4);             #  select 4 of them
+
+As an example, the main text of the problem (as a PGML block) could look like:
+
+    BEGIN_PGML
+    Match the correct image
+
+    [@ $ml -> print_q @]*
+
+    [@ $ml -> print_a @]*
+    END_PGML
+
+=head2 new_image_match_list
+
+Makes a new image match list. The following options are valid for an Image (from
+the unionImage macro)
+
+=over
+
+=item * C<size => [w,h]>
+
+the width and height of the images
+
+=item * C<width => n>
+
+the width of the images (obsolete)
+
+=item * C<height => n>
+
+the height of the images (obsolete)
+
+=item * C<tex_size => n>
+
+the size for the TeX version of the image
+
+=item * C<separation => n>
+
+the spacing between the images in a row
+
+=item * C<vseparation => n>
+
+the spacing between the images and captions
+
+=item * C<link => 0>
+
+or 1     1 to make a link to the original image
+
+=item * C<columns => n>
+
+the number of images in each row (defaults to 4)
+
+=item * C<border => n>
+
+the width of the image border
+
+=item *C<extra_html_tags => str>
+
+where C<str> is a string containing any extra html tags to the image tag.  This
+is often used for alt tags.
+
+=back
+
+=cut
+
 loadMacros(
   'PGchoicemacros.pl',
+  "PGunion.pl",
   'unionUtils.pl',
   'choiceUtils.pl',
 );
@@ -47,6 +167,7 @@ sub new_image_match_list {
 
 sub img_print_a {
   my $self = shift;
+
   $self->{ImageOptions} = [] unless defined($self->{ImageOptions});
   my %options = (
      width => 150, height => 150, tex_size => 200, columns => 4,
@@ -55,6 +176,13 @@ sub img_print_a {
      ($w,$h) = @{$options{size}} if defined($options{size});
   my ($sep,$vsep) = ($options{separation},$options{vseparation});
   my ($tsize,$link) = ($options{tex_size},$options{link});
+  my $extra_html_tags = $options{extra_html_tags};
+
+  # this is the order of the images.  Needed for getting proper extra_html_tags.
+  my @sl = @{$self->{slice}};
+  my @sh = @{$self->{shuffle}};
+  my @image_order = @sl[@sh];
+
   my $border = $options{border}; $border = ($link?2:1) unless defined($border);
   my $HTML; my @images = (); my @labels = (); my $i = 0;
   my $out;
@@ -63,7 +191,7 @@ sub img_print_a {
   while ($image = shift) {
     push(@images,Image(
       $image, size => [$w,$h], tex_size => $tsize,
-	      link => $link, border => $border
+	      link => $link, border => $border, extra_html_tags => $extra_html_tags->[$image_order[$i]]
     ));
     push(@labels,MODES(
       TeX => "\\hfil \\textbf{$main::ALPHABET[$i]}",

--- a/OpenProblemLibrary/macros/Union/unionImage.pl
+++ b/OpenProblemLibrary/macros/Union/unionImage.pl
@@ -16,7 +16,7 @@ sub _unionImage_init {}; # don't reload this file
 #                            (default is [150,150])
 #
 #    tex_size => r           the size to use in TeX mode (as a percentage
-#                            of the line width times 10).  E.g., 500 is 
+#                            of the line width times 10).  E.g., 500 is
 #                            half the width, etc.  (default is 200.)
 #
 #    link => 0 or 1          whether to include a link to the original
@@ -32,6 +32,8 @@ sub _unionImage_init {}; # don't reload this file
 #
 #    tex_center => 0 or 1    whether to center the image horizontally
 #                            in TeX mode  (default is 0)
+#    extra_html_tags => s    where s is a string of any extra html tags to be
+#                            passed to the img tag.
 #
 #  The image name can be one of a number of different things.  It can be
 #  the name of an image file, or an alias to one produce by the alias()
@@ -56,6 +58,7 @@ sub Image {
   my ($ratio,$link) = ($options{tex_size}*(.001),$options{link});
   my ($border,$align) = ($options{border},$options{align});
   my ($tcenter) = $options{tex_center};
+  my $extra_html_tags = $options{extra_html_tags};
   my $HTML; my $TeX;
   ($image,$ilink) = @{$image} if (ref($image) eq "ARRAY");
   $ilink = $ilink//'';
@@ -66,15 +69,15 @@ sub Image {
     $ilink = alias($ilink) unless ($ilink =~ m!^(/|https?:)!i); # see note
   } else {$ilink = $image}
   #
-  # Note: These cases were added to handle the examples where the 
-  # $image tag has a full url -- in practice this arises when using lighttpd 
+  # Note: These cases were added to handle the examples where the
+  # $image tag has a full url -- in practice this arises when using lighttpd
   # to server images from a different port
   # e.g. http://hosted2.webwork.rochester.edu:8000/webwork2_course_files/....
   # A smarter implementation of alias might make this check unnecessary
   #
   $border = (($link || $ilink ne $image)? 2: 1) unless defined($border);
   $HTML = '<IMG SRC="'.$image.'" WIDTH="'.$w.
-          '" HEIGHT="'.$h.'" BORDER="'.$border.'" ALIGN="'.$align.'">';
+          '" HEIGHT="'.$h.'" BORDER="'.$border.'" ALIGN="'.$align.'" '. $extra_html_tags . '>';
   $HTML = '<A HREF="'.$ilink.'">'.$HTML.'</A>' if $link or $ilink ne $image;
   $TeX = '\includegraphics[width='.$ratio.'\linewidth]{'.$image.'}';
   $TeX = '\centerline{'.$TeX.'}' if $tcenter;


### PR DESCRIPTION
This allows for adding extra html tags to unionImages and in imageChoice macros.  This is mainly for use for alt tags in images. 

A sample problem with images have been attached. The important part of this test is that the alt tag of the images have been set correctly--the order is important.

Note: there are two copies of `imageChoice.pl` in this repository. The one in `CollegeOfIdaho` is loaded before the one in Union, so this one is update. 

In a future PR, consolidation of the macros will be done. 

[image_choice.pg.txt](https://github.com/openwebwork/webwork-open-problem-library/files/9268012/image_choice.pg.txt)
<img width="91" alt="image1" src="https://user-images.githubusercontent.com/879338/183065221-4366df45-136e-4ca5-8cd3-c38de3c25b96.png">
<img width="94" alt="image2" src="https://user-images.githubusercontent.com/879338/183065223-f4888008-e505-4750-bcde-08bc48037be6.png">
<img width="91" alt="image3" src="https://user-images.githubusercontent.com/879338/183065225-3837b0f8-6a2e-4361-bb82-40f9d0245d17.png">
<img width="88" alt="image4" src="https://user-images.githubusercontent.com/879338/183065226-02064a14-95d7-454a-b805-58286bc0a9b0.png">
<img width="95" alt="image5" src="https://user-images.githubusercontent.com/879338/183065229-925d26d3-a40b-4ff2-9bc9-89ff018f9948.png">
<img width="87" alt="image6" src="https://user-images.githubusercontent.com/879338/183065231-dccdb5a9-5316-4a20-81fc-3d9728ebd82e.png">

