### PR TITLE
Rewrite problem with PGML and MathObjects

### DIFF
--- a/OpenProblemLibrary/maCalcDB/setDiffEQ3Separable/ur_de_3_1.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ3Separable/ur_de_3_1.pg
@@ -6,6 +6,7 @@
 ## Date(6/3/2002)
 ## Institution(Rochester)
 ## Level(4)
+## MO(1)
 ## TitleText1('Calculus: Early Transcendentals')
 ## AuthorText1('Stewart')
 ## EditionText1('6')

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ3Separable/ur_de_3_1.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ3Separable/ur_de_3_1.pg
@@ -19,21 +19,22 @@
 ## KEYWORDS('differential equation' 'separable' 'initial')
 ## DESCRIPTION
 ##  ## Differential equations
-##  One can ask  all,or A&B,or A&B& ( C &/or D)
-##    ( t^2 - $ At + $B)frac&#123;dy&#125;&#123;dt&#125; = y )
-##   URL:http://webhost.math.rochester.edu/mth163lib/discuss/msgReader$375
+##  One can ask all, or A&B, or A&B& (C &/or D)
+##    ( t^2 - $At + $B) dy/dt = y )
 ##
 ## ENDDESCRIPTION
 DOCUMENT() ;
 
 loadMacros(
   "PGstandard.pl",
-  "PGchoicemacros.pl",
-  "PGcourse.pl"
+  "PGcourse.pl",
+  "PGML.pl"
 );
 
 TEXT(beginproblem()) ;
 $showPartialCorrectAnswers = 1 ;
+
+Context("Numeric")->variables->are('t'=>"Real");
 
 $a = random(1,7,1) ;
 $c = random(2,7,1) ;
@@ -42,34 +43,30 @@ $p = $a + $c ;
 $B = $a*$b ;
 $A = 2*$p ;
 
-BEGIN_TEXT
-A. Solve the following initial value problem:
-\[ (t^2 - $A t + $B ) \frac { dy }{ dt } = y \] with \( y( $p ) =1\).
-(Find \(y\) as a function of \(t\).) $BR
-\(y = \) \{ans_rule(40) \}. $BR $BR 
-B.  On what interval is the solution valid?  $BR
-Answer:  It is valid for \{ans_rule(5) \} \( < t < \) \{ans_rule(5) \}.
-$BR $BR
-C.  Find the limit of the solution as \(t\) approaches the left end of the
-interval. $BR (Your answer should be a number or the word "infinite".) $BR
-Answer: \{ans_rule(25) \}. $BR $BR
-D.  Similar to C, but for the right end. $BR
-Answer: \{ans_rule(25) \}. $BR
+$twoc = 2*$c;
+$ansA = Compute("(($b-t)/(t-$a))^(1/($twoc))") ;
+$ansA->{limits} = [$a+.5,$b];
+$ansBL = Compute($a) ;
+$ansBR = Compute($b) ;
+$ansC = Compute("inf") ;
+$ansD = Compute("0") ;
 
-END_TEXT
+BEGIN_PGML
+Consider the following initial value problem:
+[``` (t^2 - [$A] t + [$B] ) \frac { dy }{ dt } = y\quad \mbox{with} \quad y( [$p] ) =1.```]
 
-$ansA = " (($b-t)/(t-$a))**(1/(2*$c))" ;
-$ansBL = $a ;
-$ansBR = $b ;
-$ansC = 'infinite' ;
-$ansD = 0 ;
+A) Solve the initial value problem (find [`y`] as a function of [`t`].)  
+[`y = `][__________]{$ansA}
+B) On what interval is the solution valid?  
+It is valid for [___]{$ansBL}[` < t < `][___]{$ansBR}.
+C) Find the limit of the solution as [`t`] approaches the left end of the
+interval.  
+Answer: [_____]{$ansC}
+D) Find the limit of the solution as [`t`] approaches the right end of the
+interval.  
+Answer: [_____]{$ansD}
 
-
-ANS(fun_cmp($ansA, var=>"t",limits=>[$a, $b] )) ;
-ANS(num_cmp($ansBL)) ;
-ANS(num_cmp($ansBR)) ;
-ANS(num_cmp(    [$ansC,   $ansD ] ,    strings=>["infinite"])) ; 
-
+END_PGML
 
 ENDDOCUMENT() ;
 ##################################################

--- a/OpenProblemLibrary/maCalcDB/setDiffEQ3Separable/ur_de_3_1.pg
+++ b/OpenProblemLibrary/maCalcDB/setDiffEQ3Separable/ur_de_3_1.pg
@@ -28,8 +28,8 @@ DOCUMENT() ;
 
 loadMacros(
   "PGstandard.pl",
-  "PGcourse.pl",
-  "PGML.pl"
+  "PGML.pl",
+  "PGcourse.pl"
 );
 
 TEXT(beginproblem()) ;


### PR DESCRIPTION
This problem was causing issues with MathQuill since it was hardcoded to look for the string `"infinity"`, and doesn't accept the MQ `inf`.  It has now been rewritten with MathObjects for better compatibility.  Some of the formatting and wording has also been improved.