### PR TITLE
Bugfix: The origin is always a source, not a spiral source,

### DIFF
--- a/Contrib/OKState/ODE/nonlin-systems/vanderpol1.pg
+++ b/Contrib/OKState/ODE/nonlin-systems/vanderpol1.pg
@@ -87,6 +87,6 @@ ANS ($ans2->cmp);
 
 ANS($jac->cmp);
 
-ANS( str_cmp ("spiral source") );
+ANS( str_cmp ("source") );
 
 ENDDOCUMENT();

--- a/OpenProblemLibrary/OKState/ODE/nonlin-systems/vanderpol1.pg
+++ b/OpenProblemLibrary/OKState/ODE/nonlin-systems/vanderpol1.pg
@@ -87,6 +87,6 @@ ANS ($ans2->cmp);
 
 ANS($jac->cmp);
 
-ANS( str_cmp ("spiral source") );
+ANS( str_cmp ("source") );
 
 ENDDOCUMENT();


### PR DESCRIPTION
The origin is always a source, not a spiral source, thanks to Xu-Yan Chen of Georgia Tech for reporting it.