### PR TITLE
Fix possible initial values for Newton's method problem.

### DIFF
--- a/OpenProblemLibrary/Valdosta/APEX_Calculus/4.1/APEX_4.1_7.pg
+++ b/OpenProblemLibrary/Valdosta/APEX_Calculus/4.1/APEX_4.1_7.pg
@@ -27,8 +27,7 @@ loadMacros(
 TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
-$a1 = random(5,8,1);
-$x0 = random(2,3,0.1);
+$x0 = random(2,2.7,0.1);
 
 $f = Formula("ln(x)");
 $df=$f->D('x');


### PR DESCRIPTION
For this problem, Newton's method gives us:

$x_{n + 1} = x_n  (1 - \ln x_n)$

However, since ln must take positive arguments, we need to ensure that $x_n > 0$ for all $n$.  For this to happen, we must have, for all $n$:

$x_n (1 - \ln x_n) > 0$
$1 - \ln x_n > 0$
$\ln x_n < 1$
$x_n < e$

So we reduce the maximum initial choice for $x_0$ from 3 to 2.7.  Previously, students that got $x_0 \geq 2.8$ received an error message.

Note that $x (1 - \ln x)$ achieves its maximum value of 1 when $x = 1$, so there's no risk of getting $x_n \geq e$ for larger $n$.

We also remove the unused variable `a1`.