### PR TITLE
Update Identity01.pg

### DIFF
--- a/OpenProblemLibrary/NAU/setTrigIdentity/Identity01.pg
+++ b/OpenProblemLibrary/NAU/setTrigIdentity/Identity01.pg
@@ -37,7 +37,7 @@ $size=scalar @leftTex;
 @answer=('sin(x)','cos(x)','1','1','csc(x)');                                      
 
 ##  strings forbidden in the answer by prefilter
-@left=('tan','cot','sec','sin','cot');
+@left=('cos','sin','cos','sin','sin');
 
 
 ##  load answer evaluator


### PR DESCRIPTION
In order to enforce simplification the sine and cosine functions have to be undefined instead of the other trig functions.