### PR TITLE
Remove note about units and change parameterization notation

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_8/prob1.pg
+++ b/OpenProblemLibrary/AlfredUniv/anton8e/chapter16/16_8/prob1.pg
@@ -1,7 +1,7 @@
 ##DESCRIPTION
 #
 # File Created: 6/4/2008
-# Last Modified: 4/17/2014
+# Last Modified: 12/5/2022
 # Problem Author: Darwyn Cook
 # WeBWorK Entry: 
 # Location: Alfred University
@@ -78,7 +78,6 @@ Context()->texStrings;
 BEGIN_TEXT
 Let \(\sigma\) be the surface \($d x + $e y + $f z=$g\) in the first octant, oriented upwards. Let C be the oriented boundary of \(\sigma\). Compute the work done in moving a unit mass particle around the boundary of \(\sigma\) through the vector field \(F = $F\) using line integrals, and using Stokes' Theorem.  
 
-$PAR Assume mass is measured in kg, length in meters, and force in Newtons (1 nt = 1kg-m). 
 $PAR
 LINE INTEGRALS
 $BR
@@ -100,7 +99,7 @@ $PAR
 $PAR
 STOKES' THEOREM
 $PAR
-\(\sigma\) may be parameterized by \(r(x,y)=(x,y,f(x,y))=\) \{ans_rule(30)\}
+\(\sigma\) may be parameterized by \(r(x,y)=x\boldsymbol{i}+y\boldsymbol{j}+f(x,y)\boldsymbol{k}=\) \{ans_rule(30)\}
 $PAR
 \(\mbox{curl } F = \) \{ans_rule(30)\}
 $PAR


### PR DESCRIPTION
Remove the note about units since the answers do not require (or accept) units.

Change the notation for the parametrization of the surface, as the provided notation (parentheses) will not be accepted for the answer.