### PR TITLE
Fix custom grader to be compatible with gateway quiz mode

### DIFF
--- a/Contrib/CUNY/OPLremix/Library/Indiana/Indiana_setSeries5IntegralTest/ur_sr_5_11.pg
+++ b/Contrib/CUNY/OPLremix/Library/Indiana/Indiana_setSeries5IntegralTest/ur_sr_5_11.pg
@@ -95,11 +95,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/ASU-topics/setCalculus/stef/stef4_4p1.pg
+++ b/OpenProblemLibrary/ASU-topics/setCalculus/stef/stef4_4p1.pg
@@ -76,26 +76,9 @@ See instructions above regarding partial credit',
 
     my      $numright=0;
 
-    $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0007'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0008'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0009'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0010'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0011'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0012'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0013'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0014'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0015'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0016'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0017'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0018'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0019'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0020'}->{score});
+    foreach my $ans_name (keys %evaluated_answers) {
+    $numright += ($evaluated_answers{$ans_name}->{score});
+    }
 
     if ($numright == 20) {
         $total = 1;

--- a/OpenProblemLibrary/Indiana/Indiana_setSeries5IntegralTest/ur_sr_5_11.pg
+++ b/OpenProblemLibrary/Indiana/Indiana_setSeries5IntegralTest/ur_sr_5_11.pg
@@ -93,11 +93,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setDerivatives21LHospital/osu_dr_21_20.pg
+++ b/OpenProblemLibrary/Rochester/setDerivatives21LHospital/osu_dr_21_20.pg
@@ -84,26 +84,9 @@ See instructions above regarding partial credit',
 
     my      $numright=0;
 
-    $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0007'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0008'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0009'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0010'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0011'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0012'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0013'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0014'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0015'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0016'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0017'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0018'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0019'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0020'}->{score});
+    foreach my $ans_name (keys %evaluated_answers) {
+    $numright += ($evaluated_answers{$ans_name}->{score});
+    }
 
     if ($numright == 20) {
         $total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries3Convergent/ns8_3_17BB.pg
+++ b/OpenProblemLibrary/Rochester/setSeries3Convergent/ns8_3_17BB.pg
@@ -89,11 +89,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries3Convergent/ns8_3_7BB.pg
+++ b/OpenProblemLibrary/Rochester/setSeries3Convergent/ns8_3_7BB.pg
@@ -89,11 +89,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries6CompTests/benny_ser2b.pg
+++ b/OpenProblemLibrary/Rochester/setSeries6CompTests/benny_ser2b.pg
@@ -95,11 +95,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries6CompTests/benny_ser3B.pg
+++ b/OpenProblemLibrary/Rochester/setSeries6CompTests/benny_ser3B.pg
@@ -89,12 +89,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 6) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries6CompTests/benny_ser4B.pg
+++ b/OpenProblemLibrary/Rochester/setSeries6CompTests/benny_ser4B.pg
@@ -91,9 +91,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 3) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries6CompTests/ur_sr_6_9a.pg
+++ b/OpenProblemLibrary/Rochester/setSeries6CompTests/ur_sr_6_9a.pg
@@ -82,12 +82,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 6) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries7AbsolutelyConvergent/eva8_3_2BB.pg
+++ b/OpenProblemLibrary/Rochester/setSeries7AbsolutelyConvergent/eva8_3_2BB.pg
@@ -95,11 +95,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries7AbsolutelyConvergent/eva8_4aBB.pg
+++ b/OpenProblemLibrary/Rochester/setSeries7AbsolutelyConvergent/eva8_4aBB.pg
@@ -94,11 +94,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Rochester/setSeries7AbsolutelyConvergent/ns8_4_20BB.pg
+++ b/OpenProblemLibrary/Rochester/setSeries7AbsolutelyConvergent/ns8_4_20BB.pg
@@ -87,11 +87,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Utah/Calculus_II/set7_Infinite_Series/set7_pr15.pg
+++ b/OpenProblemLibrary/Utah/Calculus_II/set7_Infinite_Series/set7_pr15.pg
@@ -80,11 +80,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 5) {
 		$total = 1;

--- a/OpenProblemLibrary/Utah/Calculus_II/set8_Infinite_Series/set8_pr18.pg
+++ b/OpenProblemLibrary/Utah/Calculus_II/set8_Infinite_Series/set8_pr18.pg
@@ -89,12 +89,9 @@ sub custom_problem_grader {
 
         my      $numright=0;
 
-        $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-        $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
+        foreach my $ans_name (keys %evaluated_answers) {
+        $numright += ($evaluated_answers{$ans_name}->{score});
+        }
 
 	if ($numright == 6) {
 		$total = 1;

--- a/OpenProblemLibrary/maCalcDB/setDerivatives21LHospital/osu_dr_21_20.pg
+++ b/OpenProblemLibrary/maCalcDB/setDerivatives21LHospital/osu_dr_21_20.pg
@@ -70,26 +70,9 @@ See instructions above regarding partial credit',
 
     my      $numright=0;
 
-    $numright += ($evaluated_answers{'AnSwEr0001'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0002'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0003'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0004'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0005'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0006'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0007'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0008'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0009'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0010'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0011'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0012'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0013'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0014'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0015'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0016'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0017'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0018'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0019'}->{score});
-    $numright += ($evaluated_answers{'AnSwEr0020'}->{score});
+    foreach my $ans_name (keys %evaluated_answers) {
+    $numright += ($evaluated_answers{$ans_name}->{score});
+    }
 
     if ($numright == 20) {
         $total = 1;


### PR DESCRIPTION
There are a number of problems in the OPL which have custom graders that are hard-coded to look for the keys `'AnSwEr0001'`, `'AnSwEr0002'`, etc. in the `%evaluated_answers` hash.  This means that they don't work in gateway sets because of the prepended gateway prefix.

This is a quick fix to one such problem.  Let me know if you think that this is the right approach.  If so, I will propagate it to the other offending problems.