### PR TITLE
Update s2_6_19_mo.pg

### DIFF
--- a/OpenProblemLibrary/Rochester/setDerivatives2_5Implicit/s2_6_19_mo.pg
+++ b/OpenProblemLibrary/Rochester/setDerivatives2_5Implicit/s2_6_19_mo.pg
@@ -104,7 +104,7 @@ Use implicit differentiation to find an equation
 of the tangent line to the curve \( $F = $k \)
 at the point \( $P1 \).
 $BR $BR
-The \{ helpLink(equation) \} \{ans_rule(20) \}
+The \{ helpLink('equation') \} \{ans_rule(20) \}
 defines the tangent line to the curve at the
 point \( $P1 \).
 END_TEXT


### PR DESCRIPTION
Added quotes around equation on line 107 to helpLink('equation') to eliminate error (warning) message Unquoted string "equation" may clash with future reserved word at (eval 1865) line 2.