### PR TITLE
Fix accepting answers due to excessive rounding in the

### DIFF
--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-07.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-07.pg
@@ -44,6 +44,11 @@ TEXT(beginproblem());
 
 Context("Numeric");
 Context()->variables->are(t=>"Real");
+Context()->variables->set(t=>{limits=>[-1,0]});
+Context()->flags->set(
+  reduceConstants => 0,
+  reduceConstantFunctions => 0,
+);
 
 $m = 2;
 $c = 8;
@@ -54,14 +59,19 @@ $w = 8;
 
 $F = Formula("2*$a cos($w t)")->reduce();
 
-$c1 = Compute("3*$a/200");
-$c2 = Compute("(2*$c1-8*$a/50)/6");
-$c3 = Compute("-3*$a/200");
-$c4 = Compute("$a/50");
+## this does too much rounding for some seeds
+#$c1 = Compute("3*$a/200");
+#$c2 = Compute("(2*$c1-8*$a/50)/6");
+#$c3 = Compute("-3*$a/200");
+#$c4 = Compute("$a/50");
+$c1 = Formula("3*$a/200");
+$c2 = Formula("-13*$a/600");
+$c3 = Formula("-3*$a/200");
+$c4 = Formula("$a/50");
 
-$y = Compute("$c1 e^(-2t) cos(6t) + $c2 e^(-2t) sin(6t) + $c3 cos(8t) + $c4 sin(8t)");
+$y = Formula("$c1 e^(-2t) cos(6t) + $c2 e^(-2t) sin(6t) + $c3 cos(8t) + $c4 sin(8t)");
 
-$yinfinity = Compute("$c3 cos(8t) + $c4 sin(8t)");
+$yinfinity = Formula("$c3 cos(8t) + $c4 sin(8t)");
 
 
 Context()->texStrings;

--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-07.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-07.pg
@@ -59,11 +59,6 @@ $w = 8;
 
 $F = Formula("2*$a cos($w t)")->reduce();
 
-## this does too much rounding for some seeds
-#$c1 = Compute("3*$a/200");
-#$c2 = Compute("(2*$c1-8*$a/50)/6");
-#$c3 = Compute("-3*$a/200");
-#$c4 = Compute("$a/50");
 $c1 = Formula("3*$a/200");
 $c2 = Formula("-13*$a/600");
 $c3 = Formula("-3*$a/200");

--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-08.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-08.pg
@@ -59,10 +59,6 @@ $w = 8;
 
 $F = Formula("$a e^(-t)")->reduce();
 
-## this does too much rounding for some seeds
-#$c1 = Compute("-$a/74");
-#$c2 = Compute("($a/74 + 2*$c1)/6");
-#$c3 = Compute("$a/74");
 $c1 = Formula("-$a/74");
 $c2 = Formula("-$a/444");
 $c3 = Formula("$a/74");

--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-08.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-08.pg
@@ -44,6 +44,11 @@ TEXT(beginproblem());
 
 Context("Numeric");
 Context()->variables->are(t=>"Real");
+Context()->variables->set(t=>{limits=>[-1,0]});
+Context()->flags->set(
+  reduceConstants => 0,
+  reduceConstantFunctions => 0,
+);
 
 $m = 2;
 $c = 8;
@@ -54,13 +59,18 @@ $w = 8;
 
 $F = Formula("$a e^(-t)")->reduce();
 
-$c1 = Compute("-$a/74");
-$c2 = Compute("($a/74 + 2*$c1)/6");
-$c3 = Compute("$a/74");
+## this does too much rounding for some seeds
+#$c1 = Compute("-$a/74");
+#$c2 = Compute("($a/74 + 2*$c1)/6");
+#$c3 = Compute("$a/74");
+$c1 = Formula("-$a/74");
+$c2 = Formula("-$a/444");
+$c3 = Formula("$a/74");
 
-$y = Compute("$c1 e^(-2t) cos(6t) + $c2 e^(-2t) sin(6t) + $c3 e^(-t)");
 
-$yinfinity = Compute("0");
+$y = Formula("$c1 e^(-2t) cos(6t) + $c2 e^(-2t) sin(6t) + $c3 e^(-t)");
+
+$yinfinity = Formula("0");
 
 
 Context()->texStrings;

--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-09.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-09.pg
@@ -60,11 +60,6 @@ $w = 6;
 
 $F = Formula("$a sin($w t)")->reduce();
 
-## this does too much rounding for some seeds
-#$c1 = Compute("6*$a/296");
-#$c2 = Compute("(2*$c1 - 6*$a/296)/6");
-#$c3 = Compute("-6*$a/296");
-#$c4 = Compute("$a/296");
 $c1 = Formula("3*$a/148");
 $c2 = Formula("$a/296");
 $c3 = Formula("-3*$a/148");

--- a/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-09.pg
+++ b/OpenProblemLibrary/FortLewis/DiffEq/2-Higher-order/06-Forcing-resonance/KJ-3-10-09.pg
@@ -45,10 +45,10 @@ TEXT(beginproblem());
 
 Context("Numeric");
 Context()->variables->are(t=>"Real");
-Context()->variables->set(t=>{limits=>[-3,2]});
+Context()->variables->set(t=>{limits=>[-1,0]});
 Context()->flags->set(
-  tolerance => 0.001,
-  tolType => "absolute",
+  reduceConstants => 0,
+  reduceConstantFunctions => 0,
 );
 
 $m = 2;
@@ -60,14 +60,20 @@ $w = 6;
 
 $F = Formula("$a sin($w t)")->reduce();
 
-$c1 = Compute("6*$a/296");
-$c2 = Compute("(2*$c1 - 6*$a/296)/6");
-$c3 = Compute("-6*$a/296");
-$c4 = Compute("$a/296");
+## this does too much rounding for some seeds
+#$c1 = Compute("6*$a/296");
+#$c2 = Compute("(2*$c1 - 6*$a/296)/6");
+#$c3 = Compute("-6*$a/296");
+#$c4 = Compute("$a/296");
+$c1 = Formula("3*$a/148");
+$c2 = Formula("$a/296");
+$c3 = Formula("-3*$a/148");
+$c4 = Formula("$a/296");
 
-$y = Compute("e^(-2t) ($c1 cos(6t) + $c2 sin(6t)) + $c3 cos(6t) + $c4 sin(6t)");
 
-$yinfinity = Compute("$c3 cos(6t) + $c4 sin(6t)");
+$y = Formula("e^(-2t) ($c1 cos(6t) + $c2 sin(6t)) + $c3 cos(6t) + $c4 sin(6t)");
+
+$yinfinity = Formula("$c3 cos(6t) + $c4 sin(6t)");
 
 
 Context()->texStrings;


### PR DESCRIPTION
Fix accepting answers due to excessive rounding in the problem setup.

First, make WW not reduce answers, and give the rational expressions exactly (simplified).  This also gives the "correct answer" to the student in a more reasonable way I think.

Also change the limits to [-1,0] as there the exponential is of reasonable size.

This should fix the previous problem that I suppose wasn't quite fixed.

This current issue was reported against a problem based on KJ-3-10-09.pg by Andras Balogh (UTRGV) for seed 4407.  That is this is https://github.com/jirilebl/diffyqs-webwork/blob/master/sec_2.6/prob01.pg