### PR TITLE
Fix wording of ellipse problem

### DIFF
--- a/OpenProblemLibrary/Wiley/setAnton_Section_10.4/Anton10_4Q21.pg
+++ b/OpenProblemLibrary/Wiley/setAnton_Section_10.4/Anton10_4Q21.pg
@@ -49,6 +49,11 @@ $y1=non_zero_random(1,8,1);
 $n1=$as1*$y1**2;
 $d1=($as1-$x1**2);
 ($n1,$d1)=reduce($n1,$d1);
+if ($as1 > $n1/$d1) {
+    $majorminor = "major";
+} else {
+    $majorminor = "minor";
+}
 $f1=Formula("x^2/$as1 +y^2/(b)^2");
 $xs1=$x1**2;
 $ys1=$y1**2;
@@ -86,7 +91,7 @@ Context()->texStrings;
 BEGIN_TEXT
 Find an equation for the ellipse that satisfies the following conditions.
 $PAR
-(a) Ends of major axis \((\pm $a1,0)\) and passes through \(($x1,$y1)\).
+(a) Ends of $majorminor axis \((\pm $a1,0)\) and passes through \(($x1,$y1)\).
 $PAR
 
 \(1=\) \{ ans_rule(50) \}
@@ -103,7 +108,7 @@ ANS( $ans2->cmp );
 Context()->texStrings;
 SOLUTION(EV3(<<'END_SOLUTION'));
 $PAR SOLUTION $PAR
-(a) The major axis lies on the \(x\)-axis and \(a=$a1\) will have the form\[$f1=1\]. Substituting in the point \(($x1,$y1)\) gives
+(a) The $majorminor axis lies on the \(x\)-axis and \(a=$a1\) will have the form\[$f1=1\]. Substituting in the point \(($x1,$y1)\) gives
 \[$f1v=1\] which solves to give \(b^2=$bs1\).
 Our final equation is then \[1=$F1\]
 $PAR


### PR DESCRIPTION
Depending on the random numbers chosen, there is a chance that the axis along the x-axis is the minor axis and not the major axis.  We fix the wording of the problem to reflect this.