### PR TITLE
Fix bug 4765 clarify wording increase level

### DIFF
--- a/OpenProblemLibrary/UMass-Amherst/Abstract-Algebra/PS-RingsIdealsHomomorphisms/RingsIdealsHomomorphisms1.pg
+++ b/OpenProblemLibrary/UMass-Amherst/Abstract-Algebra/PS-RingsIdealsHomomorphisms/RingsIdealsHomomorphisms1.pg
@@ -3,7 +3,7 @@
 ## DBsection(Ideals and homomorphisms)
 ## Institution(University of Massachusetts Amherst)
 ## Author(Daniel Nichols and Siman Wong)
-## Level(2)
+## Level(4)
 ## MO(1)
 ## KEYWORDS('ideals')
 
@@ -17,50 +17,93 @@ DOCUMENT();        # This should be the first executable line in the problem.
 loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",
-  "PGchoicemacros.pl",
-  "algebraMacros.pl",
   "PGcourse.pl"
 );
-
 
 TEXT(beginproblem());
 $showPartialCorrectAnswers = 0;
 
-@chooseModulus = ( 50, 51, 52, 54, 55, 56, 57, 58, 60, 62, 63, 64, 65, 66, 68, 69, 70, 72, 74, 75, 76, 77, 78, 80, 81, 82, 84, 85, 86, 87, 88, 90, 91, 92, 93, 94, 95, 96, 98, 99, 100 );
+# REVISED VERSION
+# The original verion rejected many correct 
+# answers.  This version is meant to correct that but it 
+# is more difficult than the original.  
 
-$modulus = $chooseModulus[ random( 0, @chooseModulus - 1, 1 ) ];
+# r,s,t are primes.  p=rs, q=rt so (p)+(q)=(gcd(p,q))=(r), 
+# (p)(q)=(pq)=(r^2st), (p)/cap(q)=(lcm(p,q))=(rst) are 
+# distinct in the integer ring Z.  The modulus n = xr^2st
+# is a multiple of pq so the three ideals are distinct
+# in the quotient ring Zmod(n).  Keep r,s,t,x small so 
+# n won't be too huge, and make a=py, b=qz where y and z
+# are units to create more randomness  
+# In the following the largest possible n is 
+# n = (3)(7^2)(3)(5) = 2205
 
-@elements = ( 2 .. $modulus - 2 );
+Context("Numeric");
 
-$a = splice( @elements, random( 0, @elements - 1, 1 ), 1 );
-$b = splice( @elements, random( 0, @elements - 1, 1 ), 1 );
+# randize the choice of 3 small primes  
 
-$ans[ 0 ] = Compute( gcd( $a, $b ) );
-$ans[ 1 ] = Compute( ( $a * $b ) % $modulus );
-$ans[ 2 ] = Compute( ( $a * $b ) % $modulus );
+@primes = (2,3,5,7);  
+@a = (0..2);
+for my $i (@a){
+  my $j = random($i,3,1);
+  ($primes[$i],$primes[$j]) = ($primes[$j],$primes[$i]);
+} 
+($r,$s,$t) = @primes[0,1,2];
 
-TEXT(EV3(<<'EOT'));
+# assign p, q, n
 
-In the ring \( \{ cyclic( $modulus ) \} \), express each of the following ideals in the form \( ( m ) \)
-for some element \( m \) in the ring, where \( 0 \leq m < $modulus \). $BR $BR
+$p = $r*$s;
+$q = $r*$t;
 
-(a) \( ( $a ) + ( $b ) \) $BR
-\( ( \) \{ ans_rule( 10 ) \} \( ) \) $BR $BR
+$x = (1,2,3)[random(0,2,1)];
 
-(b) \( ( $a )( $b ) \) $BR
-\( ( \) \{ ans_rule( 10 ) \} \( ) \) $BR $BR
+$n = $x*$p*$q;
 
-(c) \( ( $a ) \cap ( $b ) \) $BR
-\( ( \) \{ ans_rule( 10 ) \} \( ) \) $BR
+$y = (11,13,17)[random(0,2,1)];  # unit in Zmod(n)
+$z = (11,13,17)[random(0,2,1)];  # unit in Zmod(n)
 
-EOT
+$a = $p*$y % $n;
+$b = $q*$z % $n;
 
-ANS( $ans[0]->cmp );
-ANS( $ans[1]->cmp );
-ANS( $ans[2]->cmp );
+BEGIN_TEXT
 
+In the ring \(  \displaystyle \mathbb{Z}_{$n}  \), express each of the following ideals in the form \( ( m ) \),
+where \(0\leq m \lt $n \) is the smallest integer that is equivalent, mod $n, to a generator of the ideal.
+$PAR
+a.  \( ($a) \) = \( ( \) \{ ans_rule( 10 ) \} \( ) \) 
+
+$PAR
+b.  \( ($b) \) = \( ( \) \{ ans_rule( 10 ) \} \( ) \) 
+
+$PAR
+c.  \( ( $a ) + ( $b ) \) = \( ( \) \{ ans_rule( 10 ) \} \( ) \) 
+
+$PAR
+d.  \( ( $a )( $b ) \) = \( ( \) \{ ans_rule( 10 ) \} \( ) \) 
+
+$PAR
+e. \( ( $a ) \cap ( $b ) \) = \( ( \) \{ ans_rule( 10 ) \} \( ) \) 
+
+END_TEXT
+
+# custom error message
+
+$myChecker = sub {
+ my ($correct,$student,$ansHash) = @_;
+ my $max = $n-1;  
+ my $stu = $student -> value;
+ if ($stu > $max or $stu < 0){
+      Value->Error("Your value should be between 0 and $n - 1");
+ }
+ return ($student == $correct? 1 : 0);        
+};
+
+ANS(Compute($p)->cmp(checker => $myChecker));
+ANS(Compute($q)->cmp(checker => $myChecker));
+ANS( Compute($r)->cmp(checker => $myChecker) );  
+ANS( Compute($p*$q % $n)->cmp(checker => $myChecker) );
+ANS( Compute($r*$s*$t)->cmp(checker => $myChecker) );  
 
 COMMENT( "" );
-
 
 ENDDOCUMENT(); 


### PR DESCRIPTION
The original version rejected most correct answers by failing to account for mod n equivalences, and failed to ensure that different parts had different correct answers.  This version corrects these issues but requires raising the level of the problem. 