### PR TITLE
Remove unused variables in five-number summary problem

### DIFF
--- a/Contrib/Piedmont/OnlineMATH2100/MidtermExam/8.pg
+++ b/Contrib/Piedmont/OnlineMATH2100/MidtermExam/8.pg
@@ -83,9 +83,6 @@ DataTable(
     [
         [['index',midrule=>1], @indices],
         ['grade', @data],
-        [@five],
-        [@five2],
-        [@five3]
     ], 
 );
 \}


### PR DESCRIPTION
This apparently wasn't an issue prior to WeBWorK 2.18, but the data table is no longer displaying correctly.