### PR TITLE
Partially fix bug 4777.  Needs more work.  Update to PGML.

### DIFF
--- a/OpenProblemLibrary/Michigan/Chap2Sec4/Q01.pg
+++ b/OpenProblemLibrary/Michigan/Chap2Sec4/Q01.pg
@@ -50,117 +50,81 @@ DOCUMENT();
 loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",
-  "PGchoicemacros.pl",
+  "PGML.pl",
   "parserNumberWithUnits.pl",
   "parserPopUp.pl",
-  "parserAutoStrings.pl",
-  "AnswerFormatHelp.pl",
+  "parserRadioButtons.pl",
   "PGcourse.pl"
 );
 
 Context("Numeric");
-# AutoStrings();
-DefineStrings("degC","min","degC/min","min/degC","hr","degC/hr","hr/degC");
-$showPartialCorrectAnswers = 1;
+Context()->variables->add('degC'=>"Real",'min'=>"Real",'hr'=>"Real");
 
-# include javascript for pop-up explaining units
-# HEADER_TEXT(<<EOF);
-# <script language="javascript" type="text/javascript">
-# <!-- //
-# function unitspopup() {
-#     var url = "/webwork2_files/units.html";
-#     var opt = "height=625,width=600,location=no,menubar=no,status=no" +
-#               "resizable=yes,scrollbars=yes,toolbar=no,";
-#     window.open(url,'examdata_info',opt).focus();
-# }
-# // -->
-# </script>
-# EOF
+$showPartialCorrectAnswers = 1;
 
 $t = random(5,35,5);
 $f = random(50,80,1);
 $fp = random(0.1,2,0.1);
-$posneg = PopUp( [ "?", "positive", "negative" ], "negative" );
-# $units = NumberWithUnits( "1", "degC/min" );
-$units = String("degC/min");
-$temp = PopUp( ["?", "derivative", "temperature",
-		"change in temperature" ], "temperature" );
+
+$posneg = RadioButtons( 
+  [ 'positive.', 'negative.', 'zero.' ], 'negative.' , 
+  separator => "${SPACE}" x 4);
+
+$units = Formula("degC/min");
+$temp = PopUp( ["?", "derivative", "temperature", "change in temperature" ], 
+  "temperature" );
 $inc = PopUp( ["?", "increase", "decrease"], "decrease" );
 $dt = random(0.25,1.5,0.25);
 $dtsec = $dt*60;
 
-TEXT(beginproblem());
-Context()->texStrings;
-BEGIN_TEXT
-The temperature, \( H \), in degrees Celsius, of a cup of coffee
-placed on the kitchen counter is given by \( H = f(t) \), where
-\( t \) is in minutes since the coffee was put on the counter.
-$PAR
-${BBOLD}(a)$EBOLD
-Is \( f'(t) \) positive or negative?
-\{ $posneg->menu() \}
-$BR
-${BITALIC}(Be sure that you are able to give a reason for your
-answer.)$EITALIC
+BEGIN_PGML
+The temperature, [` H `], in degrees Celsius, of a hot cup of coffee
+placed on the kitchen counter is given by [` H = f(t) `], where
+[` t `] represents the number of minutes since the coffee was put on the 
+counter.
 
-$PAR
-${BBOLD}(b)$EBOLD
-What are the units of \( f'($t) \)?
-\{ ans_rule(15) \} \{ AnswerFormatHelp("units") \}
-$BR$BR
+    *(a)* Choose the correct word to complete the sentence.  Be sure you can give a reason for your choice:  
 
-Suppose that \( |f'($t)| = $fp \) and \( f($t) = $f \).  Fill in the
-blanks (including units where needed) and select the appropriate terms
-to complete the following statement about the temperature of the coffee
-in this case.
-$BR
-At \{ ans_rule(5) \} minutes after the coffee was put on the counter,
-its \{ $temp->menu() \} is \{ ans_rule(10) \} and will \{ $inc->menu() \}
-by about \{ ans_rule(10) \} in the next $dtsec seconds.
-$PAR
-${BBOLD}Note: If you are using MathQuill click the textbox (Tt) button before entering an answer that contains units.${EBOLD} 
+    If [`t>0`] then [` f'(t) `] is  
+    [_]{ $posneg } 
 
+If you are using MathQuill then click the textbox (Tt) button before entering the answer to part (b).    
 
-END_TEXT
-Context()->normalStrings;
+    *(b)* 
+What are the units of [` f'([$t]) `]?  [____]{ $units } [@ helpLink("units") @]* 
 
-ANS( $posneg->cmp() );
-# ANS( $units->cmp( checker=>sub {
-#     my ( $correct, $student, $ansHash ) = @_;
-#     return ( NumberWithUnits( "1", "degC/min" ) == 
-# 	     NumberWithUnits( "1", $student ) ) ? 1 : 0;
-# } ) );
-ANS( $units->cmp() );
-ANS( Compute( $t )->cmp() );
-ANS( $temp->cmp() );
-ANS( NumberWithUnits( $f, "degC" )->cmp() );
-ANS( $inc->cmp() );
-ANS( NumberWithUnits( "$fp*$dt", "degC" )->cmp() );
+    *(c)* Suppose that [` \lvert f'([$t]) \rvert = [$fp] `] and [` f([$t]) = [$f] `].  Fill in the blanks, including units where needed, and select the appropriate terms to complete the following statement about the temperature of the coffee in this case.
+
+    At [____]{$t}  minutes after the coffee was put on the counter, its [_]{$temp} is [______]{NumberWithUnits( $f, "degC" )}  and will [_]{ $inc } 
+by about [_______]{ NumberWithUnits( "$fp*$dt", "degC" )} in the next [$dtsec] seconds.
+END_PGML
+
+#ANS( $posneg->cmp() );
+#ANS( $units->cmp() );
+#ANS( Compute( $t )->cmp() );
+#ANS( $temp->cmp() );
+#ANS( NumberWithUnits( $f, "degC" )->cmp() );
+#ANS( $inc->cmp() );
+#ANS( NumberWithUnits( "$fp*$dt", "degC" )->cmp() );
 
 $delf = $fp*$dt;
 
-Context()->texStrings;
-SOLUTION(EV3(<<'END_SOLUTION'));
-$PAR SOLUTION $PAR
+BEGIN_PGML_SOLUTION
 
-${BBOLD}(a)$EBOLD
+*(a)*
 As the cup of coffee cools, the temperature decreases, so
-\(f'(t)\) is negative.
+[` f'(t) `] is negative.
 
-$PAR
-${BBOLD}(b)$EBOLD
-Since \(f'(t) = dH/dt\), the units are degrees Celsius per
-minute (degC/min).  The quantity \(f'($t)\) represents the rate
-at which the coffee is cooling, in degrees per minute, $t minutes
-after the cup is put on the counter.  Thus we can complete the statement:
-$BR
-At $t minutes after the coffee was put on the counter, its temperature
-is $f degC and will decrease by about $delf degC in the next $dtsec
+*(b)*
+Since [` f'(t) = dH/dt `], the units are degrees Celsius per
+minute (degC/min).  The quantity [` f'([$t]) `] represents the rate
+at which the coffee is cooling, in degrees per minute, [$t] minutes
+after the cup is put on the counter.  Thus we can complete the statement:  
+
+At [$t] minutes after the coffee was put on the counter, its temperature
+is [$f] degC and will decrease by about [$delf] degC in the next [$dtsec]
 seconds.
 
-END_SOLUTION
-Context()->normalStrings;
-
-;
+END_PGML_SOLUTION
 
 ENDDOCUMENT();


### PR DESCRIPTION
parserNumberWithUnits.pl can't handle units without a number. This problem asks for the unit degC/min, with no number attached.  One can make degC and min into MathObject variables, but the answer checker doesn't recognize degC/min when MathQuill transforms degC into a unicode degree symbol.