### PR TITLE
fix Anton9_7Q5.pg

### DIFF
--- a/Contrib/Wiley/setAnton_Section_9.7/Anton9_7Q5.pg
+++ b/Contrib/Wiley/setAnton_Section_9.7/Anton9_7Q5.pg
@@ -33,8 +33,8 @@ TEXT(beginproblem());
 ###################################
 # Setup
 $dx=non_zero_random(-1,1,0.2);
-$Dx=Formula("$dx/180 *pi")->reduce;
 if($dx==1){$dx=-1}
+$Dx=Formula("$dx/180 *pi")->reduce;
 $x0=Formula("pi/3");
 $x=Compute("60+$dx");
 $fxn=Compute("tan($x*pi/180)");


### PR DESCRIPTION
This is my first contribution here, and it was not clear if I should edit the file in Contrib, in OPL, or both.

The `if($dx==1){$dx=-1}` line must come before the `$Dx=...` line, otherwise `$dx` and `$Dx` end up being inconsistent, and WeBWorK will miscalculate the answer.