### PR TITLE
Clarify wording and change correct answer for TF statements

### DIFF
--- a/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.2.41_47a.pg
+++ b/OpenProblemLibrary/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.2.41_47a.pg
@@ -62,24 +62,19 @@ $tf->rf_print_q(~~&pop_up_list_print_q);
 $tf->ra_pop_up_list( 
 [ No_answer => "?", "T"=>"True", "F"=>"False"] ); 
 
-#$a = random(2,3,1);
-#$aa = $a+1;
-#$b = random(6,9,1);
-#$c = random(7,10,1);
-
 # Questions and answers
 $tf -> qa ( 
 "If  \(\  S_1  \)  and \(\  S_2  \) are subspaces of \( R^n\) of the same dimension, then \(S_1=S_2\).",
 "F",
 "If  \( \  S =\) span{\(u_1, u_2, u_3 \)},  then  \(dim(S) = 3\) .",
 "F",
-"If the set of vectors \(U\) spans a subspace \(S\), then vectors can be added to \(U\) to create a basis for \(S\)",
+"If the set of vectors \(U\) spans a subspace \(S\), then vectors can be added to \(U\) to create a basis for \(S\) (i.e. there is a set of vectors \(V\) with \(U\subseteq V\) which is a basis of \(S\)).",
 "F",
-"If the set of vectors \(U\) is linearly independent in a subspace \( S\) then vectors can be added to \(U\) to create a basis for \(S\)",
-"F",
-"If the set of vectors \(U\) spans a subspace \(S\), then vectors can be removed from \(U\) to create a basis for \(S\)",
-"F",
-"If the set of vectors \(U\) is linearly independent in a subspace \( S\) then vectors can be removed from \(U\) to create a basis for \(S\).",
+"If the set of vectors \(U\) is linearly independent in a subspace \( S\) then vectors can be added to \(U\) to create a basis for \(S\) (i.e. there is a set of vectors \(V\) with \(U\subseteq V\) which is a basis of \(S\)).",
+"T",
+"If the set of vectors \(U\) spans a subspace \(S\), then vectors can be removed from \(U\) to create a basis for \(S\) (i.e. there is a set of vectors \(V\) with \(V\subseteq U\) which is a basis of \(S\)).",
+"T",
+"If the set of vectors \(U\) is linearly independent in a subspace \( S\) then vectors can be removed from \(U\) to create a basis for \(S\) (i.e. there is a set of vectors \(V\) with \(V\subseteq U\) which is a basis of \(S\)).",
 "F",
 "Three nonzero vectors that lie in a plane in \(R^3\) might form a basis for \(R^3\).",
 "F",


### PR DESCRIPTION
Tagging @jjh2b since this is taken from his textbook.

The existing problem Library/WHFreeman/Holt_linear_algebra/Chaps_1-4/4.2.41_47a.pg contains the following statements:
"If the set of vectors \(U\) is linearly independent in a subspace \( S\) then vectors can be added to \(U\) to create a basis for \(S\)"
"If the set of vectors \(U\) spans a subspace \(S\), then vectors can be removed from \(U\) to create a basis for \(S\)"

The correct answer for both of these is coded as "False", but this depends on how you interpret "can be added" and "can be removed".  If you interpret this to include the case where no vectors are added/removed, then these statements are both true.  In fact, the statements are taken directly from the textbook, and the answers in the textbook list the first statement as true (the second doesn't have an answer in the back), which contradicts the correct answer coded in the problem.

The proposed fix here is to add some more precise notation to the end of the statements.  By using `\subseteq` it removes the ambiguity as to whether the subset/superset needs to be proper.  I'd also be okay with removing the "can be added/removed" wording altogether, but that makes the statements less accessible to readers who are less mathematically sophisticated.
