### PR TITLE
Fix typo in ur_la_10_20.pg

### DIFF
--- a/OpenProblemLibrary/Rochester/setLinearAlgebra10Bases/ur_la_10_20.pg
+++ b/OpenProblemLibrary/Rochester/setLinearAlgebra10Bases/ur_la_10_20.pg
@@ -59,7 +59,7 @@ $image_multians = MultiAnswer($image1, $image2, $image3)->with(
 
 Context()->texStrings;
 BEGIN_TEXT
-Let \( L \) be the line given by the span of \( $kernel \) in \( \mathbb{R}^3 \). 
+Let \( L \) be the line given by the span of \( $kernel \) in \( \mathbb{R}^4 \). 
 Find a basis for the orthogonal complement \( L^{\bot} \) of \( L \).
 $BR
 $BR


### PR DESCRIPTION
The given kernel has 4 components and is in R^4