### PR TITLE
Fix possible error in hypothesis test problem

### DIFF
--- a/Contrib/Piedmont/OnlineMATH2100/FinalExam/8.pg
+++ b/Contrib/Piedmont/OnlineMATH2100/FinalExam/8.pg
@@ -88,6 +88,12 @@ do {
         $crit_string = "&plusmn;$crit";
     }
 
+    if ($p1 <= 0) {
+        $p1 = 0.01;
+    } elsif ($p1 >= 1) {
+        $p1 = 0.99;
+    }
+
     $p_bar = ($p1 * $n1 + $p2 * $n2) / ($n1 + $n2);
     $q_bar = 1 - $p_bar;
     $se = Round(sqrt($p_bar * $q_bar * (1 / $n1 + 1 / $n2)), 5);


### PR DESCRIPTION
In this problem, students are asked to perform a hypothesis test for two proportions, which are randomly generated.  There was a slim chance that one of them ended up outside the interval (0, 1), so we adjust if that happens.