### PR TITLE
Fix bug 4803 ?  drop unneeded macro, change scaffold parameter

### DIFF
--- a/OpenProblemLibrary/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_04.pg
+++ b/OpenProblemLibrary/Hope/Calc1/APEX_01_03_Limits_analytical/Limit_04.pg
@@ -18,11 +18,9 @@ loadMacros(
   "MathObjects.pl",
   "PGML.pl",
   "parserDifferenceQuotient.pl",
-  "PGchoicemacros.pl",
   "scaffold.pl",
   "PGcourse.pl"
 );
-TEXT(beginproblem());
 
 Context("Numeric");
 Context()->noreduce('(-x)-y','(-x)+y');
@@ -46,8 +44,9 @@ $fs2 = Compute("1/(sqrt(x) + sqrt($b))"); # f simplified
 $d2 = DifferenceQuotient($fs2,"x",$z);
 $L2 = $fs2->eval(x=>$z);
 
-
-Scaffold::Begin(hardcopy_is_open  => "first_incorrect");
+Scaffold::Begin(
+  is_open  => "correct_or_first_incorrect"
+);
 
 Section::Begin('Part 1: Evaluate the limit');
 BEGIN_PGML


### PR DESCRIPTION
Could not reproduce error in bug 4803, but deleted unused PGchoicemacros.pl macro and modified Scaffold::Begin parameter 