### PR TITLE
Use MathObject intervals for interval of convergence problems

### DIFF
--- a/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr1.pg
+++ b/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr1.pg
@@ -21,10 +21,9 @@ DOCUMENT();        # This should be the first executable line in the problem.
 loadMacros(
   "PGstandard.pl",
   "PGchoicemacros.pl",
+  "MathObjects.pl",
   "PGcourse.pl"
 );
-
-TEXT(beginproblem()); 
 
 $showPartialCorrectAnswers = 1;
 
@@ -34,19 +33,15 @@ Find the convergence set of the given power series:
 
 \[ \sum_{n=1}^{\infty} \dfrac{2^{n}x^{n}}{n!} \]
 
-The above series converges for \{ans_rule(10)\} \( < x < \) \{ans_rule(10)\}.
+The above series converges on the interval \{ans_rule(10)\}.
 
 $PAR
 
-Enter "infinity" for \(\infty\) and "-infinity" for \(-\infty\).
+See \{helpLink("interval")\} for help entering intervals.
 
 END_TEXT
 
-$ans1 = "-infinity";
-$ans2 = "infinity";
-ANS(str_cmp($ans1));
-ANS(str_cmp($ans2));
-#ANS(num_cmp($ans));
-#ANS(fun_cmp($ans, mode=>"antider", vars=>"t"));
+Context("Interval");
+ANS(Compute("(-inf, inf)")->cmp);
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr1.pg
+++ b/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr1.pg
@@ -26,12 +26,13 @@ loadMacros(
 );
 
 $showPartialCorrectAnswers = 1;
+$a = random(2, 9);
 
 BEGIN_TEXT
 
 Find the convergence set of the given power series:
 
-\[ \sum_{n=1}^{\infty} \dfrac{2^{n}x^{n}}{n!} \]
+\[ \sum_{n=1}^{\infty} \dfrac{$a^{n}x^{n}}{n!} \]
 
 The above series converges on the interval \{ans_rule(10)\}.
 

--- a/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr2.pg
+++ b/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr2.pg
@@ -21,10 +21,9 @@ DOCUMENT();        # This should be the first executable line in the problem.
 loadMacros(
   "PGstandard.pl",
   "PGchoicemacros.pl",
+  "MathObjects.pl",
   "PGcourse.pl"
 );
-
-TEXT(beginproblem()); 
 
 $showPartialCorrectAnswers = 1;
 
@@ -34,19 +33,15 @@ Find the convergence set of the given power series:
 
 \[ \sum_{n=1}^{\infty} \dfrac{(x-2)^{n}}{n^{2}} \]
 
-The above series converges for \{ans_rule(10)\} \( \leq x \leq \) \{ans_rule(10)\}.
+The above series converges on the interval \{ans_rule(10)\}.
 
 $PAR
 
-Enter "infinity" for \(\infty\) and "-infinity" for \(-\infty\).
+See \{helpLink("interval")\} for help entering intervals.
 
 END_TEXT
 
-$ans1 = 1;
-$ans2 = 3;
-ANS(num_cmp($ans1));
-ANS(num_cmp($ans2));
-#ANS(num_cmp($ans));
-#ANS(fun_cmp($ans, mode=>"antider", vars=>"t"));
+Context("Interval");
+ANS(Compute("[1, 3]")->cmp);
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr2.pg
+++ b/OpenProblemLibrary/Utah/Calculus_II/set9_Infinite_Series/set9_pr2.pg
@@ -26,12 +26,13 @@ loadMacros(
 );
 
 $showPartialCorrectAnswers = 1;
+$a = random(1, 9);
 
 BEGIN_TEXT
 
 Find the convergence set of the given power series:
 
-\[ \sum_{n=1}^{\infty} \dfrac{(x-2)^{n}}{n^{2}} \]
+\[ \sum_{n=1}^{\infty} \dfrac{(x-$a)^{n}}{n^{2}} \]
 
 The above series converges on the interval \{ans_rule(10)\}.
 
@@ -42,6 +43,6 @@ See \{helpLink("interval")\} for help entering intervals.
 END_TEXT
 
 Context("Interval");
-ANS(Compute("[1, 3]")->cmp);
+ANS(Compute("[$a - 1, $a + 1]")->cmp);
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.


### PR DESCRIPTION
One of the problems was expecting the strings "-infinity" and "infinity", which doesn't work with the MathQuill interface and students were being marked wrong.

This is similar to #1136.