### PR TITLE
Remove mention of "contradiction" from epsilon-delta limit proofs

### DIFF
--- a/OpenProblemLibrary/MC/Proofs/DirectProofs/EpsilonDeltaLimit.pg
+++ b/OpenProblemLibrary/MC/Proofs/DirectProofs/EpsilonDeltaLimit.pg
@@ -70,10 +70,4 @@ END_TEXT
 
 ANS($CorrectProof->cmp);
 
-$showHint=2;
-BEGIN_HINT
-To show \(P \implies Q\) by contradiction, start by assuming \(P\) and \( \sim Q\).
-END_HINT
-
-
 ENDDOCUMENT();

--- a/OpenProblemLibrary/MC/Proofs/DirectProofs/EpsilonDeltaLimitLinear.pg
+++ b/OpenProblemLibrary/MC/Proofs/DirectProofs/EpsilonDeltaLimitLinear.pg
@@ -56,7 +56,7 @@ $CorrectProof = DraggableProof([
 
 
 BEGIN_TEXT
-Order \{ $CorrectProof->numNeeded \} of the following sentences so that they form a logical proof by $BBOLD contradiction $EBOLD of the statement:
+Order \{ $CorrectProof->numNeeded \} of the following sentences so that they form a logical proof of the statement:
 $PAR
 $BCENTER $BITALIC
 \[ \displaystyle{\lim_{x \rightarrow $a} $f = $L}.\]


### PR DESCRIPTION
These are direct proofs using the definition of the limit and involve no contradiction.