### PR TITLE
 Rewrite using MathObjects and PGML

### DIFF
--- a/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
+++ b/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
@@ -46,7 +46,7 @@ If [`f`] is restricted to the above domain, then the inverse function is [`g(x)=
 END_PGML
 
 BEGIN_PGML_SOLUTION
-The function [`f(x)=(x+[$a])^2`] is one-to-one on the intervals [`(-\infty, [$ans1]]`] and [`[[$ans1], \infty)`].
+The function [`f(x)=(x+[$a])^2`] is one-to-one on the intervals [`(-\infty, -[$a]]`] and [`[-[$a], \infty)`].
 The second one contains the number 100.
 
 Solving the equation [`y=(x+[$a])^2`] for [`x`] will give us two solutions: [`x = \pm\sqrt{y} - [$a]`].

--- a/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
+++ b/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
@@ -30,15 +30,17 @@ $showPartialCorrectAnswers = 1;
 Context("Numeric");
 
 $a = random(2,9,1);
-$ans1 = Compute("-$a");
-$ans2 = Infinity;
 $ans3 = Formula("sqrt(x)-$a");
+
+Context("Interval");
+
+$ansInt = Compute("[-$a, infinity)");
 
 BEGIN_PGML
 The function [`f(x)=(x+[$a])^2`] is not one-to-one. Choose the largest possible
 domain containing the number 100 so that the function restricted to the domain is one-to-one.
 
-The largest possible domain is [`\left[\strut\right.`][________]{$ans1},[________]{$ans2}[`\left.\strut\right)`].
+The largest possible domain is [_________________]{$ansInt} (use interval notation).
 
 If [`f`] is restricted to the above domain, then the inverse function is [`g(x)=`][_______________]{$ans3}.
 END_PGML

--- a/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
+++ b/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
@@ -40,7 +40,7 @@ domain containing the number 100 so that the function restricted to the domain i
 
 The largest possible domain is [`\left[\strut\right.`][________]{$ans1},[________]{$ans2}[`\left.\strut\right)`].
 
-The inverse function is [`g(x)=`][_______________]{$ans3}.
+If [`f`] is restricted to the above domain, then the inverse function is [`g(x)=`][_______________]{$ans3}.
 END_PGML
 
 BEGIN_PGML_SOLUTION

--- a/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
+++ b/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
@@ -20,35 +20,37 @@ DOCUMENT();        # This should be the first executable line in the problem.
 
 loadMacros(
   "PGstandard.pl",
-  "PGchoicemacros.pl",
+  "PGML.pl",
+  "MathObjects.pl",
   "PGcourse.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
+Context("Numeric");
+
 $a = random(2,9,1);
+$ans1 = Compute("-$a");
+$ans2 = Infinity;
+$ans3 = Formula("sqrt(x)-$a");
 
-TEXT(EV2(<<EOT));
-The function \(f(x)=(x+$a)^2\) is not one-to-one. Choose a largest possible
-domain containing the number 100 so that 
-the function restricted to the domain is one-to-one.
-$BR  
-The largest possible domain is [\{ ans_rule(10) \},\{ ans_rule(10) \});
-$BR  
-the inverse function is \(g(x)=\) \{ ans_rule(15) \}
-$BR
-$BBOLD
-If your answer is \(\infty\), enter infinity.
-$EBOLD
-EOT
+BEGIN_PGML
+The function [`f(x)=(x+[$a])^2`] is not one-to-one. Choose a largest possible
+domain containing the number 100 so that the function restricted to the domain is one-to-one.
 
-$ans1 = -$a;
-$ans2 = "infinity";
-$ans3 = "sqrt(x)-$a";
-ANS(num_cmp($ans1));
-ANS(str_cmp($ans2));
-ANS(fun_cmp($ans3));
+The largest possible domain is [`\left[\strut\right.`][________]{$ans1},[________]{$ans2}[`\left.\strut\right)`].
+
+The inverse function is [`g(x)=`][_______________]{$ans3}.
+END_PGML
+
+BEGIN_PGML_SOLUTION
+The function [`f(x)=(x+[$a])^2`] is one-to-one on the intervals [`(-\infty, [$ans1]]`] and [`[[$ans1], \infty)`].
+The second one contains the number 100.
+
+Solving the equation [`y=(x+[$a])^2`] for [`x`] will give us two solutions: [`x = \pm\sqrt{y} - [$a]`].
+According to our domain choice, [`x \ge [$ans1]`], which means we have to choose the solution with [`+`].
+Exchanging the [`x`] and [`y`] variables will give us the answer [`g(x) = [$ans3]`].
+END_PGML_SOLUTION
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.
 

--- a/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
+++ b/OpenProblemLibrary/ma117DB/set5/srw2_9_63.pg
@@ -35,7 +35,7 @@ $ans2 = Infinity;
 $ans3 = Formula("sqrt(x)-$a");
 
 BEGIN_PGML
-The function [`f(x)=(x+[$a])^2`] is not one-to-one. Choose a largest possible
+The function [`f(x)=(x+[$a])^2`] is not one-to-one. Choose the largest possible
 domain containing the number 100 so that the function restricted to the domain is one-to-one.
 
 The largest possible domain is [`\left[\strut\right.`][________]{$ans1},[________]{$ans2}[`\left.\strut\right)`].


### PR DESCRIPTION
The problem uses 'cmp_str' to check for answer 'infinity'. The `cmp_str` is deprecated, and does not work well with the MathQuill editor.

In addition to rewriting in PGML, a solution was added as well.