### PR TITLE
Prevent a point on a graph being placed on the edge of window with invisible label

### DIFF
--- a/OpenProblemLibrary/Rochester/setAlgebra28ExpFunctions/ur_le_1_5.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra28ExpFunctions/ur_le_1_5.pg
@@ -30,8 +30,7 @@ TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
 $a = random(2,5,1);
-$y = random(2,5,1);
-if ($y == $a) {$y = $y+1;}
+do {$y = random(2,5,1);} until ($y != $a);
 $s = random(-1,1,2);
 $b = ln($y/$a)/ln(2);
 $a = $a*$s;

--- a/OpenProblemLibrary/Rochester/setAlgebra28ExpFunctions/ur_le_1_5.pg
+++ b/OpenProblemLibrary/Rochester/setAlgebra28ExpFunctions/ur_le_1_5.pg
@@ -20,6 +20,7 @@ DOCUMENT();        # This should be the first executable line in the problem.
 
 loadMacros(
   "PGstandard.pl",
+  "PGML.pl",
   "PGchoicemacros.pl",
   "PGgraphmacros.pl",
   "PGnumericalmacros.pl",
@@ -47,19 +48,15 @@ add_functions($graph1, $fn, $pt0, $pt1);
 $label_0 = new Label ( 0.5,$a,"(0,$a)",'black','left','middle'); $graph1->lb($label_0);
 $label_1 = new Label ( 1.5,$y,"(1,$y)",'black','left','middle'); $graph1->lb($label_1);
 
-BEGIN_TEXT
+BEGIN_PGML
+Find the exponential function [`f(x)=a\cdot 2^{b x}`] whose graph is shown below
 
-Find the exponential function \(f(x)=a\cdot 2^{b x}\) whose graph is shown below
-$BR
-\{ image(insertGraph($graph1), width=>200, height=>200) \}
-$BR
-\(a=\) \{ans_rule(20)\} $BR
-\(b=\) \{ans_rule(20)\} 
+[!Graph of exponential function passing through points (0,[$a]) and (1,[$y])!]{$graph1}{width=>200, height=>200}
 
-END_TEXT
+* [`a=`][____________________]{$a}
+* [`b=`][____________________]{$b}
 
-ANS(num_cmp($a));
-ANS(num_cmp($b));
+END_PGML
 
 ENDDOCUMENT();       # This should be the last executable line in the problem.
 


### PR DESCRIPTION
The problem generates two random but distinct numbers between 2 and 5.
In order to assure that they are distinct, it increases one of them by
1 if they are equal. This may result in one of the numbers being 6,
which will cause a point on the graph placed on the edge of the graphing
window, with invisible label, which makes it impossible to answer the
problem.

The fix selects the second number repeatedly until the numbers are
distinct.

Also, the problem was converted to PGML.