### PR TITLE
Fix mismatch between question body and prompt in Part 2d

### DIFF
--- a/Contrib/Hope/Multi1/01-02-Vector-operations/Graphical_vector_ops_03.pg
+++ b/Contrib/Hope/Multi1/01-02-Vector-operations/Graphical_vector_ops_03.pg
@@ -136,7 +136,7 @@ c. Using geometric vector addition, what general direction do you expect [` \vec
 
     + [` \vec{c} - \vec{a} - \vec{b} = `] [___________________]{"<$Cx-$Ax-$Bx, $Cy-$Ay-$By>"} [@ AnswerFormatHelp("vectors") @]*
 
-d. Using geometric vector addition, draw the vector sum [` \vec{a} + \vec{b} + \vec{c} `].  Then, verify your answer using vector addition operations.
+d. Using geometric vector addition, draw the vector sum [` 2\vec{a} - 3\vec{b} + \vec{c} `].  Then, verify your answer using vector addition operations.
 
     + [` 2\vec{a} - 3\vec{b} + \vec{c} = `] [___________________]{"<2*$Ax-3*$Bx+$Cx, 2*$Ay-3*$By+$Cy>"} [@ AnswerFormatHelp("vectors") @]*
 END_PGML


### PR DESCRIPTION
The question, and the question prompt expects `2a-3b+c`, but the question body reads `a+b+c`.
This PR fixes the question body to be consistent with the expected answer.