### PR TITLE
Fix the percentages in the problem text

### DIFF
--- a/OpenProblemLibrary/UBC/ECON/ECON325/hw03/hw03_q12.pg
+++ b/OpenProblemLibrary/UBC/ECON/ECON325/hw03/hw03_q12.pg
@@ -79,6 +79,15 @@ q2<-p2*pt2/(p1*pt1 + p2*pt2 + p3*pt3)
 round(q2,  2)
 ');
 
+# calculate percentages from probabilities
+
+$p1perc = 100*$p1[0];
+$p2perc = 100*$p2[0];
+$p3perc = 100*$p3[0];
+
+$pt1perc = 100*$pt1[0];
+$pt2perc = 100*$pt2[0];
+$pt3perc = 100*$pt3[0];
 
 
 $q1ans = $q1[0];
@@ -89,9 +98,9 @@ $q2ans = $q2[0];
 ## Main Text: where all text goes (Required)
 Context()->texStrings;
 BEGIN_TEXT
-The members of a consulting firm rent cars from three rental agencies. It is estimated that $p1[0] percent of cars come from agency 1, $p2[0] percent
-of cars come from agency 2, and $p3[0] percent of cars come from agency 3.
-It is also estimated that $pt1[0] percent of cars from agency 1 need a tune-up, $pt2[0] percent of cars from agency 2 need a tune-up, and $pt3[0] percent
+The members of a consulting firm rent cars from three rental agencies. It is estimated that $p1perc percent of cars come from agency 1, $p2perc percent
+of cars come from agency 2, and $p3perc percent of cars come from agency 3.
+It is also estimated that $pt1perc percent of cars from agency 1 need a tune-up, $pt2perc percent of cars from agency 2 need a tune-up, and $pt3perc percent
 of cars from agency 3 need a tune-up. Answer the following questions, rounding your answers to two decimal places where appropriate.
 
 $BR

--- a/OpenProblemLibrary/UBC/ECON/ECON325/hw03/hw03_q12.pg
+++ b/OpenProblemLibrary/UBC/ECON/ECON325/hw03/hw03_q12.pg
@@ -15,12 +15,8 @@ DOCUMENT();
 ## Initializations: (Required)
 loadMacros(
   "PGstandard.pl",
-  "PGchoicemacros.pl",
-  "parserRadioButtons.pl",
   "MathObjects.pl",
-  "parserMultiAnswer.pl",
   "RserveClient.pl",
-  "answerHints.pl",
   "PGcourse.pl"
 );
 

--- a/OpenProblemLibrary/UBC/ECON/ECON325/hw03/hw03_q12.pg
+++ b/OpenProblemLibrary/UBC/ECON/ECON325/hw03/hw03_q12.pg
@@ -17,6 +17,7 @@ loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",
   "RserveClient.pl",
+  "PGML.pl",
   "PGcourse.pl"
 );
 
@@ -90,112 +91,71 @@ $pt2perc = 100*$pt2[0];
 $pt3perc = 100*$pt3[0];
 
 
-$q1ans = $q1[0];
-$q2ans = $q2[0];
+$q1ans = Compute("$q1[0]");
+$q2ans = Compute("$q2[0]");
 
 
 #########################################################
 ## Main Text: where all text goes (Required)
 Context()->texStrings;
-BEGIN_TEXT
-The members of a consulting firm rent cars from three rental agencies. It is estimated that $p1perc percent of cars come from agency 1, $p2perc percent
-of cars come from agency 2, and $p3perc percent of cars come from agency 3.
-It is also estimated that $pt1perc percent of cars from agency 1 need a tune-up, $pt2perc percent of cars from agency 2 need a tune-up, and $pt3perc percent
-of cars from agency 3 need a tune-up. Answer the following questions, rounding your answers to two decimal places where appropriate.
+BEGIN_PGML
+The members of a consulting firm rent cars from three rental agencies.
+It is estimated that [$p1perc] percent of cars come from agency 1, [$p2perc] percent
+of cars come from agency 2, and [$p3perc] percent of cars come from agency 3.
+It is also estimated that [$pt1perc] percent of cars from agency 1 need a tune-up,
+[$pt2perc] percent of cars from agency 2 need a tune-up, and [$pt3perc] percent
+of cars from agency 3 need a tune-up. Answer the following questions,
+rounding your answers to two decimal places where appropriate.
 
-$BR
-$BR
-$BBOLD(a) $EBOLD What is the probability that a rental car delivered to the firm will need a tune-up? 
-\{ans_rule(7) \} 
-$BR
-$BR
-$BBOLD(b) $EBOLD If a rental car delivered to the firm needs a tune-up, what is the
-probability that it came from agency 2? \{ans_rule(7) \} 
-END_TEXT
+a)  What is the probability that a rental car delivered to the firm will need a tune-up? 
+    [_______]{$q1ans->cmp(tol=>0.01)}
 
-#########################################################
-## Answers evaluation (Required)
-ANS( num_cmp($q1ans, tol=>0.01) );
-ANS( num_cmp($q2ans, tol=>0.01) );
-
+b) If a rental car delivered to the firm needs a tune-up, what is the
+probability that it came from agency 2? [_______]{$q2ans->cmp(tol=>0.01)}
+END_PGML
 
 #########################################################
 ## Solution (Optional but recommended)
 Context()->texStrings;
-BEGIN_SOLUTION
-We have the following probabilities, where P (A|B) means the probability of event A given event B:
-$BR
-$BR
-$BCENTER
-\(
-P(\text{Agency}~ 1) = $p1[0]
-\)
-$ECENTER
-$BR
-$BCENTER
-\(
-P(\text{Agency}~ 2) = $p2[0]
-\)
-$ECENTER
-$BR
-$BCENTER
-\(
-P(\text{Agency}~ 3) = $p3[0]
-\)
-$ECENTER
-$BR
-$BCENTER
-\(
-P( \text{Tune-up required} |\text{Agency} ~1) = $pt1[0]
-\)
-$ECENTER
-$BR
-$BCENTER
-\(
-P( \text{Tune-up required} |\text{Agency}~ 2) = $pt2[0]
-\)
-$ECENTER
-$BR
-$BCENTER
-\(
-P( \text{Tune-up required} |\text{Agency}~ 3) = $pt3[0]
-\)
-$ECENTER
-$BR
-$BR
-$BBOLD (a) $EBOLD We require P (Tune up required), which is found by adding the
-probabilities of the events {Tune up required and car from agency i} over \(i = 1, 2, 3\). For instance,  
-$BR
-$BR
-$BCENTER
-\begin{align*}
-P ( \text{Tune up required and car from agency} 1)  &=P(\text{Tune up required} ~ | \text{car from agency} 1)   \times P(\text{car from agency} 1)  \\
-&= $p1[0] \times $pt1[0] =$p11[0]. 
-\end{align*}
-$ECENTER
-$BR
-Finding the probabilities for the other two agencies, we have
-$BR
-$BR
-$BCENTER
-\begin{align*}
-P(\text{Tune up required})
-&= \sum\limits_{i=1}^3 P ( \text{Tune up required and car from agency}~ i)  \\
-&= \sum\limits_{i=1}^3 P(\text{Tune up required} ~ | \text{car from agency}~ i)   \times P(\text{car from agency}~ i) \\
-&= $p1[0] \times $pt1[0]  + $p2[0] \times $pt2[0] + $p3[0] \times $pt3[0] \\
-&= $q1ans.
-\end{align*}
-$ECENTER
-$BR
-$BR
+BEGIN_PGML_SOLUTION
+We have the following probabilities, where [`\operatorname{P}(A\mid B)`] means the probability of event A given event B:
 
-$BBOLD (b) $EBOLD Using Bayes Theorem, P (Car from agency 2 | Car requires tune up) is 
-$BR
-$BR
-$BCENTER
-\(
-\frac{ P(\text{Car from agency}~ 2) P(\text{Tune up required}~|~\text{car from agency}~ 2)   }{  P(\text{Tune up required}) } = \frac{$p2[0] \times $pt2[0]} { $p1[0] \times $pt1[0]  + $p2[0] \times $pt2[0] + $p3[0] \times $pt3[0] } =$q2ans.
-\)
-$ECENTER
-END_SOLUTION
+*   [``\operatorname{P}(\text{Agency}~ 1) = [$p1[0]]``]
+*   [``\operatorname{P}(\text{Agency}~ 2) = [$p2[0]]``]
+*   [``\operatorname{P}(\text{Agency}~ 3) = [$p3[0]]``]
+
+*   [``\operatorname{P}(\text{Tune-up required} \mid \text{Agency} ~1) = [$pt1[0]]``]
+*   [``\operatorname{P}(\text{Tune-up required} \mid \text{Agency} ~2) = [$pt2[0]]``]
+*   [``\operatorname{P}(\text{Tune-up required} \mid \text{Agency} ~3) = [$pt3[0]]``]
+
+a)  We require [`\operatorname{P}(\text{Tune-up required})`], which is found by adding the
+    probabilities of the events {Tune up required _and_ car from agency [`i`]} over [`i = 1, 2, 3`]. For instance,  
+
+    [```
+    \begin{align*}
+    \operatorname{P}(\text{Tune up required and car from agency} ~1)  &= \operatorname{P}(\text{Tune up required} \mid \text{car from agency} ~1)
+    \times \operatorname{P}(\text{car from agency} ~1)  \\
+    &= [$p1[0]] \times [$pt1[0]] = [$p11[0]].
+    \end{align*}
+    ```]
+
+    Finding the probabilities for the other two agencies, we have
+
+    [```
+    \begin{align*}
+    \operatorname{P}(\text{Tune up required})
+    &= \sum\limits_{i=1}^3 \operatorname{P}( \text{Tune up required and car from agency}~ i)  \\
+    &= \sum\limits_{i=1}^3 \operatorname{P}(\text{Tune up required} \mid \text{car from agency}~ i)
+    \times \operatorname{P}(\text{car from agency}~ i) \\
+    &= [$p1[0]] \times [$pt1[0]]  + [$p2[0]] \times [$pt2[0]] + [$p3[0]] \times [$pt3[0]] \\
+    &= [$q1ans].
+    \end{align*}
+    ```]
+
+b)  Using Bayes Theorem, [`\operatorname{P}(\text{Car from agency 2} \mid \text{Car requires tune up})`] is 
+    [```
+    \frac{ \operatorname{P}(\text{Car from agency}~ 2) \operatorname{P}(\text{Tune up required}\mid \text{car from agency}~ 2)}
+    {\operatorname{P}(\text{Tune up required})} = \frac{[$p2[0]] \times [$pt2[0]]}{[$p1[0]] \times [$pt1[0]] + [$p2[0]] \times [$pt2[0]] + [$p3[0]] \times [$pt3[0]] } = [$q2ans].
+    ```]
+END_PGML_SOLUTION
 ENDDOCUMENT();


### PR DESCRIPTION
The numbers in the text of the problem are referred to as "percents", but they are actually probabilities, so the text says things like _0.07 percent_ instead of _7 percent_.

This replaces the probabilities by percents.  It also  removes unnecessary macro files and converts the problem to PGML.