### PR TITLE
Fix unquoted string warning for helpLink()

### DIFF
--- a/Contrib/AlfredUniv/AUCI/chapter3/lesson1/gravity.pg
+++ b/Contrib/AlfredUniv/AUCI/chapter3/lesson1/gravity.pg
@@ -101,7 +101,7 @@ $BR
 \(g = \) \{ans_rule(40)\}
 $BR
 $BR
-\{helpLink(units)\}
+\{helpLink('units')\}
 END_TEXT
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/ASU-topics/setImplicitDerivatives/5-4-27.pg
+++ b/OpenProblemLibrary/ASU-topics/setImplicitDerivatives/5-4-27.pg
@@ -87,7 +87,7 @@ to the graph of the equation
 \( x = $x0 \).
 $BR $BR
 \{ ans_rule(15) \} is an
-\{ helpLink(equation) \}
+\{ helpLink('equation','equation') \}
 of the tangent line to the
 curve at the point where
 \( x = $x0 \).

--- a/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_26.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_26.pg
@@ -84,7 +84,7 @@ to the hyperbola defined by
 \( $F = $e \) at the point  \( $Po \).
 $BR $BR
 The tangent line is defined by the
-\{ helpLink(equation) \} \{ ans_rule() \}.
+\{ helpLink('equation','equation') \} \{ ans_rule() \}.
 END_TEXT
 Context()->normalStrings;
 

--- a/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_31.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_31.pg
@@ -75,7 +75,7 @@ called a ${BBOLD}kampyle of Exodus${EBOLD}.
 Find an equation of the tangent line to
 this curve at the point \( $Po \).
 $BR $BR
-An \{ helpLink(equation) \} of the tangent
+An \{ helpLink('equation','equation') \} of the tangent
 line to the curve at the point \( $Po \)
 is \{ ans_rule(15) \}.
 END_TEXT

--- a/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_32.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_32.pg
@@ -96,7 +96,7 @@ called a ${BBOLD}Tschirnhausen cubic${EBOLD}.
 Find the equation of the tangent line to
 this curve at the point \( $Po \).
 $BR $BR
-An \{ helpLink(equation) \} of the tangent
+An \{ helpLink('equation','equation') \} of the tangent
 line to the curve at the point \( $Po \) is
 \{ ans_rule(15) \}.
 END_TEXT

--- a/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_33.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_3_6/Stewart5_3_6_33.pg
@@ -105,7 +105,7 @@ the tangent lines at the points
 \( $P0 \) and \( $P1 \).
 $BR$BR
 \{ ans_rule(15) \}
-is an \{ helpLink(equation) \}
+is an \{ helpLink('equation','equation') \}
 of the tangent line to the curve
 at the point \( $P0 \).
 $BR$BR

--- a/OpenProblemLibrary/UCSB/Stewart5_4_4/Stewart5_4_4_59.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_4_4/Stewart5_4_4_59.pg
@@ -36,7 +36,7 @@ $limit = Compute("e^($p)");
 
 Context()->texStrings;
 BEGIN_TEXT
-Find the \{ helpLink(limit) \}.
+Find the \{ helpLink('limit','limit') \}.
 Use l'Hospital's Rule if appropriate.
 $BR $BR
 \(\displaystyle \lim_{x \to \infty} $f = \)

--- a/OpenProblemLibrary/UCSB/Stewart5_4_4/Stewart5_4_4_6.pg
+++ b/OpenProblemLibrary/UCSB/Stewart5_4_4/Stewart5_4_4_6.pg
@@ -37,7 +37,7 @@ $limit = Compute("1/$d");
 
 Context()->texStrings;
 BEGIN_TEXT
-Find the \{ helpLink(limit) \}.
+Find the \{ helpLink('limit','limit') \}.
 Use L'Hospital's Rule if appropriate.
 $BR $BR
 \(\displaystyle \lim_{x \to $a} $f = \)

--- a/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_23.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_23.pg
@@ -89,7 +89,7 @@ an equation of the tangent line to the
 ${BBOLD}ellipse${EBOLD} defined by
 \( $F = $k \) at the point \( ($xo, $yo) \).
 $BR $BR
-An \{ helpLink(equation) \} of the tangent
+An \{ helpLink('equation','equation') \} of the tangent
 line is \{ ans_rule() \}.
 END_TEXT
 Context()->normalStrings;

--- a/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_28.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_28.pg
@@ -60,7 +60,7 @@ an equation of the tangent line to the
 ${BBOLD}devil's curve${EBOLD},defined by
 \( $G = $F \), at the point \( $P \).
 $BR $BR
-An \{ helpLink(equation) \} of the
+An \{ helpLink('equation','equation') \} of the
 tangent line to the devil's curve at
 the given point is \{ ans_rule(10) \}.
 END_TEXT

--- a/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_prob01.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_prob01.pg
@@ -63,7 +63,7 @@ defined by \[ $f = $d \] has horizontal
 and vertical tangent lines.
 $BR $BR
 The circle has horizontal tangent lines
-at the \{ helpLink(point, "point(s)") \}
+at the \{ helpLink('point', 'point(s)') \}
 \{ ans_rule(15) \}.
 $BR $BR
 The circle has vertical tangent lines

--- a/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_prob02.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_5_prob02.pg
@@ -62,7 +62,7 @@ defined by
 has horizontal and vertical tangent lines.
 $BR $BR
 The parabola has horizontal tangent lines
-at the \{ helpLink(point, "point(s)") \}
+at the \{ helpLink('point', "point(s)") \}
 \{ ans_rule(15) \}.
 $BR $BR
 The parabola has vertical tangent lines

--- a/OpenProblemLibrary/Utah/Calculus_I/set5_The_Derivative/1210s5p17/1210s5p17.pg
+++ b/OpenProblemLibrary/Utah/Calculus_I/set5_The_Derivative/1210s5p17/1210s5p17.pg
@@ -119,7 +119,7 @@ Find the point at which the ${lr} vertical
 tangent line touches the ellipse.
 $BR $BR
 The ${lr} vertical tangent line touches the
-ellipse at the \{ helpLink(point) \}
+ellipse at the \{ helpLink('point','point') \}
 \{ ans_rule(25) \}.
 $BR $BR $BR
 ${BBOLD}Hint:${EBOLD} The horizontal tangent is

--- a/OpenProblemLibrary/maCalcDB/setDerivatives2_5Implicit/s2_6_25_mo.pg
+++ b/OpenProblemLibrary/maCalcDB/setDerivatives2_5Implicit/s2_6_25_mo.pg
@@ -72,7 +72,7 @@ the curve
 \[ 2(x^2 + y^2)^2 = 25(x^2 - y^2) \]
 (a lemniscate) at the point \( ($x0, $y0) \).
 $BR $BR
-An \{ helpLink(equation) \} of the tangent
+An \{ helpLink('equation','equation') \} of the tangent
 line to the lemniscate at the given point is
 \{ ans_rule(10) \}.
 END_TEXT


### PR DESCRIPTION
This adds quotes to all instances of `helpLink()` that were detected by my (rather naive) regex.  This should fix the "unquoted string" warning shown when instructors view the problem.

This should fix #1184.