### PR TITLE
Fix events for probability 0 or 1

### DIFF
--- a/Contrib/METU-NCC/MAT101/Probability/pdf.pg
+++ b/Contrib/METU-NCC/MAT101/Probability/pdf.pg
@@ -60,7 +60,9 @@ $c = random(1,$b-1);
 @i = pick(2,(0,1));
 
 $Cans = random(0,1);
-$C    = ("> ".random($a-3,$a-1),"< ".random($b+1,$b+3))[$Cans];
+$Czero    = list_random("< ".random($a-3,$a-1),"> ".random($b+1,$b+3));
+$Cone    = list_random("> ".random($a-3,$a-1),"< ".random($b+1,$b+3));
+$C = ($Czero, $Cone)[$Cans];
 
 Context()->texStrings;
 


### PR DESCRIPTION
With the directions of the inequalities, the event in the last part of the problem will always have probability 1, even if `$Cans` is 0, 
so there is a 50% chance that the part will be graded incorrectly.

This fixes that issue, and adds more versions of the event in the last part.