### PR TITLE
Fix typos in taxonomy

### DIFF
--- a/OpenProblemLibrary/AlfredUniv/PDE/separable/nonhomogeneous3.pg
+++ b/OpenProblemLibrary/AlfredUniv/PDE/separable/nonhomogeneous3.pg
@@ -5,7 +5,7 @@
 
 ## DBsubject(Differential equations)
 ## DBchapter(Partial differential equations)
-## DBsection(Inhomogenous equations)
+## DBsection(Inhomogeneous equations)
 ## Date(9/1/2011)
 ## Institution(Alfred University)
 ## Author(Darwyn Cook)

--- a/OpenProblemLibrary/Taxonomy
+++ b/OpenProblemLibrary/Taxonomy
@@ -439,7 +439,7 @@ Differential equations
 		Laplace's equation
 		Other separable equations 
 		Fourier series
-		Inhomogenous equations
+		Inhomogeneous equations
 Linear algebra
 	Systems of linear equations
 		Systems with 2 variables

--- a/OpenProblemLibrary/Taxonomy2
+++ b/OpenProblemLibrary/Taxonomy2
@@ -149,9 +149,9 @@ Calculus - multivariable
 		Vectors and vector arithmetic <<< Geometry__Vector geometry__Vectors and vector arithmetic
 		Dot product, length, and unit vectors <<< Geometry__Vector geometry__Dot product, length, and unit vectors
 		Cross product <<< Geometry__Vector geometry__Cross product
-		Cross product <<< Geometry__Vector geometry__Lines
-		Cross product <<< Geometry__Vector geometry__Planes
-		Cross product <<< Geometry__Vector geometry__Lines with planes
+		Lines <<< Geometry__Vector geometry__Lines
+		Planes <<< Geometry__Vector geometry__Planes
+		Lines with planes <<< Geometry__Vector geometry__Lines with planes
 		Coordinate systems <<< Geometry__Vector geometry__Coordinate systems
 	Calculus of vector valued functions
 		Parameterized curves
@@ -451,7 +451,7 @@ Differential equations
 		Laplace's equation
 		Other separable equations 
 		Fourier series
-		Inhomogenous equations
+		Inhomogeneous equations
 Linear algebra
 	Systems of linear equations
 		Systems with 2 variables
@@ -629,7 +629,7 @@ Precalculus <<<
 		Graphs <<< Algebra__Exponential and logarithmic expressions and functions__Graphs
 		Applications and models - population growth <<< Algebra__Exponential and logarithmic expressions and functions__Applications and models - population growth
 		Applications and models - radioactive decay <<< Algebra__Exponential and logarithmic expressions and functions__Applications and models - radioactive decay
-		Applications and models – general <<< Algebra__Exponential and logarithmic expressions and functions__Applications and models - general
+		Applications and models - general <<< Algebra__Exponential and logarithmic expressions and functions__Applications and models - general
 	Finite sequences and series <<<
 		Notation <<< Algebra__Finite sequences and series__Notation
 		Arithmetic <<< Algebra__Finite sequences and series__Arithmetic


### PR DESCRIPTION
This PR fixes a few typos in the taxonomy files:
- fix misspelling of "Inhomogeneous"
- correct links that were incorrectly attributed to "Cross product"
- normalize character used for dash (hyphen might not be correct, but it is consistent with the rest of the file)