### PR TITLE
Fix bug 4860, update to PGML, add solution.

### DIFF
--- a/OpenProblemLibrary/TCNJ/TCNJ_MatrixEquations/problem7.pg
+++ b/OpenProblemLibrary/TCNJ/TCNJ_MatrixEquations/problem7.pg
@@ -16,7 +16,7 @@ loadMacros(
   "PGstandard.pl",
   "MathObjects.pl",
   "PGML.pl",
-  "parserCheckboxList.pl",
+  "parserPopUp.pl",  
   "PGcourse.pl"
 );
 
@@ -24,39 +24,118 @@ TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 Context("Numeric");
 
-@yes = ( 'A vector  \( b \) is a linear combination of the columns of a matrix \( A \) if and only if the equation \( Ax = b \) has at least one solution. ', 
-    'The first entry in the product \( Ax \) is a sum of products of real numbers. ' , 
-    'If the columns of \( A \) span \( {\mathbb R}^m\), then the equation \( Ax = b \) is consistent for each \( b \) in \( {\mathbb R}^m\). ' ,
-    'If the equation \( Ax = b \) is inconsistent for some \( b \) in \( {\mathbb R}^m\), then \( A \) cannot have a pivot position in every row. ' ,
-    'Every matrix equation \( Ax = b \) corresponds to a vector equation with the same solution set. ' ,
-    'Any linear combination of vectors in \(\mathbb{R}^m\) can always be written in the form \( Ax \) for a suitable matrix \( A \) and vector \( x \). ' ,
-    'The solution set of a linear system whose augmented matrix is \( [ a_1a_2 \cdots a_n \vert b ] \) is the same as the solution set of \( Ax = b \), if \( A = [ a_1 a_2 \cdots a_n ] \). ' ,
-    'If the equation \( Ax = b \) is inconsistent, then \( b \) is not in the set spanned by the columns of \( A \). ' ,
-    'If the columns of \( A \) do not span \( {\mathbb R}^m\), then the equation \( Ax = b \) is inconsistent for some \( b \) in \( {\mathbb R}^m\). ' 
-);
+@yes = (); @yesTF=(); @yesSol=();
+ 
+push @yes, 'The vector  \( b \) is a linear combination of the columns of the matrix \( A \) if and only if the equation \( Ax = b \) has at least one solution. '; 
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True. \(b\) is a linear combination of the columns of \(A\) if and only if there are real numbers \(x_1,\ldots,x_n\) such that \(\sum_{j=1}^n A_{i,j}x_j = b_i\) for every \(i=1,\ldots,m\), if and only if the column vector \(x=(x_1,\ldots,x_n)\) is a solution to the equation \(Ax=b\).';
 
-@no = ( 'The equation \( Ax = b \) is referred to as a vector equation. ' ,
-    'The equation \( Ax = b \) is consistent if the augmented matrix \( [ A \vert b ] \) has a pivot position in every row. ',
-    'If the augmented matrix \( [ A\vert  b ] \) has a pivot position in every row, then the equation \( Ax = b \) is inconsistent. ' 
-);
+push @yes, 'The first component in the vector \( Ax \) is a sum of products of real numbers. ' ; 
+push @yesTF , DropDownTF("True");
+push @yesSol, 'True. \((Ax)_1 = \sum_{j=1}^m A_{1,j}x_j\)';
 
-# a random set of 4 "yes" items
+push @yes, 'If the columns of \( A \) span \( {\mathbb R}^m\), then the equation \( Ax = b \) is consistent for each \( b \) in \( {\mathbb R}^m\). ' ;
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True. The columns of  \(A\) span \( {\mathbb R}^m\) if and only if for every \(b\in{\mathbb R}^m\) there exist real numbers \(x_1,\ldots,x_n\)  such that \(b_i = \sum_{j=1}^n A_{i,j}x_j\) for every \(i=1,\ldots, m\), if and only if for every \(b\in{\mathbb R}^m\) there is a vector \(x=[x_1,\ldots,x_n]\) that is a solution to the matrix equation \(Ax=b\).  
+An equation is consistent if and only if it has a solution.';
 
-@items = random_subset(4,@yes);
+push @yes, 'If the equation \( Ax = b \) is inconsistent for some \( b \) in \( {\mathbb R}^m\), then \( A \) cannot have a pivot position in every row. ' ;
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True.  If the matrix \(A\) had a pivot position in every row then one could solve the equation \(Ax=b\) using row reduction and back substitution, so the equation would be consistent, not inconsistent, because it would have a solution.';
 
-# add a random set of 2 "no" items
+push @yes, 'Every matrix equation \( Ax = b \) corresponds to a vector equation with the same solution set. ' ;
+push @yesTF,DropDownTF("True");
+push @yesSol,'True.  If one interprets the columns of \(A\) as column vectors then the matrix equation becomes a vector equation without changing its meaning or solution.';
 
-push(@items, random_subset(2,@no));
+push @yes,  'Any linear combination of vectors in \(\mathbb{R}^m\) can always be written in the form \( Ax \) for a suitable matrix \( A \) and vector \( x \). ' ;
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True. A linear combination of vectors \(a_1,\ldots,a_n\) is a sum 
+\(\sum_{j=1}^n a_jx_j\) where \(x_1,\ldots,x_n\) are real numbers.  Regard \(x=[x_1,\ldots,x_n]\) as a column vector in \(\mathbb{R}^n\), and \(A\) as the matrix  whose columns are \(a_1,\ldots,a_n\).  Then the sum is exactly the same as the product \(Ax\).';
 
-# randomize the final list of 6 items
+push @yes, 'If the columns of \(A\) are the m-dimensional column vectors a_1 a_2 \cdots a_n then the solution set of a linear system whose augmented matrix is \( [ a_1a_2 \cdots a_n \vert b ] \) is the same as the solution set of the matrix equation \( Ax = b \). ' ;
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True. The linear system whose augmented matrix is \( [ a_1a_2 \cdots a_n \vert b ] \) means exactly the same thing as the linear system represented by the matrix equation \( Ax = b \), so both have the same solutions' ;
 
-$questions = CheckboxList([ ~~@items ], [0,1,2,3]);
+push @yes, 'If the equation \( Ax = b \) is inconsistent, then \( b \) is not in the set spanned by the columns of \( A \). ' ;
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True. If the equation is inconsistent then it has no solution, which means that \(b\) is not in the span of the columns of \(A\).';
+
+push @yes,   'If the columns of \( A \) do not span \( {\mathbb R}^m\), then the equation \( Ax = b \) is inconsistent for some \( b \) in \( {\mathbb R}^m\). '; 
+push @yesTF, DropDownTF("True");
+push @yesSol, 'True. If the columns of \(A\) do not span \(\mathbb{R}^m\) then there is a vector \(b\in \mathbb{R}^m\) that is not in the span of the columns, so the equation \(Ax=b\) has no solution, so it is inconsistent.';
+
+
+@no=(); @noTF=(); @noSol=(); 
+
+push @no, 'The equation \(Ax=b\) is always called a "vector equation", never a "matrix equation".';
+push @noTF, DropDownTF("False");
+push @noSol, 'False.  People who regard \(Ax\) as representing a linear combination of the columns of \(A\) might call it a "vector equation".  Others might describe it as a "matrix equation" if they regard \(x\) as a \(1\times n\) matrix and \(b\) as a \(1\times m\) matrix.  It depends on your point of view.  This is an aspect of the power of linear algebra: the same expression can represent many different things. ';
+
+# the next solution works for two of the questions.
+
+$notEnoughData = 'False. The hypothesis "the augmented matrix has a pivot position in every row" does not provide enough information, by itself, to determine whether the equation is consistent or inconsistent. It could go either way. Therefore the given general statement is false. 
+
+For example, the 
+simple equation \(x_1=0\) has an obvious solution, so it is consistent. Its 
+augmented matrix \([1\vert 0]\) has a pivot in every row.  (Yes, there
+is only one row).  But the equally simple equation \(0x_1 = 1\) has no solution so it is inconsistent, but its augmented matrix \([0\vert 1]\) also has a pivot in every row. ';
+
+push @no,   'The equation \( Ax = b \) is consistent if the augmented matrix \( [ A \vert b ] \) has a pivot position in every row. ';
+push @noTF, DropDownTF("False");
+push @noSol, $notEnoughData;
+
+push @no, 'If the augmented matrix \( [ A\vert  b ] \) has a pivot position in every row, then the equation \( Ax = b \) is inconsistent. ' ;
+push @noTF, DropDownTF("False");
+push @noSol, $notEnoughData;
+
+# select a random set of 4 "yes" items
+@yesSlice = random_subset(4,(0..scalar(@yes)-1));
+
+#select a random set of 2 "no" items
+@noSlice = random_subset(2,(0..scalar(@no)-1));
+
+#concatenate these random sets
+
+@question = (@yes[@yesSlice],@no[@noSlice]);
+@answer = (@yesTF[@yesSlice],@noTF[@noSlice]);
+@solution = (@yesSol[@yesSlice],@noSol[@noSlice]);
+
+# randomize presentation order
+
+@allslice = random_subset(6,(0..5));
+@question = @question[@allslice];
+@answer = @answer[@allslice];
+@solution = @solution[@allslice];
 
 BEGIN_PGML
-Let [`A`] be an [`m\times n`] matrix of real numbers, [`x \in \mathbb{R}^n`], [`b\in \mathbb{R}^m`].  Select the _true_ statements in the list below.
+In the following [`A`] represents an arbitrary [`m\times n`] matrix of real numbers, and [`x \in \mathbb{R}^n`] and [`b\in \mathbb{R}^m`] represent arbitrary vectors.  Select the _true_ statements in the list below.  Remember that a general statement "if P then Q" is true if and only if Q is true in every case where P is true.
 
-[_]{$questions}
+1. [_]{$answer[0]} [$question[0]]
+
+2. [_]{$answer[1]} [$question[1]]
+
+3. [_]{$answer[2]} [$question[2]]
+
+4. [_]{$answer[3]} [$question[3]]
+
+5. [_]{$answer[4]} [$question[4]]
+
+6. [_]{$answer[5]} [$question[5]]
 END_PGML
+
+BEGIN_PGML_SOLUTION
+1. [$solution[0]]
+
+2. [$solution[1]]
+
+3. [$solution[2]]
+
+4. [$solution[3]]
+
+5. [$solution[4]]
+
+6. [$solution[5]]
+END_PGML_SOLUTION
 
 ENDDOCUMENT();       # This should be the last executable line in the problem.
 


### PR DESCRIPTION
Bug 4860 referred to an incorrect answer.  It wasn't really incorrect, just obscure and confusing.  This rewrite rewords part of the problem and adds a solution that should explain why the answers are correct.