### PR TITLE
Corrected logic and spelling of ASU-topics/setStat/di12

### DIFF
--- a/OpenProblemLibrary/ASU-topics/setStat/di12.pg
+++ b/OpenProblemLibrary/ASU-topics/setStat/di12.pg
@@ -21,26 +21,26 @@ loadMacros('PGstandard.pl', 'PGML.pl', 'parserRadioButtons.pl', 'PGcourse.pl');
 
 @questions = (
     '_The mean body temperature for humans in fact differs from 98.6 '
-        . 'degrees Farenheit, and the result of the sampling leads to that '
+        . 'degrees Fahrenheit, and the result of the sampling leads to that '
         . 'conclusion_ is a',
-    '_The mean body temperature for humans in fact is 98.6 degrees Farenheit, '
+    '_The mean body temperature for humans in fact is 98.6 degrees Fahrenheit, '
         . 'and the result of the sampling does not lead to the rejection of the '
-        . 'fact that the mean body temprature is 98.6 degrees Farenheit_ is a',
+        . 'fact that the mean body temperature is 98.6 degrees Fahrenheit_ is a',
     '_The mean body temperature for humans in fact differs from 98.6 degrees '
-        . 'Farenheit, but the result of the sampling fails to lead to that '
+        . 'Fahrenheit, but the result of the sampling fails to lead to that '
         . 'conclusion_ is a',
-    '_The mean body temperature for humans in fact is 98.6 degrees Farenheit, '
+    '_The mean body temperature for humans in fact is 98.6 degrees Fahrenheit, '
         . 'but the result of the sampling leads to the conclusion that the mean '
-        . 'body temprature for humans differs from 98.6 degrees Farenheit_ is a '
+        . 'body temperature for humans differs from 98.6 degrees Fahrenheit_ is a '
 );
 
 my $options = [ 'Type I error', 'Type II error', 'correct decision' ];
 
 @radios = (
+    RadioButtons($options, 2, labels => 'ABC'),
+    RadioButtons($options, 2, labels => 'ABC'),
     RadioButtons($options, 1, labels => 'ABC'),
-    RadioButtons($options, 2, labels => 'ABC'),
     RadioButtons($options, 0, labels => 'ABC'),
-    RadioButtons($options, 2, labels => 'ABC'),
 );
 
 @order = random_subset(4, 0 .. 3);


### PR DESCRIPTION
This is a radio-button problem where the correct choices were misidentified. The first two items describe scenarios where statistical analysis leads to the correct decision (option number 2). The third scenario is a false negative, a type II error (option 1). The fourth scenario is a false positive, a type I error (option 0). Detailed explanations are below. 

Corrected spelling as well.

- The mean body temperature for humans in fact differs from 98.6 degrees Fahrenheit, and the result of the sampling leads to that conclusion is a **[Alternative is true, and the conclusion leads there. Good decision.]** 
- The mean body temperature for humans in fact is 98.6 degrees Fahrenheit, and the result of the sampling does not lead to the rejection of the fact that the mean body temperature is 98.6 degrees Fahrenheit is a **[Null is true, and we don’t reject the null. Good decision.]** 
- The mean body temperature for humans in fact differs from 98.6 degrees Fahrenheit, but the result of the sampling fails to lead to that conclusion is a **[Alternative is true, but result fails to lead to that conclusion. This is Type-II Error.]**
- The mean body temperature for humans in fact is 98.6 degrees Fahrenheit, but the result of the sampling leads to the conclusion that the mean body temperature for humans differs from 98.6 degrees Fahrenheit is a  **[Null is true, and but we reject the null. This is Type-I Error.]**

 