### PR TITLE
Corrections to College Physics Urone textbook questions

### DIFF
--- a/Contrib/BrockPhysics/College_Physics_Urone/15.Thermodynamics/Carnots_Perfect_Heat_Engine_The_Second_Law_of_Thermodynamics_Restated/NU_U17-15-04-004.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/15.Thermodynamics/Carnots_Perfect_Heat_Engine_The_Second_Law_of_Thermodynamics_Restated/NU_U17-15-04-004.pg
@@ -47,7 +47,7 @@ $PAR
 
 $PAR
 
-Steam locomotives have an efficiency of \($eff\)\(\textrm{%}\) and operate with a hot steam temperature of \($temp^{\circ}\textrm{C}\) .
+Steam locomotives have an efficiency of \($eff \, \mathrm{%}\) and operate with a hot steam temperature of \($temp^{\circ}\mathrm{C}\) .
 
 $PAR
 
@@ -55,7 +55,7 @@ a) What would the cold reservoir temperature be if this were a Carnot engine?
 
 $PAR
 
-\{ans_rule(40)\} \(^{\circ}\textrm{C}\)
+\{ans_rule(40)\} \(^{\circ}\mathrm{C}\)
 
 $PAR
 
@@ -70,11 +70,11 @@ BEGIN_TEXT
 
 $PAR
 
-b) What would the maximum efficiency of this steam engine be if its cold reservoir temperature were \($temp2^{\circ}\textrm{C}\)?
+b) What would the maximum efficiency of this steam engine be if its cold reservoir temperature were \($temp2^{\circ}\mathrm{C}\)?
 
 $PAR
 
-\{ans_rule(40)\} \(\textrm{%}\)
+\{ans_rule(40)\} \(\mathrm{%}\)
 
 $PAR
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_001.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_001.pg
@@ -50,10 +50,10 @@ $PAR
 
 
 a) What frequency is received by a person watching an oncoming ambulance moving
-at \($vskm \, \(\textrm{km/h}\) and emitting a steady \($fs \, \(\textrm{Hz}\) sound from its siren? The speed of sound on this day is \($vw \, \(\textrm{m/s}\).
+at \($vskm \, \mathrm{km/h}\) and emitting a steady \($fs \, \mathrm{Hz}\) sound from its siren? The speed of sound on this day is \($vw \, \mathrm{m/s}\).
 $PAR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 
 $PAR
 END_TEXT
@@ -64,7 +64,7 @@ BEGIN_TEXT
 b) What frequency does she receive after the ambulance has passed?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 
 $PAR
 END_TEXT

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_002.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_002.pg
@@ -48,11 +48,11 @@ $PAR
 
 
 
-a) At an air show a jet flies directly toward the stands at a speed of \($vskm \, \(\textrm{km/h}\),
-emitting a frequency of \($fs \, \(\textrm{Hz}\), on a day when the speed of sound is \($vw \, \(\textrm{m/s}\). What frequency is received by the observers? 
+a) At an air show a jet flies directly toward the stands at a speed of \($vskm \, \mathrm{km/h}\),
+emitting a frequency of \($fs \, \mathrm{Hz}\), on a day when the speed of sound is \($vw \, \mathrm{m/s}\). What frequency is received by the observers?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 
 $PAR
 END_TEXT
@@ -64,7 +64,7 @@ b) What frequency do they receive as the plane flies directly away from them?
 $BR
 $BR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 
 $PAR
 END_TEXT

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_003.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_003.pg
@@ -47,11 +47,11 @@ $PAR
 
 
 What frequency is received by a mouse just before being dispatched by a hawk flying
-at it at \($vs \, \(\textrm{m/s}\) and emitting a screech of frequency \($fs \, \(\textrm{Hz}\)? Take the speed of
-sound to be \($vw \, \(\textrm{m/s}\).
+at it at \($vs \, \mathrm{m/s}\) and emitting a screech of frequency \($fs \, \mathrm{Hz}\)? Take the speed of
+sound to be \($vw \, \mathrm{m/s}\).
 $PAR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 
 $PAR
 END_TEXT

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_004.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_004.pg
@@ -46,12 +46,12 @@ $PAR
 
 
 
-A spectator at a parade receives an \($fobs \, \(\textrm{Hz}\) tone from an oncoming trumpeter who is
-playing an \($fs \, \(\textrm{Hz}\) note. At what speed is the musician approaching if the speed of
-sound is \($vw \, \(\textrm{m/s}\)?
+A spectator at a parade receives an \($fobs \, \mathrm{Hz}\) tone from an oncoming trumpeter who is
+playing an \($fs \, \mathrm{Hz}\) note. At what speed is the musician approaching if the speed of
+sound is \($vw \, \mathrm{m/s}\)?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{m/s}\)
+\{ans_rule(40)\} \(\mathrm{m/s}\)
 $PAR
 END_TEXT
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_005.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_005.pg
@@ -44,14 +44,14 @@ BEGIN_TEXT
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 
 $PAR
-A commuter train blows its \($fs \, \(\textrm{Hz}\) horn as it approaches a crossing. The speed of
-sound is \($vw \, \(\textrm{m/s}\). 
+A commuter train blows its \($fs \, \mathrm{Hz}\) horn as it approaches a crossing. The speed of
+sound is \($vw \, \mathrm{m/s}\).
 $PAR
-a) An observer waiting at the crossing receives a frequency of \($fobs \, \(\textrm{Hz}\). What is the speed of the train? 
+a) An observer waiting at the crossing receives a frequency of \($fobs \, \mathrm{Hz}\). What is the speed of the train?
 $PAR
 
 
-\{ans_rule(40)\} \(\textrm{m/s}\)
+\{ans_rule(40)\} \(\mathrm{m/s}\)
 $PAR
 END_TEXT
 
@@ -60,7 +60,7 @@ ANS(num_cmp("$vs"));
 BEGIN_TEXT
 b) What frequency does the observer receive as the train moves away?
 $PAR
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 $PAR
 END_TEXT
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_006.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_006.pg
@@ -42,7 +42,7 @@ BEGIN_TEXT
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 
 $PAR
-Calculate the factor by which the frequency shifts produced when you pull a tuning fork toward you at \($vs \, \(\textrm{m/s}\) on a day when the speed of sound is \($vw \, \(\textrm{m/s}\)? 
+Calculate the factor by which the frequency shifts produced when you pull a tuning fork toward you at \($vs \, \mathrm{m/s}\) on a day when the speed of sound is \($vw \, \mathrm{m/s}\)?
 $PAR
 
 \{ans_rule(40)\} 

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_007.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_007.pg
@@ -45,10 +45,10 @@ BEGIN_TEXT
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 
 $PAR
-Two eagles fly directly toward one another, the first at \($vo1 \, \(\textrm{m/s}\) and the second at \($vo2 \, \(\textrm{m/s}\). Both screech, the first one emitting a frequency of \($fs1 \, \(\textrm{Hz}\) and the second one emitting a frequency of \($fs2 \, \(\textrm{Hz}\). What frequency does the first eagle receive if the speed of sound is \($vw \, \(\textrm{m/s}\)?
+Two eagles fly directly toward one another, the first at \($vo1 \, \mathrm{m/s}\) and the second at \($vo2 \, \mathrm{m/s}\). Both screech, the first one emitting a frequency of \($fs1 \, \mathrm{Hz}\) and the second one emitting a frequency of \($fs2 \, \mathrm{Hz}\). What frequency does the first eagle receive if the speed of sound is \($vw \, \mathrm{m/s}\)?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 $PAR
 END_TEXT
 
@@ -58,7 +58,7 @@ BEGIN_TEXT
 b) What frequency does the second eagle?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{Hz}\)
+\{ans_rule(40)\} \(\mathrm{Hz}\)
 $PAR
 END_TEXT
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_008.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/17.Physics_of_Hearing/17-04.Doppler_Effect/NU_U17_17_04_008.pg
@@ -43,10 +43,10 @@ BEGIN_TEXT
 $PAR
 What is the minimum speed at which a source must travel toward you for you to be
 able to hear that its frequency is Doppler shifted? That is, what speed produces a shift
-of \(0.300 \, \(\textrm{%}\) on a day when the speed of sound is \($vw \, \(\textrm{m/s}\)?
+of \(0.300 \, \mathrm{%}\) on a day when the speed of sound is \($vw \, \mathrm{m/s}\)?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{m/s}\)
+\{ans_rule(40)\} \(\mathrm{m/s}\)
 $PAR
 END_TEXT
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/3.Two_Dimensional_Kinematics/003-005_ADDITIONOFVELOCITIES/NU_U17-03-05-015.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/3.Two_Dimensional_Kinematics/003-005_ADDITIONOFVELOCITIES/NU_U17-03-05-015.pg
@@ -49,14 +49,14 @@ $adeg = $arad*180/pi;
 BEGIN_TEXT
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 $PAR
-A ship sailing in the Gulf Stream is heading \($wdeg^\circ\) west of north at a speed of \($sw\,\textrm{m/s}\) relative to the water. Its velocity relative to the Earth is \($se\,\textrm{m/s}\) \($edeg^\circ\) west of north.
+A ship sailing in the Gulf Stream is heading \($wdeg^\circ\) west of north at a speed of \($sw\,\mathrm{m/s}\) relative to the water. Its velocity relative to the Earth is \($se\,\mathrm{m/s}\) \($edeg^\circ\) west of north.
 $PAR
 What is the velocity of the Gulf Stream?
 $PAR
 (The velocity obtained is typical for the Gulf Stream a few hundred kilometers off the east coast of the United States.)
 $PAR
 
-\{ans_rule(40)\} \(\textrm{m/s}\)
+\{ans_rule(40)\} \(\mathrm{m/s}\)
 
 $PAR
 
@@ -65,8 +65,8 @@ $PAR
 $PAR
 END_TEXT
 
-ANS(num_cmp("$vw"));
-ANS(num_cmp("$adeg"));
+ANS(num_cmp("$vw", tol => 0.1, tolType => "absolute"));
+ANS(num_cmp("$adeg", tol => 0.1, tolType => "absolute"));
 
 BEGIN_HINT
 Consider trigonometric problem solving strategies in order to answer this question.

--- a/Contrib/BrockPhysics/College_Physics_Urone/30.Atomic_Physics/30-02.Discovery_of_the_Parts_of_the_Atom_Electrons_and_Nuclei/NU_U17_30_02_001.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/30.Atomic_Physics/30-02.Discovery_of_the_Parts_of_the_Atom_Electrons_and_Nuclei/NU_U17_30_02_001.pg
@@ -39,10 +39,10 @@ BEGIN_TEXT
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 
 $PAR
-Rutherford found the diameter of the nucleus to be about \(10^{-15} \, \(\textrm{m}\). This implied a huge density. What would this density be for gold?
+Rutherford found the diameter of the nucleus to be about \(10^{-15} \, \mathrm{m}\). This implied a huge density. What would this density be for gold?
 $PAR
 
-\{ans_rule(40)\} \(\textrm{kg/m}^3\)
+\{ans_rule(40)\} \(\mathrm{kg/m}^3\)
 
 $PAR
 END_TEXT
@@ -50,7 +50,7 @@ END_TEXT
 ANS(num_cmp("$E"));
 
 BEGIN_HINT
-Convert \(\textrm{amu}\) for gold to \(\textrm{kg}\) to help you find density.
+Convert \(\mathrm{amu}\) for gold to \(\mathrm{kg}\) to help you find density.
 END_HINT
 Context()->normalStrings;
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-05.Half-Life_and_Activity/NU_U17-31-05-008.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-05.Half-Life_and_Activity/NU_U17-31-05-008.pg
@@ -44,7 +44,7 @@ $mass_g = $mass*10**-3;
 $M = 235;
 
 $timeSI= (0.693*$Na*$mass_g)/($activitySI*$M);
-$half_life = ($timeSI)/(86400*365.25)*10**-8;
+$half_life = ($timeSI)/(86400*365.25);
 
 Context() -> texStrings;
 BEGIN_TEXT 

--- a/Contrib/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-06.Binding_Energy/NU_U17-31-06-006.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-06.Binding_Energy/NU_U17-31-06-006.pg
@@ -43,7 +43,7 @@ $N_strontium = 52;
 
 $mass_nickel = 57.935346;
 $mass_strontium = 89.907738;
-$mass_proton = 1.007825;
+$mass_proton = 1.007276;
 $mass_neutron = 1.008665;
 
 $binding_energy_per_A_nickel = (931.5)*($Z_nickel*$mass_proton + $N_nickel*$mass_neutron - $mass_nickel)/($Z_nickel + $N_nickel);

--- a/Contrib/BrockPhysics/College_Physics_Urone/4.Dynamics_Force_and_Newtons_Laws_of_Motion/Newtons_Second_Law_of_Motion_Concept_of_a_System/NU_U17-04-03-009.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/4.Dynamics_Force_and_Newtons_Laws_of_Motion/Newtons_Second_Law_of_Motion_Concept_of_a_System/NU_U17-04-03-009.pg
@@ -44,13 +44,13 @@ BEGIN_TEXT
 
 $PAR
 
-Suppose two children push horizontally, but in exactly opposite directions, on a third child in a wagon. The first child exerts a force of \(75.0 \, \(\textrm{N}\), the second a force of \(90.0 \, \textrm{N}\), friction is \($d1 \, \textrm{N}\), and the mass of the third child plus wagon is \($w \, \textrm{kg}\).
+Suppose two children push horizontally, but in exactly opposite directions, on a third child in a wagon. The first child exerts a force of \(75.0 \, \mathrm{N}\), the second a force of \(90.0 \, \mathrm{N}\), friction is \($d1 \, \mathrm{N}\), and the mass of the third child plus wagon is \($w \, \mathrm{kg}\).
 $PAR
 (a) Calculate the acceleration. 
 
 $PAR
 
-\{ans_rule(40)\} \(\textrm{m/s}^2\)
+\{ans_rule(40)\} \(\mathrm{m/s}^2\)
 
 END_TEXT
 
@@ -59,10 +59,10 @@ ANS(num_cmp("$A1"));
 BEGIN_TEXT
 $PAR
 
-(b) What would the acceleration be if friction were \(15.0 \, \textrm{N}\)? 
+(b) What would the acceleration be if friction were \(15.0 \, \mathrm{N}\)?
 
 $PAR
-\{ans_rule(40)\} \(\textrm{m/s}^2\)
+\{ans_rule(40)\} \(\mathrm{m/s}^2\)
 
 END_TEXT
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/7.Work_Energy_and_Energy_Resources/7-01.Work.The_Scientific_Definition/NU_U17_07_01_008.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/7.Work_Energy_and_Energy_Resources/7-01.Work.The_Scientific_Definition/NU_U17_07_01_008.pg
@@ -39,10 +39,10 @@ $m = random(65,99,2);
 $d = random(25,43,2);
 $us = 1.000;
 $g = 9.80;
-$Wf = $us*$m*$g*cos($rads)*($d*cos($d180));
-$Wr = $m*$g*(sin($rads)-($us)*cos($rads))*$d*cos($d180);
-$Wg = $m*$g*sin($rads)*$d*cos($rads);
-$W = $Wf+$Wr+$Wg;
+$Wf = $us * $m * $g * cos($rads) * $d*cos($d180);
+$Wr = $m * $g * (sin($rads) - ($us)*cos($rads)) * $d*cos($d180);
+$Wg = $m * $g * cos(pi/2 - $rads) * $d; # not sin($rads) because of round-off error
+$W = $Wf + $Wr + $Wg;
 
 
 BEGIN_TEXT
@@ -53,12 +53,12 @@ tex_size=>700, extra_html_tags=>'alt="Rescue Sled."' ) \}
 $PAR
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 $PAR
-Suppose the ski patrol lowers a rescue sled and victim, having a total mass of \($m\, \textrm{kg}\), down a \($degree^{\circ}\) slope at constant speed, as shown above. The coefficient of friction between the sled and the snow is \($us\). 
+Suppose the ski patrol lowers a rescue sled and victim, having a total mass of \($m\, \mathrm{kg}\), down a \($degree^{\circ}\) slope at constant speed, as shown above. The coefficient of friction between the sled and the snow is \($us\).
 $PAR
-a) How much work is done by friction as the sled moves \($d\, \textrm{m}\) along the hill? 
+a) How much work is done by friction as the sled moves \($d\, \mathrm{m}\) along the hill?
 
 $PAR
-\{ans_rule(40)\} \( \textrm{J}\)
+\{ans_rule(40)\} \( \mathrm{J}\)
 
 END_TEXT
 
@@ -69,7 +69,7 @@ $PAR
 b) How much work is done by the rope on the sled in this distance? 
 
 $PAR
-\{ans_rule(40)\} \( \textrm{J}\)
+\{ans_rule(40)\} \( \mathrm{J}\)
 
 END_TEXT
 
@@ -80,7 +80,7 @@ $PAR
 c) What is the work done by the gravitational force on the sled? 
 
 $PAR
-\{ans_rule(40)\} \( \textrm{J}\)
+\{ans_rule(40)\} \( \mathrm{J}\)
 
 END_TEXT
 
@@ -91,7 +91,7 @@ $PAR
 d) What is the total work done?
 
 $PAR
-\{ans_rule(40)\} \( \textrm{J}\)
+\{ans_rule(40)\} \( \mathrm{J}\)
 
 END_TEXT
 

--- a/Contrib/BrockPhysics/College_Physics_Urone/7.Work_Energy_and_Energy_Resources/7-07.Power/NU_U17_07_07_011.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/7.Work_Energy_and_Energy_Resources/7-07.Power/NU_U17_07_07_011.pg
@@ -31,26 +31,26 @@ $showPartialCorrectAnswers = 1;
 
 $Pa = random(2,7,1);
 $months = random(12,19,1);
-$Ea = $Pa*$months*(1/12)*365*24*3600;
+$Ea = $Pa * ($months/12) * 365*24*3600;
 $Eb = random(4,9,1);
 $EJ = $Eb*(10**4);
 $Pb = random(1,3,1);
 $PW = $Pb*(10**-3);
-$tb = $EJ/$PW*60*60*24*365;
+$tb = $EJ / $PW / (365*24*3600);
 
 BEGIN_TEXT
 $PAR
-a) What is the available energy content, in joules, of a battery that operates a \($Pa.00\,\textrm{-W}\) electric clock for \($months\) months? 
+a) What is the available energy content, in joules, of a battery that operates a \($Pa.00\,\mathrm{W}\) electric clock for \($months\) months?
 
 $PAR
-\{ans_rule(40)\} \(\textrm{J}\)
+\{ans_rule(40)\} \(\mathrm{J}\)
 END_TEXT
 
 ANS(num_cmp("$Ea"));
 
 BEGIN_TEXT
 $PAR
-b) How long can a battery that can supply \($Eb.00 \times 10^{4}\, \textrm{J}\) run a pocket calculator that consumes energy at the rate of \($Pb.00 \times 10^{-3}\, \textrm{W}\)?
+b) How long can a battery that can supply \($Eb.00 \times 10^{4}\, \mathrm{J}\) run a pocket calculator that consumes energy at the rate of \($Pb.00 \times 10^{-3}\, \mathrm{W}\)?
 
 $PAR
 \{ans_rule(40)\} years

--- a/Contrib/BrockPhysics/College_Physics_Urone/7.Work_Energy_and_Energy_Resources/7-08.Work_Energy_and_Power_in_Humans/NU_U17_07_08_011.pg
+++ b/Contrib/BrockPhysics/College_Physics_Urone/7.Work_Energy_and_Energy_Resources/7-08.Work_Energy_and_Power_in_Humans/NU_U17_07_08_011.pg
@@ -48,10 +48,10 @@ BEGIN_TEXT
 $PAR
 <strong>If you don't solve this problem correctly in $showHint tries, you can get a hint.</strong>
 $PAR
-a) Calculate the energy used by a \($m\textrm{-kg}\) woman who does \($N\) deep knee bends in which her centre of mass is lowered and raised \($h\, \textrm{m}\). You may assume her efficiency is \($percent\)%. 
+a) Calculate the energy used by a \($m\,\mathrm{kg}\) woman who does \($N\) deep knee bends in which her centre of mass is lowered and raised \($h\, \mathrm{m}\). You may assume her efficiency is \($percent\,\mathrm{%}\).
 
 $PAR
-\{ans_rule(40)\} \(\textrm{J}\)
+\{ans_rule(40)\} \(\mathrm{J}\)
 
 END_TEXT
 
@@ -59,10 +59,10 @@ ANS(num_cmp("$Win"));
 
 BEGIN_TEXT
 $PAR
-b) What is the average power consumption rate in watts if she does this in \($min\, \textrm{min}\)?
+b) What is the average power consumption rate in watts if she does this in \($min\, \mathrm{min}\)?
 
 $PAR
-\{ans_rule(40)\} \(\textrm{W}\)
+\{ans_rule(40)\} \(\mathrm{W}\)
 
 END_TEXT
 

--- a/Pending/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-05.Half-Life_and_Activity/NU_U17-31-05-008.pg
+++ b/Pending/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-05.Half-Life_and_Activity/NU_U17-31-05-008.pg
@@ -44,7 +44,7 @@ $mass_g = $mass*10**-3;
 $M = 235;
 
 $timeSI= (0.693*$Na*$mass_g)/($activitySI*$M);
-$half_life = ($timeSI)/(86400*365.25)*10**-8;
+$half_life = ($timeSI)/(86400*365.25);
 
 Context() -> texStrings;
 BEGIN_TEXT 

--- a/Pending/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-06.Binding_Energy/NU_U17-31-06-006.pg
+++ b/Pending/BrockPhysics/College_Physics_Urone/31.Radioactivity_and_Nuclear_Physics/31-06.Binding_Energy/NU_U17-31-06-006.pg
@@ -43,7 +43,7 @@ $N_strontium = 52;
 
 $mass_nickel = 57.935346;
 $mass_strontium = 89.907738;
-$mass_proton = 1.007825;
+$mass_proton = 1.007276;
 $mass_neutron = 1.008665;
 
 $binding_energy_per_A_nickel = (931.5)*($Z_nickel*$mass_proton + $N_nickel*$mass_neutron - $mass_nickel)/($Z_nickel + $N_nickel);


### PR DESCRIPTION
This PR corrects some calculation errors in BrockPhysics/College_Physics_Urone questions and cleans up some display and formatting issues with extraneous pg markup `\(` being shown in the text .

Corrections:
* **7-07.Power/NU_U17_07_07_011.pg** formula for time
* **7-01.Work.The_Scientific_Definition/NU_U17_07_01_008.pg** fixed round off error
* **31-06.Binding_Energy/NU_U17-31-06-006.pg** mass of proton
* **31-05.Half-Life_and_Activity/NU_U17-31-05-008.pg** removed bizarre factor of 10^8

Added tolerance to **003-005_ADDITIONOFVELOCITIES/NU_U17-03-05-015.pg** to coerce correct significant figures in answer.

Converted latex \textrm{} to \mathrm{} for consistent font presentation.

Let me know if you want changes made to the request.