### PR TITLE
FIX github action generate opl release no runners

### DIFF
--- a/.github/workflows/generate-opl-release.yml
+++ b/.github/workflows/generate-opl-release.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y libdbi-perl libjson-perl libdbd-mariadb-perl
+          sudo apt-get update && sudo apt-get install -y libdbi-perl libjson-perl cpanminus build-essential libmariadb-dev && sudo cpanm install DBD::MariaDB
 
       - name: Verify MariaDB connection
         env:


### PR DESCRIPTION
Github's ubuntu-20.04 runner image was hard deprecated on 2025-04-01, so no runners are available. The github action for generating the OPL release just gets stuck waiting for a runner to become available.

I've updated the runner to ubuntu-24.04. This required installing DBD::MariaDB from cpan as it wasn't available from apt, which required installing cpanminus, build-essential, libmariadb-dev as dependencies.