### PR TITLE
Fix domain for x in logarithmic differentiation problem

### DIFF
--- a/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_7_38.pg
+++ b/OpenProblemLibrary/UMN/calculusStewartCCC/s_3_7_38.pg
@@ -45,7 +45,7 @@ $ans = Compute("x^(cos($a*x))*(cos($a*x)/x-$a*sin($a*x)*ln(x))");
 #####################################################################
 Context()->texStrings;
 BEGIN_TEXT
-Use logarithmic differentiation to find the derivative of the function \(\displaystyle y = x^{\cos $a x}.\)
+Use logarithmic differentiation to find the derivative of the function \(\displaystyle y = x^{\cos $a x}\), where \(x > 0\).
 $PAR
 Answer: \(\displaystyle y' = \) \{ans_rule(30)\}
 END_TEXT


### PR DESCRIPTION
Restrict x to [0.001, 1/a] to avoid log(x) errors in derivative calculation. Previously allowed negative x, causing runtime errors.