### PR TITLE
bug fixes for solution to Michigan/Chap14Sec7/Q21.pg

### DIFF
--- a/OpenProblemLibrary/Michigan/Chap14Sec7/Q21.pg
+++ b/OpenProblemLibrary/Michigan/Chap14Sec7/Q21.pg
@@ -5,7 +5,6 @@
 
 ## Tagged by glr 01/11/10
 
-
 ## DBsubject(Calculus - multivariable)
 ## DBchapter(Differentiation of multivariable functions)
 ## DBsection(Directional derivatives and the gradient)
@@ -37,98 +36,119 @@
 DOCUMENT();
 
 loadMacros(
-  "PGstandard.pl",
-  "PGchoicemacros.pl",
-  "MathObjects.pl",
-  "PGgraphmacros.pl",
-  "parserPopUp.pl",
-  "PGcourse.pl"
+    "PGstandard.pl",  "PGchoicemacros.pl",
+    "MathObjects.pl", "PGgraphmacros.pl",
+    "parserPopUp.pl", "PGcourse.pl"
 );
 
 Context("Numeric");
 $showPartialCorrectAnswers = 1;
 
-@gr = ();  @fx = ();  @fy = ();  @fxx = ();
-@fyy = (); @fxy = ();
+@gr  = ();
+@fx  = ();
+@fy  = ();
+@fxx = ();
+@fyy = ();
+@fxy = ();
 
-$gr[0] = init_graph(0,0,2,2, size=>[250,250]);
+$gr[0] = init_graph(0, 0, 2, 2, size => [ 250, 250 ]);
 $gr[0]->lb('reset');
-$gr[1] = init_graph(0,0,2,2, size=>[250,250]);
+$gr[1] = init_graph(0, 0, 2, 2, size => [ 250, 250 ]);
 $gr[1]->lb('reset');
 
-$x_sl = random(-1,1,2);
-$xx_sl = random(-1,1,2);
-$y_sl = random(-1,1,2);
-$yy_sl = random(-1,1,2);
+$x_sl  = random(-1, 1, 2);
+$xx_sl = random(-1, 1, 2);
+$y_sl  = random(-1, 1, 2);
+$yy_sl = random(-1, 1, 2);
 
-@lineLoc = ( [ .25, 1, 1.5, 1.75, 1.875 ],
-	     [ .125, .25, .5, 1, 1.75 ] );
-$xl0 = ( $xx_sl == -1 ) ? 1 : 0;  # which set of line locations to use
-$yl0 = ( $yy_sl == -1 ) ? 1 : 0;
-$xv0 = ( $x_sl == -1 ) ? 5 : 1;   # the value of the left-most contour
-$yv0 = ( $y_sl == -1 ) ? 5 : 1;   # the value of the bottom contour
-for ( my $i=0; $i<5; $i++ ) {
-    $gr[0]->moveTo( $lineLoc[$xl0]->[$i], 0 );
-    $gr[0]->lineTo( $lineLoc[$xl0]->[$i], 2, 'blue', 2 );
-    $gr[1]->moveTo( 0, $lineLoc[$yl0]->[$i] );
-    $gr[1]->lineTo( 2, $lineLoc[$yl0]->[$i], 'blue', 2 );
+@lineLoc = ([ .25, 1, 1.5, 1.75, 1.875 ], [ .125, .25, .5, 1, 1.75 ]);
+$xl0     = ($xx_sl == -1) ? 1 : 0;    # which set of line locations to use
+$yl0     = ($yy_sl == -1) ? 1 : 0;
+$xv0     = ($x_sl == -1)  ? 5 : 1;    # the value of the left-most contour
+$yv0     = ($y_sl == -1)  ? 5 : 1;    # the value of the bottom contour
+for (my $i = 0; $i < 5; $i++) {
+    $gr[0]->moveTo($lineLoc[$xl0]->[$i], 0);
+    $gr[0]->lineTo($lineLoc[$xl0]->[$i], 2, 'blue', 2);
+    $gr[1]->moveTo(0, $lineLoc[$yl0]->[$i]);
+    $gr[1]->lineTo(2, $lineLoc[$yl0]->[$i], 'blue', 2);
 
-    $gr[0]->lb( new Label( $lineLoc[$xl0]->[$i]+.02, 0.025, $xv0, 'black', 'left',
-			   'bottom' ) );
-    $gr[1]->lb( new Label( 0.025, $lineLoc[$yl0]->[$i], $yv0, 'black', 'left',
-			   'bottom' ) );
+    $gr[0]->lb(new Label(
+        $lineLoc[$xl0]->[$i] + .02,
+        0.025, $xv0, 'black', 'left', 'bottom'
+    ));
+    $gr[1]->lb(new Label(
+        0.025, $lineLoc[$yl0]->[$i], $yv0, 'black', 'left', 'bottom'
+    ));
     $xv0 += $x_sl;
     $yv0 += $y_sl;
 }
-$gr[0]->stamps( closed_circle( 1, 1, 'black' ) );
-$gr[1]->stamps( closed_circle( 1, 1, 'black' ) );
-$gr[0]->lb( new Label( 1.05,1.05,'P','black','left','bottom' ) );
-$gr[1]->lb( new Label( 1.05,1.05,'P','black','left','bottom' ) );
-@grDesc = ( "Graph with vertical contours having values " .
-	        ( $x_sl > 0 ) ? "1 to 5 " : "5 to 1 " .
-	        "left to right across the graph, which are " .
-	        "closer together at the " .
-	        ( $xx_sl > 0 ) ? "right " : "left " .
-	        "side of the graph.",
-	    "Graph with horizontal contours having values " .
-	        ( $y_sl > 0 ) ? "1 to 5 " : "5 to 1 " .
-	        "from the bottom to the top of the graph, which are " .
-	        "closer together at the " .
-	        ( $yy_sl > 0 ) ? "top " : "bottom " .
-	        "of the graph." );
+$gr[0]->stamps(closed_circle(1, 1, 'black'));
+$gr[1]->stamps(closed_circle(1, 1, 'black'));
+$gr[0]->lb(new Label(1.05, 1.05, 'P', 'black', 'left', 'bottom'));
+$gr[1]->lb(new Label(1.05, 1.05, 'P', 'black', 'left', 'bottom'));
+@grDesc = (
+    "Graph with vertical contours having values " . ($x_sl > 0) ? "1 to 5 "
+    : "5 to 1 "
+        . "left to right across the graph, which are "
+        . "closer together at the "
+        . ($xx_sl > 0) ? "right "
+    : "left " . "side of the graph.",
+    "Graph with horizontal contours having values " . ($y_sl > 0)
+    ? "1 to 5 "
+    : "5 to 1 "
+        . "from the bottom to the top of the graph, which are "
+        . "closer together at the "
+        . ($yy_sl > 0) ? "top "
+    : "bottom " . "of the graph."
+);
 
 ## the signs of the derivatives and second derivatives for each
 ##    of these graphs are then
-$fx[0] = PopUp( [ '?', 'positive', 'negative', 'zero' ],
-		$x_sl > 0 ? 'positive' : 'negative' );
-$fx[1] = PopUp( [ '?', 'positive', 'negative', 'zero' ], 'zero' );
-$fy[0] = PopUp( [ '?', 'positive', 'negative', 'zero' ], 'zero' );
-$fy[1] = PopUp( [ '?', 'positive', 'negative', 'zero' ],
-		$y_sl > 0 ? 'positive' : 'negative' );
-$fxx[0] = PopUp( [ '?', 'positive', 'negative', 'zero' ],
-		 $xx_sl*$x_sl > 0 ? 'positive' : 'negative' );
-$fxx[1] = PopUp( [ '?', 'positive', 'negative', 'zero' ], 'zero' );
-$fyy[0] = PopUp( [ '?', 'positive', 'negative', 'zero' ], 'zero' );
-$fyy[1] = PopUp( [ '?', 'positive', 'negative', 'zero' ],
-		 $yy_sl*$y_sl > 0 ? 'positive' : 'negative' );
-$fxy[0] = PopUp( [ '?', 'positive', 'negative', 'zero' ], 'zero' );
-$fxy[1] = PopUp( [ '?', 'positive', 'negative', 'zero' ], 'zero' );
+$fx[0] = PopUp(
+    [ '?', 'positive', 'negative', 'zero' ],
+    $x_sl > 0 ? 'positive' : 'negative'
+);
+$fx[1] = PopUp([ '?', 'positive', 'negative', 'zero' ], 'zero');
+$fy[0] = PopUp([ '?', 'positive', 'negative', 'zero' ], 'zero');
+$fy[1] = PopUp(
+    [ '?', 'positive', 'negative', 'zero' ],
+    $y_sl > 0 ? 'positive' : 'negative'
+);
+$fxx[0] = PopUp(
+    [ '?', 'positive', 'negative', 'zero' ],
+    $xx_sl * $x_sl > 0 ? 'positive' : 'negative'
+);
+$fxx[1] = PopUp([ '?', 'positive', 'negative', 'zero' ], 'zero');
+$fyy[0] = PopUp([ '?', 'positive', 'negative', 'zero' ], 'zero');
+$fyy[1] = PopUp(
+    [ '?', 'positive', 'negative', 'zero' ],
+    $yy_sl * $y_sl > 0 ? 'positive' : 'negative'
+);
+$fxy[0] = PopUp([ '?', 'positive', 'negative', 'zero' ], 'zero');
+$fxy[1] = PopUp([ '?', 'positive', 'negative', 'zero' ], 'zero');
 
 ## the explanations for what these are
-@fxExpl = ( ( $x_sl > 0 ? "increases" : "decreases" ) .
-	        " as we move left-to-right",
-	    "does not change as we move left-to-right" );
-@fyExpl = ( "does not change as we move up or down",
-	    ( $y_sl > 0 ? "increases" : "decreases" ) . " as we move up" );
-@fxxExpl = ( ($xx_sl*$x_sl > 0 ? "increases" : "decreases" ) . 
-	        " as we move left-to-right",
-	    "does not change as we move left-to-right" );
-@fyyExpl = ( "does not change as we move up or down",
-	    ( $yy_sl*$y_sl > 0 ? "increases" : "decreases" ) . " as we move up" );
+@fxExpl = (
+    ($x_sl > 0 ? "increases" : "decreases") . " as we move left-to-right",
+    "does not change as we move left-to-right"
+);
+@fyExpl = (
+    "does not change as we move up or down",
+    ($y_sl > 0 ? "increases" : "decreases") . " as we move up"
+);
+@fxxExpl = (
+    ($xx_sl * $x_sl > 0 ? "increases" : "decreases")
+    . " as we move left-to-right",
+    "does not change as we move left-to-right"
+);
+@fyyExpl = (
+    "does not change as we move up or down",
+    ($yy_sl * $y_sl > 0 ? "increases" : "decreases") . " as we move up"
+);
 
 ## the order in which we display these
-@order = ( random(0,1,1) );
-push( @order, ($order[0] + 1)%2 );
+@order = (random(0, 1, 1));
+push(@order, ($order[0] + 1) % 2);
 
 Context()->texStrings;
 
@@ -166,19 +186,19 @@ $ECENTER
 END_TEXT
 Context()->normalStrings;
 
-ANS($fx[$order[0]]->cmp() );
-ANS($fy[$order[0]]->cmp() );
-ANS($fxx[$order[0]]->cmp() );
-ANS($fyy[$order[0]]->cmp() );
-ANS($fxy[$order[0]]->cmp() );
-ANS($fx[$order[1]]->cmp() );
-ANS($fy[$order[1]]->cmp() );
-ANS($fxx[$order[1]]->cmp() );
-ANS($fyy[$order[1]]->cmp() );
-ANS($fxy[$order[1]]->cmp() );
+ANS($fx[ $order[0] ]->cmp());
+ANS($fy[ $order[0] ]->cmp());
+ANS($fxx[ $order[0] ]->cmp());
+ANS($fyy[ $order[0] ]->cmp());
+ANS($fxy[ $order[0] ]->cmp());
+ANS($fx[ $order[1] ]->cmp());
+ANS($fy[ $order[1] ]->cmp());
+ANS($fxx[ $order[1] ]->cmp());
+ANS($fyy[ $order[1] ]->cmp());
+ANS($fxy[ $order[1] ]->cmp());
 
-@ovar = ( 'x', 'y' );
-@dir  = ( 'up', 'left-to-right' );
+@ovar = ('x',  'y');
+@dir  = ('up', 'left-to-right');
 
 Context()->texStrings;
 BEGIN_SOLUTION
@@ -221,6 +241,4 @@ we go $dir[$order[1]].
 END_SOLUTION
 Context()->normalStrings;
 
-
-;
 ENDDOCUMENT();


### PR DESCRIPTION
The existing code for the solution throws a non-fatal warning for privileged users (uninitialized variable `@fyyExpl`) and present an incorrect/incomplete solution to student users.

Details of my fixes:
- added some missing parentheses around ternary conditionals
- the select logic for the `fvvExpl` arrays is incorrect: we want to switch on f_vv*f_v > 0 (not f_vv > 0)
- typo on line 126: we want to initialize `@fyyExpl`, not `@fyExpl`
