### PR TITLE
Fix formatting of integral answer in sc5_5_24.pg add + C

### DIFF
--- a/OpenProblemLibrary/Rochester/setIntegrals14Substitution/sc5_5_24.pg
+++ b/OpenProblemLibrary/Rochester/setIntegrals14Substitution/sc5_5_24.pg
@@ -43,7 +43,7 @@ TEXT(EV2(<<EOT));
 
 Evaluate the indefinite integral.
 $BR \[ \int \frac{x^$c}{x^$a + $b} \, dx \]
-$BR $BR \{ans_rule( 30) \}
+$BR $BR \{ans_rule( 30) \} \( + C \)
 $BR
 [NOTE:  Remember to enter all necessary *, (, and )  !!      $BR
 Enter arctan(x) for  \( \tan^{-1} x \) , sin(x) for \( \sin x \) . ]


### PR DESCRIPTION
Several students were unsure whether the answer should include a “+ C.” In its current form, the problem marks responses that include “+ C” as incorrect, which creates unnecessary ambiguity. This change resolves that issue by explicitly including “+ C” in the problem statement, making the expectation clear and consistent with how similar problems are presented elsewhere in WeBWorK.