### PR TITLE
Files from PR 1359

### DIFF
--- a/OpenProblemLibrary/FortLewis/Calc3/18-4-Greens-theorem/HGM4-18-4-17-Greens-theorem.pg
+++ b/OpenProblemLibrary/FortLewis/Calc3/18-4-Greens-theorem/HGM4-18-4-17-Greens-theorem.pg
@@ -134,9 +134,11 @@ $rd2 = $r / 2;
 $gr[0]->moveTo($rd2,0);
 $gr[0]->arrowTo($rd2+0.1,0,"red",3);
 
+$grAlt = "A vector field witha wedge shaped path traveled counterclockwise";
+$grDescr = "A vector field with a counterclockwise rotation and magnitude increasing as points go away from the origin. A wedge shaped path going from the origin to (3,0), then along a circular path of radius 3 from the origin for 30 degrees, then back to the origin. ";
 
 foreach my $i (0) {
-  $fig[$i] = image(insertGraph($gr[$i]),width=>"400",height=>"400",tex_size=>"700");
+  $fig[$i] = image(insertGraph($gr[$i]),width=>"400",height=>"400",tex_size=>"700", alt=>$grAlt, long_description=>$grDescr)
 }
 
 

--- a/OpenProblemLibrary/Michigan/Chap14Sec1/Q09.pg
+++ b/OpenProblemLibrary/Michigan/Chap14Sec1/Q09.pg
@@ -163,7 +163,8 @@ $fy[3] = PopUp( [ "?", "positive", "negative" ],
 
 ## we'll ask for three of these
 @ask = PGsort( sub { $_[0] < $_[1] }, NchooseK( 4, 3 ) );
-
+$grAlt = "A contour plot with circles centered at the origin and the radius of successive circles shrinking.";
+$grDescr = "A plot of circles centered at the origin. The smallest circle is labeled 6 and successively larger circles are labeled 9, 12, 15,18,21, 24. The difference in radius between successive circles is decreasing. A point labeled P is on the contour labeled 12 and in the first quadrant. A point labeled Q is on the contour labeled 12 and is in the fourth quadrant. A point labeled S is on the contour labeled 12 and in the second quadrant. A point labeled R is on the contour labeled 12 and is in the third quadrant.";
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -176,7 +177,7 @@ positive \(x\) value and negative \(y\), etc.)
 $PAR
 $BCENTER
 \{ image( insertGraph( $contour ), tex_size=>300, height=>300, width=>300,
-	  extra_html_tags=>'alt="' . $grdesc . '"' ) \}
+	  alt=>$grAlt, long_description=>$grDescr) \}
 $ECENTER
 $PAR
 ${BBOLD}(a)$EBOLD

--- a/OpenProblemLibrary/Michigan/Chap14Sec1/Q26.pg
+++ b/OpenProblemLibrary/Michigan/Chap14Sec1/Q26.pg
@@ -131,6 +131,9 @@ $hw22 = Compute( "($happ{$t2}->{$w2a} - $happ{$t2}->{$w2})/0.1" );
 $hw22a = Compute( "($happ{$t2}->{$w2} - $happ{$t2}->{$w2b})/0.1" );
 $hw22b = Compute( "($happ{$t2}->{$w2a} - $happ{$t2}->{$w2b})/0.2" );
 
+$grAlt = "A contour map with four level curves";
+$grDescr = "A graph showing \(H(T,0.1), H(T,0.2), H(T,0.3), H(T,0.4)\), which are decreasing functions of \(T\), each at a higher value of \(H\). As \(H\) increases, the associated level curve is more concave up.";
+
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -146,9 +149,7 @@ diagram, but shows cross-sections of \( H \) with \( w \) fixed at
 $PAR
 $BCENTER
 \{ image( insertGraph( $gr ), tex_size=>250, height=>350, width=>350,
-	  extra_html_tags=>'alt="graph showing H(T,0.1), H(T,0.2), ' .
-	  'H(T,0.3) and H(T,0.4), which are decresaing functions ' .
-	  'of T, each at a higher value of H."' ) \}
+	  alt=>$grAlt, long_description=>$grDescr) \}
 $ECENTER
 $PAR
 ${BBOLD}(a)$EBOLD

--- a/OpenProblemLibrary/Michigan/Chap16Sec1/Q03.pg
+++ b/OpenProblemLibrary/Michigan/Chap16Sec1/Q03.pg
@@ -112,6 +112,9 @@ $tol = ($over - $under)/2;
 $overTest = Compute( "($oversum)*2*2 - $tol" )->with( tolType=>'absolute', tolerance=>($tol+1) );
 $underTest = Compute( "($undersum)*2*2 + $tol" )->with( tolType=>'absolute', tolerance=>($tol+1) );
 
+$grAlt = "A contour plot of the function g";
+$grDescr = "A contour plot with horizontal range from 5 yo 11 and vertical range from 2 to 8. There are five contours labeled 2, 3, 4, 5, and 6 that are hyperbolas with the labels increasing across the graphs being further up and to the right.";
+
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -121,8 +124,7 @@ The figure below shows contours of \( g(x,y) \) on the region
 $PAR
 $BCENTER
 \{ image( insertGraph( $gr ), height=>300, width=>300, tex_size=>300,
-	  extra_html_tags=>'alt="contour graph showing the contours ' .
-	  'of the function."' ) \}
+	   alt=>$grAlt, long_description=>$grDescr) \}
 $ECENTER
 $PAR
 Using \( \Delta x = \Delta y =2 \), find an overestimate and an

--- a/OpenProblemLibrary/Michigan/Chap16Sec1/Q27.pg
+++ b/OpenProblemLibrary/Michigan/Chap16Sec1/Q27.pg
@@ -152,6 +152,9 @@ $avgint = Compute( "($max + $min)/2" );
 $avg = Compute( "($max + $min)/50" );
 $tolval = ($max - $min)/50 + 0.1;
 
+$grAlt = "A contour plot of the temperature in a 5 by 5 meter room";
+$grDescr = "A contour plot with horizontal and vertical range from 0 to 5. There are ten contours labeled from 21 to 30 and the contours become more curved when moving away from the middle of the plot.";
+
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -161,8 +164,8 @@ degrees C, in a 5 meter by 5 meter heated room.
 $PAR
 $BCENTER
 \{ image( insertGraph( $gr ), height=>300, width=>300, tex_size=>300,
-	  extra_html_tags=>'alt="contour graph showing the temperatures ' .
-	  'in the room"' ) \}
+	   alt=>$grAlt, long_description=>$grDescr) \}
+
 $ECENTER
 Using Riemann sums, estimate the average temperature in the room.
 $BR

--- a/OpenProblemLibrary/Michigan/Chap16Sec4/Q07.pg
+++ b/OpenProblemLibrary/Michigan/Chap16Sec4/Q07.pg
@@ -126,7 +126,7 @@ if( $whichSec < 3 ) {
 }
 
 @desc = ( "a rectangular region with diagonally opposite corners ($x0,$y0) " .
-	    "and ($x1,y1).",
+	    "and ($x1,$y1).",
 	  "a sector of a circle of radius $r0 centered at the origin, with " .
 	    "radial endpoints ($rcx0,$rcy0) and ($rcx1,$rcy1)." );
 
@@ -221,6 +221,8 @@ $chk[1] = MultiAnswer( Compute($sangles[$whichSec]->[0]),
 
 @order = NchooseK(2,2);
 
+$grAlt = "A wedge shaped region";
+$grAlt2 = "A rectangular shaped region";
 
 Context()->texStrings;
 TEXT(beginproblem());
@@ -236,7 +238,8 @@ The region
 $BR
 $BCENTER
 \{ image( insertGraph( $gr[$order[0]] ), tex_size=>250, height=>250,
-	  width=>250, extra_html_tags=>'alt="' . $desc[$order[0]] . '"' ) \}
+	  width=>250, alt=>$grAlt, long_description=>$desc[$order[0]]) \}
+
 $ECENTER
 With
 \( a = \) \{ $chk[$order[0]]->ans_rule(5) \},
@@ -254,7 +257,7 @@ The region
 $BR
 $BCENTER
 \{ image( insertGraph( $gr[$order[1]] ), tex_size=>250, height=>250,
-	  width=>250, extra_html_tags=>'alt="' . $desc[$order[1]] . '"' ) \}
+	  width=>250, alt=>$grAlt2, long_description=>$desc[$order[1]]) \}
 $ECENTER
 With
 \( a = \) \{ $chk[$order[1]]->ans_rule(5) \},

--- a/OpenProblemLibrary/Michigan/Chap17Sec5/Q25.pg
+++ b/OpenProblemLibrary/Michigan/Chap17Sec5/Q25.pg
@@ -105,6 +105,9 @@ $param = MultiAnswer( $xst, $yst, $zst, $s0, $s1, $t0, $t1 )->with(
 $vol = NumberWithUnits( "$n0*$po2*pi*(1 + 2*$rb*$rb)", "in^3" );
 $volc = $n0*$po2*(1 + 2*$rb*$rb);
 
+$grAlt = "A column that has a sinusoidal radius";
+$grDescr = "figure of a column with a vertically varying outside radius.  the maximum radius is r0 inches, the vertical distance between maximum radii is a0 inches, and the difference between the minimum and maximum radii is 2 inches.";
+
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -114,11 +117,7 @@ that its profile is sinusoidal as shown in the figure below.
 $BR
 $BCENTER
 \{ image( 'q15f1.png', tex_size=>200, height=>432, width=>173,
-	  extra_html_tags=>'alt="figure of a column with a ' .
-	  'vertically varying outside radius.  the maximum radius ' .
-	  'is r0 inches, the vertical distance between maximum ' .
-	  'radii is a0 inches, and the difference between the ' .
-	  'minimum and maximum radii is 2 inches."' ) \}
+	  alt=>$grAlt, long_description=>$grDescr) \}
 $ECENTER
 $BR
 In this figure, \(r_0 = $r1\) inches and \(a_0 = $p0\) inches.

--- a/OpenProblemLibrary/Michigan/Chap17Sec5/Q31.pg
+++ b/OpenProblemLibrary/Michigan/Chap17Sec5/Q31.pg
@@ -57,6 +57,8 @@ $s0 = Compute( "0" );
 $s1 = Compute( "$r0" );
 $t0 = Compute( "0" );
 $t1 = Compute( "2*pi" );
+$grAlt = "A plot of a cone surface with vertex on the z-axis";
+$grDescr = "figure of a cone with circular base on the xy-plane, centered on the z-axis, and point on the positive z-axis.";
 
 Context()->texStrings;
 TEXT(beginproblem());
@@ -66,9 +68,8 @@ Consider the cone shown below.
 $BR
 $BCENTER
 \{ image( "q31fig.png", tex_size=>250, height=>280, width=>230,
-	  extra_html_tags=>'alt="figure of a cone with circular base ' .
-	  'on the xy-plane, centered on the z-axis, and point on the ' .
-	  'positive z-axis."' ) \}
+          alt=>$grAlt, long_description=>$grDescr) \}
+
 $ECENTER
 $BR
 If the height of the cone is $z0 and the base radius is $r0, write

--- a/OpenProblemLibrary/Michigan/Chap18Sec1/Q21.pg
+++ b/OpenProblemLibrary/Michigan/Chap18Sec1/Q21.pg
@@ -128,7 +128,7 @@ for ( my $i=0; $i<3; $i++ ) {
 
     $invMap{$pickem[$i]} = $i;
 
-    $desc .= "Curve C" . ($i+1) . " is " . $curves[$pickem[$i]]->[3] . ".  ";
+    $desc .= "Curve C" . ($i+1) . " is " . $curves[$pickem[$i]]->[3] . ".  The vector field points with constant length horizontally to the left ";
 }
 
 ## then the popups are
@@ -137,7 +137,7 @@ for ( my $i=0; $i<3; $i++ ) {
 $int1 = PopUp( [ @intdesc ], $intdesc[$invMap{$picked[0]} + 1] );
 $int2 = PopUp( [ @intdesc ], $intdesc[$invMap{$picked[1]} + 1] );
 $int3 = PopUp( [ @intdesc ], $intdesc[$invMap{$picked[2]} + 1] );
-
+$grAlt = "A horizontal vector field with three linear segment paths";
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -147,7 +147,7 @@ together with the paths \( C_1 \), \( C_2 \), and \( C_3 \).
 $PAR
 $BCENTER
 \{ image( insertGraph( $gr ), tex_size=>250, height=>250, width=>250,
-	  extra_html_tags=>'alt="' . $desc . '"' ) \}
+          alt=>$grAlt, long_description=>$desc) \}
 $BR
 ${BITALIC}(${BBOLD}Note:$EBOLD For the vector field, vectors are shown with a
 dot at the ${BBOLD}tail$EBOLD of the vector.)$EITALIC

--- a/OpenProblemLibrary/Michigan/Chap19Sec1/Q12.pg
+++ b/OpenProblemLibrary/Michigan/Chap19Sec1/Q12.pg
@@ -53,6 +53,9 @@ $z0 = list_random(2,3,4);
 
 $flux = Compute( "$x0*($a*$z0 + $c*$x0)" );
 
+$grAlt = "A tilted plane in the first octant";
+$grDescr = "Figure showing part of a plane intersecting the yz-plane along the line segment between (0,0,b) and (0,a,b), and intersecting the xy-plane along the line segmentn between (a,0,0) and (a,a,0).  The orientation is given by an arrow pointing from the part of the plane upwards with positive slope dz/dx.";
+
 Context()->texStrings;
 TEXT(beginproblem());
 BEGIN_TEXT
@@ -64,12 +67,8 @@ assuming it is oriented as shown and that \(a = $x0\) and
 $BR
 $BCENTER
 \{ image( "q12fig.png", height=>280, width=>300, tex_size=>250,
-	  extra_html_tags=>'alt="Figure showing part of a plane ' .
-	  'intersecting the yz-plane along the line segment between ' .
-	  '(0,0,b) and (0,a,b), and intersecting the xy-plane along ' .
-	  'the line segmentn between (a,0,0) and (a,a,0).  The ' .
-	  'orientation is given by an arrow pointing from the part ' .
-	  'of the plane upwards with positive slope dz/dx."' ) \}
+	  alt=>$grAlt, long_description=>$grDescr) \}
+
 $ECENTER
 $PAR
 flux = \{ ans_rule(35) \}

--- a/OpenProblemLibrary/Michigan/Chap20Sec3/Q13.pg
+++ b/OpenProblemLibrary/Michigan/Chap20Sec3/Q13.pg
@@ -103,11 +103,11 @@ $BR
 ${BCENTER}
 \{ begintable(3) \}
 \{ row( image( insertGraph($gr[0]), height=>250, width=>250, tex_size=>250,
-	       extra_html_tags=>'alt="graph of the first vector field"' ),
+	       alt=>"A vector field", long_description=>"A vector field with a slight counterclockwise rotation around the origin that increases in strength as the points get closer to the origin."),
 	image( insertGraph($gr[1]), height=>250, width=>250, tex_size=>250,
-	       extra_html_tags=>'alt="graph of the second vector field"' ),
+	       alt=>"A vector field", long_description=>"A vector field symmetric about the horizontal axis that points to the right and down for positive y values and to the right and up for negative y values."),
 	image( insertGraph($gr[2]), height=>250, width=>250, tex_size=>250,
-	       extra_html_tags=>'alt="graph of the third vector field"' ) ) \}
+	      alt=>"A vector field", long_description=>"A vector field symmetric about the vertical axis that points to the right and up for positive x values and to the left and up for negative x values.") ) \}
 \{ row( "${BBOLD}(a)$EBOLD", "${BBOLD}(b)$EBOLD", "${BBOLD}(c)$EBOLD" ) \}
 \{ endtable() \}
 ${ECENTER}

--- a/OpenProblemLibrary/Michigan/Chap20Sec3/Q31.pg
+++ b/OpenProblemLibrary/Michigan/Chap20Sec3/Q31.pg
@@ -101,7 +101,7 @@ ${BITALIC}tail$EITALIC of each arrow.
 $BR
 $BCENTER
 \{ image( insertGraph( $gr ), height=>250, width=>250, tex_size=>250,
-	  extra_html_tags=>'alt="graph of the vector field"' ) \}
+	  alt=>"A vector field", long_description=>"A vector field that points to the right and up on the positive x axis, to the right and up on the positive y axis, to the left and down on the negative x axis, and to the left and down on negative y axis.") \}
 $ECENTER
 $PAR
 ${BBOLD}(a)$EBOLD

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.1_Vector_Fields/16.1.15.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.1_Vector_Fields/16.1.15.pg
@@ -38,6 +38,8 @@ if ($perm[1]==2) {$answer='2'; $mc->qa("", "Plot 2"); $mc->extra("Plot 1", "Plot
 if ($perm[2]==2) {$answer='3'; $mc->qa("", "Plot 3"); $mc->extra("Plot 2", "Plot 1", "Plot 4");};
 if ($perm[3]==2) {$answer='4'; $mc->qa("", "Plot 4"); $mc->extra("Plot 2", "Plot 3", "Plot 1");};
 
+$grAlt = ["A plot of a vector field","A plot of a vector field","A plot of a vector field","A plot of a vector field"];
+$grDescr = ["A vector field over the region from negative a to a. This vector field points up for points below the line y equals x and down above y equals x. This vector field points to the right for points above the line y equals negative x and to the left for points below the line y equals negative x.","A vector field over the region from negative a to a. This vector field points in a swirl around (a,0).", " A vector field over the region from negative a to a. This vector field points up for points above y equals 0 and down for points where y is less than 0. This vector field points to the right for points to the right of x equals negative 1 and to the left for points to the left of x equals negative one. "," A vector field over the region from negative a to a. This vector field points up for points above y equals 0 and down for points where y is less than 0. This vector field points to the right for all points. "];
 
 BEGIN_TEXT
 \{ textbook_ref_exact("Rogawski ET 2e", "16.1","15") \}
@@ -45,13 +47,13 @@ $PAR
 Match the planar vector field \(\mathbf{F} = \left< $a x + $a, y\right>\) with
 the corresponding plot in the Figures below.
 $PAR
-\{image("image_16_1_15_$plot[$perm[0]].png", width=>194, height=>199)\} \(\Leftarrow\) $BBOLD Plot 1 \(\quad\)
-\{image("image_16_1_15_$plot[$perm[1]].png", width=>194, height=>199)\}
-\(\Leftarrow\)Plot 2 $PAR
-\{image("image_16_1_15_$plot[$perm[2]].png", width=>194, height=>199)\} 
-\(\Leftarrow\)Plot 3 \(\quad\)
-\{image("image_16_1_15_$plot[$perm[3]].png", width=>194, height=>199)\} 
-\(\Leftarrow\)Plot 4 $EBOLD $BR
+\{image("image_16_1_15_$plot[$perm[0]].png", width=>194, height=>199,  alt=>$grAlt[$perm[0]], long_description=>$grDescr[$perm[0]]) \} \(\Leftarrow\) Plot 1 \(\quad\)
+
+\{image("image_16_1_15_$plot[$perm[1]].png", width=>194, height=>199,  alt=>$grAlt[$perm[1]], long_description=>$grDescr[$perm[1]])\} \(\Leftarrow\)Plot 2 $PAR
+
+\{image("image_16_1_15_$plot[$perm[2]].png", width=>194, height=>199,  alt=>$grAlt[$perm[2]], long_description=>$grDescr[$perm[2]])\} \(\Leftarrow\)Plot 3 \(\quad\)
+
+\{image("image_16_1_15_$plot[$perm[3]].png", width=>194, height=>199,  alt=>$grAlt[$perm[3]], long_description=>$grDescr[$perm[3]])\} \(\Leftarrow\)Plot 4 $BR
 With \(a=$a\)
 $PAR
 Answer : \{ $mc->print_a\}

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.2_Line_Integrals/16.2.41.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.2_Line_Integrals/16.2.41.pg
@@ -40,6 +40,15 @@ $answerA=$sol[$perm[0]];
 $answerB=$sol[$perm[1]];
 $answerC=$sol[$perm[2]];
 
+$grAlt = "A vector field with a circle path in the middle";
+$grDescr = "A vector field that moves to the right and down for all points. The length of the vectors increases as you go up and to the right. The circular path is drawn in the middle. ";
+
+$grAlt2 = "A vector field with a circle path in the middle";
+$grDescr2 = "A vector field that moves horizontally for right for all points. The length of the vectors increases as you go to the right. The circular path is drawn in the middle. ";
+
+$grAlt3 = "A vector field with a circle path in the middle";
+$grDescr3 = "A vector field that points toward the middle of the circular path. The length of the vectors increases as you move away from the middle of the circular path.";
+
 BEGIN_TEXT
 \{ textbook_ref_exact("Rogawski ET 2e", "16.2","41") \}
 $PAR
@@ -49,11 +58,10 @@ each case, $BR determine whether the line integral around the circle
 $PAR
 Note: Use "0" for zero, "P" for positive, and "N" for negative.
 $PAR
-\{image("image_16_2_13_$plot[$perm[0]].png", width=>167, height=>169)\}  $BBOLD (A) \{ans_rule(2)\} $PAR
-\{image("image_16_2_13_$plot[$perm[1]].png", width=>167, height=>169)\}
-(B) \{ans_rule(2)\} $PAR
-\{image("image_16_2_13_$plot[$perm[2]].png", width=>167, height=>169)\} 
-(C) \{ans_rule(2)\} $PAR
+\{image("image_16_2_13_$plot[$perm[0]].png", width=>167, height=>169, alt=>$grAlt, long_description=>$grDescr) \}
+$BBOLD (A) \{ans_rule(2)\} $PAR
+\{image("image_16_2_13_$plot[$perm[1]].png", width=>167, height=>169, alt=>$grAlt2, long_description=>$grDescr2) \} (B) \{ans_rule(2)\} $PAR
+\{image("image_16_2_13_$plot[$perm[2]].png", width=>167, height=>169, alt=>$grAlt3, long_description=>$grDescr3) \} (C) \{ans_rule(2)\} $PAR
 $EBOLD
 $PAR
 
@@ -86,3 +94,4 @@ In the vector field below, the vector field is orthogonal to the unit tangent ve
 END_SOLUTION
 
 ENDDOCUMENT();
+

--- a/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.5_Surface_Integrals_of_Vector_Fields/16.5.3.pg
+++ b/OpenProblemLibrary/WHFreeman/Rogawski_Calculus_Early_Transcendentals_Second_Edition/16_Line_and_Surface_Integrals/16.5_Surface_Integrals_of_Vector_Fields/16.5.3.pg
@@ -44,6 +44,9 @@ $ee="\mathbf{e}";
 TEXT('<SCRIPT>jsMath.Extension.Require("AMSmath");</SCRIPT>')
        if $displayMode eq 'HTML_jsMath';
 
+$grAlt = "A two by two grid of squares with center points of each square labeled A in the top left, B in the top right, C in the bottom left, and D in the bottom right.";
+$grDescr = "A two by two grid of squares with center points of each square labeled A in the top left, B in the top right, C in the bottom left, and D in the bottom right.";
+
 Context()->texStrings;
 
 BEGIN_TEXT
@@ -57,7 +60,7 @@ field whose values at the labeled points are
 \[\begin{array}{llll} $FF(A) &= $faV,&\qquad $FF(B) &= $fbV\\
                     $FF(C) &= $fcV,&\qquad $FF(D) &= $fdV\end{array}
 \]
-\{image("image_16_5_3.png", width=>163, height=>167)\} $PAR
+\{image("image_16_5_3.png", width=>163, height=>167,alt=>$grAlt, long_description=>$grDescr)\} $PAR
 \(\iint_{$surf} $FF \cdot \,d\mathbf{S} \approx \) \{ans_rule()\}
 $PAR
 


### PR DESCRIPTION
Files from PR 1359 that only change alt text descriptions.  I excluded one file, Michigan/Chap12Sec4/Q15.pg, from the PR because that file seems to have been based on an out-of-date file, so including it would have undone some improvements that are present in the current version..  