### PR TITLE
Add alt text to images in graph theory questions

### DIFF
--- a/OpenProblemLibrary/NAU/setGraphTheory/AddToMakeEulerCircuit.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/AddToMakeEulerCircuit.pg
@@ -136,7 +136,7 @@ $evalgraph = sub {
 
 BEGIN_TEXT
 $PAR
-\{Plot($pic)\}
+\{image(insertGraph($pic), alt=>"a graph which can have an Euler circuit with one additional edge")\}
 
 $PAR
 Consider the graph given above.  Add an edge so the resulting graph has an 

--- a/OpenProblemLibrary/NAU/setGraphTheory/AddToMakeEulerTrail.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/AddToMakeEulerTrail.pg
@@ -137,7 +137,7 @@ $evalgraph = sub {
 
 BEGIN_TEXT
 $PAR
-\{Plot($pic)\}
+\{image(insertGraph($pic),alt=>"a graph that can have an Euler trail with the addition of one edge")\}
 
 $PAR
 Consider the graph given above.  Add an edge so the resulting graph has an 

--- a/OpenProblemLibrary/NAU/setGraphTheory/FindChromaticNumber.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/FindChromaticNumber.pg
@@ -122,7 +122,7 @@ $Chromgroup = sub {
 
 BEGIN_TEXT
 $BR
-\{ Plot($pic)\}
+\{ image(insertGraph($pic), alt=>"a graph to find the chromatic number of")\}
 $PAR
 What is the chromatic number of the above graph?
 \{ ans_rule(5) \}

--- a/OpenProblemLibrary/NAU/setGraphTheory/FindEulerTrail.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/FindEulerTrail.pg
@@ -67,7 +67,7 @@ $evalfunc = sub {
 
 BEGIN_TEXT
 $PAR
-\{Plot($pic)\}
+\{image(insertGraph($pic),alt=>"a graph through which to find an Euler trail")\}
 
 $PAR
 Consider the graph given above.  Give an Euler trail through the graph by listing 

--- a/OpenProblemLibrary/NAU/setGraphTheory/FindIsomorphism.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/FindIsomorphism.pg
@@ -81,7 +81,7 @@ push @graphs, GRshuffledgraph_graph($graphs[0]);
 
 $orig_pic = GRpic_graph_labels($graphs[0],$orig_lab);
 for ($i = 1; $i < 4; $i++){
-  push @pics, GRpic_graph_labels($graphs[$i], $new_lab);
+  push @pics, image(insertGraph(GRpic_graph_labels($graphs[$i], $new_lab)),alt=>"graph possibly isomorphic to Gamma");
 }
 
 ($table, $ans) = radio_table([@pics],[0,0,1], geometry=>[1,3]);
@@ -151,7 +151,7 @@ $Iso_Eval = sub {
 BEGIN_TEXT
 Consider the graph \( \Gamma \) :
 $PAR
-\{ Plot($orig_pic, tex_size => 300) \}
+\{ image( insertGraph($orig_pic), alt=>"the graph Gamma") \}
 
 $PAR
 Which of the graphs below is isomorphic to \(\Gamma\)?

--- a/OpenProblemLibrary/NAU/setGraphTheory/IsEuler.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/IsEuler.pg
@@ -63,7 +63,7 @@ push @graph, $tempgraph;
 
 push @graph, GRnoneuler_size($size[3]);
 for ($i = 0; $i < 4; $i++){
-  push @pics, GRpic_graph_labels($graph[$i],$labels[$i]);
+  push @pics, image(insertGraph(GRpic_graph_labels($graph[$i],$labels[$i])),alt=>"a graph which may have an Euler circuit or trail");
 }
 
 @trail = (1,1,0,0);

--- a/OpenProblemLibrary/NAU/setGraphTheory/IsEuler2.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/IsEuler2.pg
@@ -64,7 +64,7 @@ push @graph, $tempgraph;
 
 push @graph, GRnoneuler_size($size[3]);
 for ($i = 0; $i < 4; $i++){
-  push @pics, GRpic_graph_labels($graph[$i],$labels[$i]);
+  push @pics, image(insertGraph(GRpic_graph_labels($graph[$i],$labels[$i])),alt=>"graph which may have an Euler circuit");
 }
 
 @circuit = (1,1,0,0);

--- a/OpenProblemLibrary/NAU/setGraphTheory/IsIsomorphic.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/IsIsomorphic.pg
@@ -38,7 +38,7 @@ push @list, GRshuffledgraph_graph($list[0]);
 
 foreach $i (0..3){
   $list[$i] = GRshuffledgraph_graph($list[$i]);
-  push @pics, GRpic_graph_labels($list[$i],$labels);
+  push @pics, image(insertGraph(GRpic_graph_labels($list[$i],$labels)), alt=>"one of four graphs that may be isomorphic");
 }
 
 ($table, $ans) = checkbox_table([@pics], [1,0,0,1]);

--- a/OpenProblemLibrary/NAU/setGraphTheory/KnownChromatic.pg
+++ b/OpenProblemLibrary/NAU/setGraphTheory/KnownChromatic.pg
@@ -47,11 +47,11 @@ push @pics, GRdodecahedron();
 %opts = (separation=>1);
 
 $table=BeginTable(center=>0).
-AlignedRow([Plot($used[0]), Plot($used[1])], %opts).
+AlignedRow([image(insertGraph($used[0]),alt=>"a graph for which to find the chromatic number"), image(insertGraph($used[1]),alt=>"a graph for which to find the chromatic number")], %opts).
 TableSpace(2,2).
 AlignedRow([ans_rule(5), ans_rule(5)], %opts).
 TableSpace(20,2).
-AlignedRow([Plot($used[2]), Plot($used[3])], %opts).
+AlignedRow([image(insertGraph($used[2]),alt=>"a graph for which to find the chromatic number"), image(insertGraph($used[3]),alt=>"a graph for which to find the chromatic number")], %opts).
 TableSpace(2,2).
 AlignedRow([ans_rule(5), ans_rule(5)], %opts).
 EndTable();


### PR DESCRIPTION
These are all problems I use in my Discrete Mathematics: an Open Introduction book.  They previously had no alt text.  I added some (not particularly helpful, but at least they won't be flagged by accessibility checkers).

Tested that each problem still compiles correctly.  No answer checking logic would change.