### PR TITLE
Correct misleading and likely factually incorrect solution text

### DIFF
--- a/Contrib/DMOI/0-Introduction_and_Preliminaries/0_2-Mathematical_Statements/0_2_12.pg
+++ b/Contrib/DMOI/0-Introduction_and_Preliminaries/0_2-Mathematical_Statements/0_2_12.pg
@@ -108,7 +108,7 @@ BEGIN_PGML_SOLUTION
 END_PGML_SOLUTION
 } else {
   BEGIN_PGML_SOLUTION
-[`P([$x])`] is the statement "[`[$n]\cdot [$x] + 1`] is even", which is false. Thus the statement [`\forall x P(x)`] is false (for example, [$x] is a counterexample). However, we cannot tell anything about [`\exists x P(x)`] since we do not know the truth value of [`P(x)`] for other elements of the domain of discourse. In this case, [`\exists x P(x)`] happens to be true (since [`P(1)`] is true, for example).
+[`P([$x])`] is the statement "[`[$n]\cdot [$x] + 1`] is even", which is false. Thus the statement [`\forall x P(x)`] is false (for example, [$x] is a counterexample). However, we cannot tell anything about [`\exists x P(x)`] since we do not know the truth value of [`P(x)`] for other elements of the domain of discourse.
 END_PGML_SOLUTION
 }
 

--- a/Contrib/DMOI/0-Introduction_and_Preliminaries/0_2-Mathematical_Statements/0_2_13.pg
+++ b/Contrib/DMOI/0-Introduction_and_Preliminaries/0_2-Mathematical_Statements/0_2_13.pg
@@ -108,7 +108,7 @@ BEGIN_PGML_SOLUTION
 END_PGML_SOLUTION
 } else {
   BEGIN_PGML_SOLUTION
-[`P([$x])`] is the statement "[`[$n]\cdot [$x] + 1`] is even", which is false. Thus the statement [`\forall x P(x)`] is false (for example, [$x] is a counterexample). However, we cannot tell anything about [`\exists x P(x)`] since we do not know the truth value of [`P(x)`] for other elements of the domain of discourse. In this case, [`\exists x P(x)`] happens to be true (since [`P(1)`] is true, for example).
+[`P([$x])`] is the statement "[`[$n]\cdot [$x] + 1`] is even", which is false. Thus the statement [`\forall x P(x)`] is false (for example, [$x] is a counterexample). However, we cannot tell anything about [`\exists x P(x)`] since we do not know the truth value of [`P(x)`] for other elements of the domain of discourse.
 END_PGML_SOLUTION
 }
 


### PR DESCRIPTION
In two problems of DMOI, the solution text made a claim that the particular statement was true for some inputs.  But this will only work for certain random versions.  The extra comment from the solution isn't needed, so I just deleted it from both solutions.