### PR TITLE
Make sure foil randomization cannot be correct.

### DIFF
--- a/Contrib/DMOI/1-Counting/1_4-Combinatorial_Proofs/1_4_extra-02.pg
+++ b/Contrib/DMOI/1-Counting/1_4-Combinatorial_Proofs/1_4_extra-02.pg
@@ -20,7 +20,6 @@ loadMacros(
   "draggableProof.pl",
   "PGcourse.pl"
 );
-TEXT(beginproblem());
 
 Context("Numeric");
 
@@ -72,7 +71,7 @@ $Proof = DraggableProof([
 [
 "Consider the question: $incorrect[$indexIncorrect][0]",
 "This is because $incorrect[$indexIncorrect][1]",
-"This is because $correct[$indexCorrect][2]",
+"This is because $incorrect[$indexIncorrect][2]",
 ],
 
 

--- a/Contrib/DMOI/1-Counting/1_4-Combinatorial_Proofs/1_4_extra-03.pg
+++ b/Contrib/DMOI/1-Counting/1_4-Combinatorial_Proofs/1_4_extra-03.pg
@@ -20,13 +20,15 @@ loadMacros(
   "PGchoicemacros.pl",
   "PGcourse.pl"
 );
-TEXT(beginproblem());
 
 Context("Numeric");
 
-#wordbank contains a word with three unique letters, and then the total number of letters, the number of most frequent letter, second most frequent.
-$n = random(10,30,1);
-$k = random(5,$n-3,1);
+# To ensure that (0, 0) -> (n, n-k) and (k, k) -> (n, n)
+# cannot have the same count, need to make sure that n != 2k.
+do {
+	$n = random(10, 30);
+	$k = random(5,  $n - 3);
+} until (2*$k != $n);
 $end = Compute($n-$k);
 
 $j = random(2,$k-1,1);


### PR DESCRIPTION
It is possible that one of the foils produces the correct answer. This will randomize values in a loop until the foil is guaranteed to not give the correct answer.

A second issue was brought to my attention. One of the draggable proof problems had the same statement listed twice. This was because the wrong variable was being used for the extra statement. I believe the problem should have used the incorrect statement for the extra incorrect statements.